### PR TITLE
Fixed sample CLI config template

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/pongo-core",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/pongo-core",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "workspaces": [
         "packages/dumbo",
         "packages/pongo"
@@ -8611,7 +8611,7 @@
     },
     "packages/pongo": {
       "name": "@event-driven-io/pongo",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dependencies": {
         "pg-connection-string": "^2.6.4"
       },

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo-core",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "engines": {

--- a/src/packages/pongo/package.json
+++ b/src/packages/pongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "scripts": {

--- a/src/packages/pongo/src/commandLine/configFile.ts
+++ b/src/packages/pongo/src/commandLine/configFile.ts
@@ -25,7 +25,7 @@ const sampleConfig = (collectionNames: string[] = ['users']) => {
   const types = collectionNames
     .map(
       (name) =>
-        `type ${formatTypeName(name)} = { name: string, description: string, date: Date }`,
+        `type ${formatTypeName(name)} = { name: string; description: string; date: Date }`,
     )
     .join('\n');
 


### PR DESCRIPTION
It's not super critical, but I used `,` instead of `;` in the type template in the sample config file generation. This PR changes that.