### PR TITLE
FIX: typo in variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const cruella = { _id: uuid(), name: "Cruella", age: 40 };
 await pongoCollection.insertOne(roger);
 await pongoCollection.insertOne(cruella);
 
-const { insertedId } = await pongoCollection.insertOne(alice);
+const { insertedId } = await pongoCollection.insertOne(anita);
 const anitaId = insertedId;
 
 // Updating
@@ -80,7 +80,7 @@ const cruella = { _id: uuid(), name: "Cruella", age: 40 };
 await pongoCollection.insertOne(roger);
 await pongoCollection.insertOne(cruella);
 
-const { insertedId } = await pongoCollection.insertOne(alice);
+const { insertedId } = await pongoCollection.insertOne(anita);
 const anitaId = insertedId;
 
 // Updating


### PR DESCRIPTION
Tiny fix in the example: `alice` variable was used instead of the (supposedly correct) `anita`.