### PR TITLE
Changed _id type to TEXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,14 @@ Pongo uses the following table structure for storing collections:
 
 ```sql
 CREATE TABLE IF NOT EXISTS "YourCollectionName" (
-    _id UUID PRIMARY KEY,
-    data JSONB
+    _id           TEXT           PRIMARY KEY,
+    data          JSONB          NOT NULL,
+    metadata      JSONB          NOT NULL     DEFAULT '{}',
+    _version      BIGINT         NOT NULL     DEFAULT 1,
+    _partition    TEXT           NOT NULL     DEFAULT 'png_global',
+    _archived     BOOLEAN        NOT NULL     DEFAULT FALSE,
+    _created      TIMESTAMPTZ    NOT NULL     DEFAULT now(),
+    _updated      TIMESTAMPTZ    NOT NULL     DEFAULT now()
 )
 ```
 

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -102,8 +102,14 @@ Pongo uses the following table structure for storing collections:
 
 ```sql
 CREATE TABLE IF NOT EXISTS "YourCollectionName" (
-    _id UUID PRIMARY KEY,
-    data JSONB
+    _id           TEXT           PRIMARY KEY,
+    data          JSONB          NOT NULL,
+    metadata      JSONB          NOT NULL     DEFAULT '{}',
+    _version      BIGINT         NOT NULL     DEFAULT 1,
+    _partition    TEXT           NOT NULL     DEFAULT 'png_global',
+    _archived     BOOLEAN        NOT NULL     DEFAULT FALSE,
+    _created      TIMESTAMPTZ    NOT NULL     DEFAULT now(),
+    _updated      TIMESTAMPTZ    NOT NULL     DEFAULT now()
 )
 ```
 

--- a/src/packages/pongo/src/postgres/postgresCollection.ts
+++ b/src/packages/pongo/src/postgres/postgresCollection.ts
@@ -179,7 +179,16 @@ export const postgresCollection = <T extends PongoDocument>(
 export const collectionSQLBuilder = (collectionName: string) => ({
   createCollection: (): SQL =>
     sql(
-      'CREATE TABLE IF NOT EXISTS %I (_id UUID PRIMARY KEY, data JSONB)',
+      `CREATE TABLE IF NOT EXISTS %I (
+        _id           TEXT           PRIMARY KEY, 
+        data          JSONB          NOT NULL, 
+        metadata      JSONB          NOT NULL     DEFAULT '{}',
+        _version      BIGINT         NOT NULL     DEFAULT 1,
+        _partition    TEXT           NOT NULL     DEFAULT 'png_global',
+        _archived     BOOLEAN        NOT NULL     DEFAULT FALSE,
+        _created      TIMESTAMPTZ    NOT NULL     DEFAULT now(),
+        _updated      TIMESTAMPTZ    NOT NULL     DEFAULT now()
+    )`,
       collectionName,
     ),
   insertOne: <T>(document: WithId<T>): SQL =>


### PR DESCRIPTION
Changed _id type to Text. In PostgreSQL, this should be almost equally the same indexable. Of course, it'll take a bit more storage, but let's live with that for now.

We can, in the future, allow, as Marten does, to use different definitions of collection tables.

Changing from `uuid` to text will allow more sophisticated key strategies.

Most importantly, it'll reuse the stream ID as a document ID for Emmett projections.

Besides that, I added columns for future concepts:
- `_version` - for optimistic concurrency handling,
- `_partition` - for built-in PostgreSQL partitioning,
- `_created`, `_modified` - for timestamp metadata,
- `metadata` - for technical additional data,
- `_archived` - for soft deletion and also partitioning