### PR TITLE
Added PongoSchema that automatically generates cliend and database typed properties

### DIFF
--- a/src/packages/pongo/src/core/typing/entries.ts
+++ b/src/packages/pongo/src/core/typing/entries.ts
@@ -6,7 +6,7 @@ type IterableEntry<T> = Entry<T> & {
   [Symbol.iterator](): Iterator<Entry<T>>;
 };
 
-export const entries = <T extends object>(obj: T): IterableEntry<T>[] =>
+export const objectEntries = <T extends object>(obj: T): IterableEntry<T>[] =>
   Object.entries(obj).map(([key, value]) => [key as keyof T, value]);
 
 export type NonPartial<T> = { [K in keyof Required<T>]: T[K] };

--- a/src/packages/pongo/src/core/typing/schema.ts
+++ b/src/packages/pongo/src/core/typing/schema.ts
@@ -1,0 +1,145 @@
+import {
+  type PongoClient,
+  type PongoCollection,
+  type PongoDb,
+  type PongoDocument,
+} from './operations';
+
+export interface PongoCollectionSchema<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  T extends PongoDocument = PongoDocument,
+> {
+  name: string;
+}
+
+// Database schema interface
+export interface PongoDbSchema<
+  T extends Record<string, PongoCollectionSchema> = Record<
+    string,
+    PongoCollectionSchema
+  >,
+> {
+  name?: string;
+  collections: T;
+}
+
+export interface PongoClientSchema<
+  T extends Record<string, PongoDbSchema> = Record<string, PongoDbSchema>,
+> {
+  dbs: T;
+}
+
+export type CollectionsMap<T extends Record<string, PongoCollectionSchema>> = {
+  [K in keyof T]: PongoCollection<
+    T[K] extends PongoCollectionSchema<infer U> ? U : PongoDocument
+  >;
+};
+
+export type PongoDbWithSchema<
+  T extends Record<string, PongoCollectionSchema>,
+  ConnectorType extends string = string,
+> = CollectionsMap<T> & PongoDb<ConnectorType>;
+
+export type DBsMap<T extends Record<string, PongoDbSchema>> = {
+  [K in keyof T]: CollectionsMap<T[K]['collections']>;
+};
+
+export type PongoClientWithSchema<T extends PongoClientSchema> = DBsMap<
+  T['dbs']
+> &
+  PongoClient;
+
+const pongoCollectionSchema = <T extends PongoDocument>(
+  name: string,
+): PongoCollectionSchema<T> => ({
+  name,
+});
+
+function pongoDbSchema<T extends Record<string, PongoCollectionSchema>>(
+  collections: T,
+): PongoDbSchema<T>;
+function pongoDbSchema<T extends Record<string, PongoCollectionSchema>>(
+  name: string,
+  collections: T,
+): PongoDbSchema<T>;
+function pongoDbSchema<T extends Record<string, PongoCollectionSchema>>(
+  nameOrCollections: string | T,
+  collections?: T | undefined,
+): PongoDbSchema<T> {
+  if (collections === undefined) {
+    if (typeof nameOrCollections === 'string') {
+      throw new Error('You need to provide colleciton definition');
+    }
+    return {
+      collections: nameOrCollections,
+    };
+  }
+
+  return nameOrCollections && typeof nameOrCollections === 'string'
+    ? {
+        name: nameOrCollections,
+        collections,
+      }
+    : { collections: collections };
+}
+
+const pongoClientSchema = <T extends Record<string, PongoDbSchema>>(
+  dbs: T,
+): PongoClientSchema<T> => ({
+  dbs,
+});
+
+export const pongoSchema = {
+  client: pongoClientSchema,
+  db: pongoDbSchema,
+  collection: pongoCollectionSchema,
+};
+
+// Factory function to create DB instances
+export const proxyPongoDbWithSchema = <
+  T extends Record<string, PongoCollectionSchema>,
+  ConnectorType extends string = string,
+>(
+  pongoDb: PongoDb<ConnectorType>,
+  dbSchema: PongoDbSchema<T>,
+): PongoDbWithSchema<T, ConnectorType> => {
+  const collectionNames = Object.keys(dbSchema.collections);
+
+  return new Proxy(
+    pongoDb as PongoDb<ConnectorType> & {
+      [key: string]: unknown;
+    },
+    {
+      get(target, prop: string) {
+        if (collectionNames.includes(prop)) return pongoDb.collection(prop);
+
+        return target[prop];
+      },
+    },
+  ) as PongoDbWithSchema<T, ConnectorType>;
+};
+
+// Factory function to create Client instances
+export const proxyClientWithSchema = <
+  TypedClientSchema extends PongoClientSchema,
+>(
+  client: PongoClient,
+  schema: TypedClientSchema | undefined,
+): PongoClientWithSchema<TypedClientSchema> => {
+  if (!schema) return client as PongoClientWithSchema<TypedClientSchema>;
+
+  const dbNames = Object.keys(schema.dbs);
+
+  return new Proxy(
+    client as PongoClient & {
+      [key: string]: unknown;
+    },
+    {
+      get(target, prop: string) {
+        if (dbNames.includes(prop)) return client.db(schema.dbs[prop]?.name);
+
+        return target[prop];
+      },
+    },
+  ) as PongoClientWithSchema<TypedClientSchema>;
+};

--- a/src/packages/pongo/src/postgres/dbClient.ts
+++ b/src/packages/pongo/src/postgres/dbClient.ts
@@ -6,10 +6,12 @@ import {
   type PostgresPoolOptions,
 } from '@event-driven-io/dumbo';
 import {
+  objectEntries,
   pongoCollection,
   type PongoDb,
   type PongoDbClientOptions,
 } from '../core';
+import { proxyPongoDbWithSchema } from '../core/typing/schema';
 import { postgresSQLBuilder } from './sqlBuilder';
 
 export type PostgresDbClientOptions = PongoDbClientOptions<PostgresConnector>;
@@ -46,6 +48,16 @@ export const postgresDb = (
     transaction: () => pool.transaction(),
     withTransaction: (handle) => pool.withTransaction(handle),
   };
+
+  const dbsSchema = options?.schema?.definition?.dbs;
+
+  if (dbsSchema) {
+    const dbSchema = objectEntries(dbsSchema)
+      .map((e) => e[1])
+      .find((db) => db.name === dbName || db.name === databaseName);
+
+    if (dbSchema) return proxyPongoDbWithSchema(db, dbSchema);
+  }
 
   return db;
 };

--- a/src/packages/pongo/src/postgres/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/postgres/sqlBuilder/filter/index.ts
@@ -1,6 +1,6 @@
 import {
-  entries,
   hasOperators,
+  objectEntries,
   QueryOperators,
   type PongoFilter,
 } from '../../../core';
@@ -25,7 +25,7 @@ const constructComplexFilterQuery = (
 ): string => {
   const isEquality = !hasOperators(value);
 
-  return entries(value)
+  return objectEntries(value)
     .map(
       ([nestedKey, val]) =>
         isEquality

--- a/src/packages/pongo/src/postgres/sqlBuilder/filter/queryOperators.ts
+++ b/src/packages/pongo/src/postgres/sqlBuilder/filter/queryOperators.ts
@@ -1,5 +1,5 @@
 import { sql } from '@event-driven-io/dumbo';
-import { entries, OperatorMap } from '../../../core';
+import { objectEntries, OperatorMap } from '../../../core';
 
 export const handleOperator = (
   path: string,
@@ -41,7 +41,7 @@ export const handleOperator = (
         (value as unknown[]).map((v) => sql('%L', v)).join(', '),
       );
     case '$elemMatch': {
-      const subQuery = entries(value as Record<string, unknown>)
+      const subQuery = objectEntries(value as Record<string, unknown>)
         .map(([subKey, subValue]) =>
           sql(`@."%s" == %s`, subKey, JSON.stringify(subValue)),
         )

--- a/src/packages/pongo/src/postgres/sqlBuilder/update/index.ts
+++ b/src/packages/pongo/src/postgres/sqlBuilder/update/index.ts
@@ -1,6 +1,6 @@
 import { sql, type SQL } from '@event-driven-io/dumbo';
 import {
-  entries,
+  objectEntries,
   type $inc,
   type $push,
   type $set,
@@ -9,7 +9,7 @@ import {
 } from '../../../core';
 
 export const buildUpdateQuery = <T>(update: PongoUpdate<T>): SQL =>
-  entries(update).reduce((currentUpdateQuery, [op, value]) => {
+  objectEntries(update).reduce((currentUpdateQuery, [op, value]) => {
     switch (op) {
       case '$set':
         return buildSetQuery(value, currentUpdateQuery);


### PR DESCRIPTION
Now, you'll be able to define schema like:

```ts
const schema = pongoSchema.client({
  database: pongoSchema.db({
    users: pongoSchema.collection<User>('users'),
    customers: pongoSchema.collection<Customer>('customers'),
  }),
});
```
And pass it to the client, getting the typed version.

````ts
const typedClient = pongoClient(postgresConnectionString, {
  schema: { definition: schema },
});
const users = typedClient.database.users;

const _id = new Date().toISOString();
const doc: User = {
  _id,
  name: 'Anita',
  age: 25,
};
const inserted = await users.insertOne(doc);

const pongoDoc = await users.findOne({
  _id: inserted.insertedId,
});
```

That's also the next step to being able to migrate schema upfront. The schema will be the basis to know what should be migrated.