### PR TITLE
YugabyteDB as a distributed alternative to PostgreSQL

### DIFF
--- a/samples/simple-ts/README.md
+++ b/samples/simple-ts/README.md
@@ -10,8 +10,13 @@ Read more in [Emmett getting started guide](https://event-driven-io.github.io/em
 
 Sample require EventStoreDB, you can start it by running
 
+with PostgreSQL:
 ```bash
 docker-compose up
+```
+Alternatively, with YugabyteDB (PostgreSQL-compatible distributed SQL)
+```bash
+docker-compose -f docker-compose-yugabytedb.yml up
 ```
 
 You need to install packages with

--- a/samples/simple-ts/README.md
+++ b/samples/simple-ts/README.md
@@ -14,9 +14,11 @@ with PostgreSQL:
 ```bash
 docker-compose up
 ```
-Alternatively, with YugabyteDB (PostgreSQL-compatible distributed SQL)
+Alternatively, with YugabyteDB (PostgreSQL-compatible distributed SQL) starting 3 nodes:
 ```bash
-docker-compose -f docker-compose-yugabytedb.yml up
+docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=0
+docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=1
+docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=2
 ```
 
 You need to install packages with

--- a/samples/simple-ts/docker-compose-yugabytedb.yml
+++ b/samples/simple-ts/docker-compose-yugabytedb.yml
@@ -1,11 +1,27 @@
 version: "3.8" # Specify Docker Compose version
 
 services:
-  postgres:
+  yugabytedb:
     image: yugabytedb/yugabyte:latest
     command: yugabyted start --background=false --ysql_port=5432
     ports:
       - "5432:5432"
+      - "15433:15433"
+    healthcheck:
+      interval: 15s
+      timeout: 3s
+      test: postgres/bin/pg_isready -h yugabytedb -p 5432
+
+  dist:
+    image: yugabytedb/yugabyte:latest
+    command: yugabyted start --join yugabytedb --background=false --ysql_port=5432
+    deploy:
+     replicas: 0
+     restart_policy: 
+       condition: on-failure
+    depends_on:
+      yugabytedb:
+        condition: service_healthy
 
   pgadmin:
     container_name: pgadmin_container
@@ -23,5 +39,6 @@ services:
       - ./docker/pgAdmin/pgpass:/pgpass
       - ./docker/pgAdmin/servers.json:/pgadmin4/servers.json
     depends_on:
-      - postgres
+      yugabytedb:
+        condition: service_healthy
     restart: unless-stopped

--- a/samples/simple-ts/docker-compose-yugabytedb.yml
+++ b/samples/simple-ts/docker-compose-yugabytedb.yml
@@ -1,0 +1,27 @@
+version: "3.8" # Specify Docker Compose version
+
+services:
+  postgres:
+    image: yugabytedb/yugabyte:latest
+    command: yugabyted start --background=false --ysql_port=5432
+    ports:
+      - "5432:5432"
+
+  pgadmin:
+    container_name: pgadmin_container
+    image: dpage/pgadmin4
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD:-postgres}
+      - PGADMIN_CONFIG_SERVER_MODE=False
+      - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
+    ports:
+      - "${PGADMIN_PORT:-5050}:80"
+    entrypoint: /bin/sh -c "chmod 600 /pgpass; /entrypoint.sh;"
+    user: root
+    volumes:
+      - ./docker/pgAdmin/pgpass:/pgpass
+      - ./docker/pgAdmin/servers.json:/pgadmin4/servers.json
+    depends_on:
+      - postgres
+    restart: unless-stopped


### PR DESCRIPTION
This PR adds a docker compose in `simple-ts` to start YugabyteDB instead of PostgreSQL.
YugabyteDB is an Open Source PostgreSQL-compatible Distributed SQL. It can scale horizontally by simply adding new nodes.

Example, here is a 6 nodes YugabyteDB cluster with Replication Factor 3 (resilient to one node failure):
```
docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=0
docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=1
docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=2
docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=3
docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=4
docker-compose -f docker-compose-yugabytedb.yml up -d --scale dist=5
```
The application connects to any node with the same driver as PostgreSQL
```
npm install
npm run start
```
The YugabyteDB UI is on port 15433:
![image](https://github.com/user-attachments/assets/d3117c0e-8cc5-498f-b602-46e6bc2c41d2)
The "users" table is distributed to 6 tablets with Raft leaders on all nodes:
![image](https://github.com/user-attachments/assets/c5c1194f-95e3-49e1-a2de-0fa50bc748f8)



