### PR TITLE
Added findOneAndDelete, findOneAndReplace, findOneAndUpdate methods

### DIFF
--- a/src/packages/pongo/src/main/typing/operations.ts
+++ b/src/packages/pongo/src/main/typing/operations.ts
@@ -32,6 +32,15 @@ export interface PongoCollection<T extends PongoDocument> {
   deleteMany(filter?: PongoFilter<T>): Promise<PongoDeleteResult>;
   findOne(filter?: PongoFilter<T>): Promise<T | null>;
   find(filter?: PongoFilter<T>): Promise<T[]>;
+  findOneAndDelete(filter: PongoFilter<T>): Promise<T | null>;
+  findOneAndReplace(
+    filter: PongoFilter<T>,
+    replacement: WithoutId<T>,
+  ): Promise<T | null>;
+  findOneAndUpdate(
+    filter: PongoFilter<T>,
+    update: PongoUpdate<T>,
+  ): Promise<T | null>;
   countDocuments(filter?: PongoFilter<T>): Promise<number>;
   drop(): Promise<boolean>;
   rename(newName: string): Promise<PongoCollection<T>>;

--- a/src/packages/pongo/src/mongo/mongoCollection.ts
+++ b/src/packages/pongo/src/mongo/mongoCollection.ts
@@ -378,12 +378,12 @@ export class Collection<T extends Document> implements MongoCollection<T> {
   ): Promise<WithId<T> | null>;
   findOneAndDelete(filter: Filter<T>): Promise<WithId<T> | null>;
   findOneAndDelete(
-    _filter: unknown,
+    filter: unknown,
     _options?: unknown,
-  ):
-    | Promise<import('mongodb').WithId<T> | null>
-    | Promise<import('mongodb').ModifyResult<T>> {
-    throw new Error('Method not implemented.');
+  ): Promise<WithId<T> | null | ModifyResult<T>> {
+    return this.collection.findOneAndDelete(
+      filter as PongoFilter<T>,
+    ) as Promise<WithId<T> | null>;
   }
   findOneAndReplace(
     filter: Filter<T>,
@@ -405,13 +405,14 @@ export class Collection<T extends Document> implements MongoCollection<T> {
     replacement: WithoutId<T>,
   ): Promise<WithId<T> | null>;
   findOneAndReplace(
-    _filter: unknown,
-    _replacement: unknown,
+    filter: unknown,
+    replacement: unknown,
     _options?: unknown,
-  ):
-    | Promise<import('mongodb').WithId<T> | null>
-    | Promise<import('mongodb').ModifyResult<T>> {
-    throw new Error('Method not implemented.');
+  ): Promise<WithId<T> | null | ModifyResult<T>> {
+    return this.collection.findOneAndReplace(
+      filter as PongoFilter<T>,
+      replacement as WithoutId<T>,
+    ) as Promise<WithId<T> | null>;
   }
   findOneAndUpdate(
     filter: Filter<T>,
@@ -433,13 +434,14 @@ export class Collection<T extends Document> implements MongoCollection<T> {
     update: UpdateFilter<T>,
   ): Promise<WithId<T> | null>;
   findOneAndUpdate(
-    _filter: unknown,
-    _update: unknown,
+    filter: unknown,
+    update: unknown,
     _options?: unknown,
-  ):
-    | Promise<import('mongodb').WithId<T> | null>
-    | Promise<import('mongodb').ModifyResult<T>> {
-    throw new Error('Method not implemented.');
+  ): Promise<WithId<T> | null | ModifyResult<T>> {
+    return this.collection.findOneAndUpdate(
+      filter as PongoFilter<T>,
+      update as PongoUpdate<T>,
+    ) as Promise<WithId<T> | null>;
   }
   aggregate<T extends Document = Document>(
     _pipeline?: Document[] | undefined,

--- a/src/packages/pongo/src/postgres/postgresCollection.ts
+++ b/src/packages/pongo/src/postgres/postgresCollection.ts
@@ -119,6 +119,44 @@ export const postgresCollection = <T extends PongoDocument>(
       const result = await execute(SqlFor.findOne(filter ?? {}));
       return (result.rows[0]?.data ?? null) as T | null;
     },
+    findOneAndDelete: async (filter: PongoFilter<T>): Promise<T | null> => {
+      await createCollection;
+
+      const existingDoc = await collection.findOne(filter);
+
+      if (existingDoc === null) return null;
+
+      await collection.deleteOne(filter);
+      return existingDoc;
+    },
+    findOneAndReplace: async (
+      filter: PongoFilter<T>,
+      replacement: WithoutId<T>,
+    ): Promise<T | null> => {
+      await createCollection;
+
+      const existingDoc = await collection.findOne(filter);
+
+      if (existingDoc === null) return null;
+
+      await collection.replaceOne(filter, replacement);
+
+      return existingDoc;
+    },
+    findOneAndUpdate: async (
+      filter: PongoFilter<T>,
+      update: PongoUpdate<T>,
+    ): Promise<T | null> => {
+      await createCollection;
+
+      const existingDoc = await collection.findOne(filter);
+
+      if (existingDoc === null) return null;
+
+      await collection.updateOne(filter, update);
+
+      return existingDoc;
+    },
     handle: async (
       id: string,
       handle: DocumentHandler<T>,


### PR DESCRIPTION
That closes all the basic methods support. Of course, they're not yet fully aligned with Mongo, but we'll get there.