### PR TITLE
Replaced chalk by ansis to keep Pongo compatible with CommonJS

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/pongo-core",
-  "version": "0.16.4-alpha.1",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/pongo-core",
-      "version": "0.16.4-alpha.1",
+      "version": "0.16.4",
       "workspaces": [
         "packages/dumbo",
         "packages/pongo"
@@ -8657,7 +8657,7 @@
     },
     "packages/dumbo": {
       "name": "@event-driven-io/dumbo",
-      "version": "0.12.1-alpha.1",
+      "version": "0.12.1",
       "devDependencies": {
         "@types/node": "22.4.1"
       },
@@ -8671,7 +8671,7 @@
     },
     "packages/pongo": {
       "name": "@event-driven-io/pongo",
-      "version": "0.16.4-alpha.1",
+      "version": "0.16.4",
       "bin": {
         "pongo": "dist/cli.js"
       },
@@ -8679,7 +8679,7 @@
         "@types/node": "22.4.1"
       },
       "peerDependencies": {
-        "@event-driven-io/dumbo": "0.12.1-alpha.1",
+        "@event-driven-io/dumbo": "0.12.1",
         "@types/mongodb": "^4.0.7",
         "@types/pg": "^8.11.6",
         "@types/uuid": "^10.0.0",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@event-driven-io/pongo-core",
-  "version": "0.16.3",
+  "version": "0.16.4-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@event-driven-io/pongo-core",
-      "version": "0.16.3",
+      "version": "0.16.4-alpha.1",
       "workspaces": [
         "packages/dumbo",
         "packages/pongo"
@@ -47,7 +47,7 @@
         "node": ">=20.11.1"
       },
       "peerDependencies": {
-        "chalk": "^5.3.0",
+        "ansis": "^3.3.2",
         "cli-table3": "^0.6.5",
         "commander": "^12.1.0",
         "pg": "^8.12.0",
@@ -1722,6 +1722,15 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha512-tOIuy1/SK/dr94ZA0ckDohKXNeBNqZ4us6PjMVLs5h1w2GBB6uPtOknp2+VF4F/zcy9LI70W+Z+pE2Soajky1w=="
     },
+    "node_modules/ansis": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.3.2.tgz",
+      "integrity": "sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==",
+      "peer": true,
+      "engines": {
+        "node": ">=15"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -2568,18 +2577,6 @@
       "dependencies": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.1"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "peer": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -6251,9 +6248,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -8660,7 +8657,7 @@
     },
     "packages/dumbo": {
       "name": "@event-driven-io/dumbo",
-      "version": "0.12.0",
+      "version": "0.12.1-alpha.1",
       "devDependencies": {
         "@types/node": "22.4.1"
       },
@@ -8674,7 +8671,7 @@
     },
     "packages/pongo": {
       "name": "@event-driven-io/pongo",
-      "version": "0.16.3",
+      "version": "0.16.4-alpha.1",
       "bin": {
         "pongo": "dist/cli.js"
       },
@@ -8682,11 +8679,11 @@
         "@types/node": "22.4.1"
       },
       "peerDependencies": {
-        "@event-driven-io/dumbo": "0.12.0",
+        "@event-driven-io/dumbo": "0.12.1-alpha.1",
         "@types/mongodb": "^4.0.7",
         "@types/pg": "^8.11.6",
         "@types/uuid": "^10.0.0",
-        "chalk": "^5.3.0",
+        "ansis": "^3.3.2",
         "cli-table3": "^0.6.5",
         "commander": "^12.1.0",
         "pg": "^8.12.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo-core",
-  "version": "0.16.4-alpha.1",
+  "version": "0.16.4-alpha.2",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "engines": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo-core",
-  "version": "0.16.3",
+  "version": "0.16.4-alpha.1",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "engines": {
@@ -88,11 +88,11 @@
     "vitepress": "^1.3.3"
   },
   "peerDependencies": {
+    "cli-table3": "^0.6.5",
+    "commander": "^12.1.0",
     "pg": "^8.12.0",
     "pg-connection-string": "^2.6.4",
-    "chalk": "^5.3.0",
-    "cli-table3": "^0.6.5",
-    "commander": "^12.1.0"
+    "ansis": "^3.3.2"
   },
   "dependencies": {
     "@types/benchmark": "^2.1.5",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo-core",
-  "version": "0.16.4-alpha.2",
+  "version": "0.16.4",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "engines": {

--- a/src/packages/dumbo/package.json
+++ b/src/packages/dumbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/dumbo",
-  "version": "0.12.0",
+  "version": "0.12.1-alpha.1",
   "description": "Dumbo - tools for dealing with PostgreSQL",
   "type": "module",
   "scripts": {

--- a/src/packages/dumbo/package.json
+++ b/src/packages/dumbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/dumbo",
-  "version": "0.12.1-alpha.1",
+  "version": "0.12.1-alpha.2",
   "description": "Dumbo - tools for dealing with PostgreSQL",
   "type": "module",
   "scripts": {

--- a/src/packages/dumbo/package.json
+++ b/src/packages/dumbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/dumbo",
-  "version": "0.12.1-alpha.2",
+  "version": "0.12.1",
   "description": "Dumbo - tools for dealing with PostgreSQL",
   "type": "module",
   "scripts": {

--- a/src/packages/dumbo/src/core/tracing/printing/color.ts
+++ b/src/packages/dumbo/src/core/tracing/printing/color.ts
@@ -1,0 +1,21 @@
+import ansis from 'ansis';
+
+let enableColors = true;
+
+export const color = {
+  set level(value: 0 | 1) {
+    enableColors = value === 1;
+  },
+  hex:
+    (value: string) =>
+    (text: string): string =>
+      enableColors ? ansis.hex(value)(text) : text,
+  red: (value: string): string => (enableColors ? ansis.red(value) : value),
+  green: (value: string): string => (enableColors ? ansis.green(value) : value),
+  blue: (value: string): string => (enableColors ? ansis.blue(value) : value),
+  cyan: (value: string): string => (enableColors ? ansis.cyan(value) : value),
+  yellow: (value: string): string =>
+    enableColors ? ansis.yellow(value) : value,
+};
+
+export default color;

--- a/src/packages/dumbo/src/core/tracing/printing/index.ts
+++ b/src/packages/dumbo/src/core/tracing/printing/index.ts
@@ -1,1 +1,2 @@
+export * from './color';
 export * from './pretty';

--- a/src/packages/dumbo/src/core/tracing/printing/pretty.ts
+++ b/src/packages/dumbo/src/core/tracing/printing/pretty.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import chalk from './color';
 
 const TWO_SPACES = '  ';
 

--- a/src/packages/dumbo/src/core/tracing/printing/pretty.unit.spec.ts
+++ b/src/packages/dumbo/src/core/tracing/printing/pretty.unit.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
-import chalk from 'chalk';
 import { describe, it } from 'node:test';
+import chalk from './color';
 import { prettyJson } from './pretty';
 
 void describe('prettyPrintJson', () => {

--- a/src/packages/dumbo/tsup.config.ts
+++ b/src/packages/dumbo/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   clean: true, // clean up the dist folder
   dts: true, // generate dts files
   format: ['esm', 'cjs'], // generate cjs and esm files
-  minify: true, //env === 'production',
+  minify: false, //env === 'production',
   bundle: true, //env === 'production',
   skipNodeModulesBundle: true,
   watch: env === 'development',

--- a/src/packages/pongo/package.json
+++ b/src/packages/pongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo",
-  "version": "0.16.4-alpha.1",
+  "version": "0.16.4-alpha.2",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "scripts": {
@@ -87,7 +87,7 @@
     "pongo": "./dist/cli.js"
   },
   "peerDependencies": {
-    "@event-driven-io/dumbo": "0.12.1-alpha.1",
+    "@event-driven-io/dumbo": "0.12.1-alpha.2",
     "@types/mongodb": "^4.0.7",
     "@types/pg": "^8.11.6",
     "@types/uuid": "^10.0.0",

--- a/src/packages/pongo/package.json
+++ b/src/packages/pongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo",
-  "version": "0.16.4-alpha.2",
+  "version": "0.16.4",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "scripts": {
@@ -87,7 +87,7 @@
     "pongo": "./dist/cli.js"
   },
   "peerDependencies": {
-    "@event-driven-io/dumbo": "0.12.1-alpha.2",
+    "@event-driven-io/dumbo": "0.12.1",
     "@types/mongodb": "^4.0.7",
     "@types/pg": "^8.11.6",
     "@types/uuid": "^10.0.0",

--- a/src/packages/pongo/package.json
+++ b/src/packages/pongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@event-driven-io/pongo",
-  "version": "0.16.3",
+  "version": "0.16.4-alpha.1",
   "description": "Pongo - Mongo with strong consistency on top of Postgres",
   "type": "module",
   "scripts": {
@@ -87,13 +87,13 @@
     "pongo": "./dist/cli.js"
   },
   "peerDependencies": {
-    "@event-driven-io/dumbo": "0.12.0",
+    "@event-driven-io/dumbo": "0.12.1-alpha.1",
     "@types/mongodb": "^4.0.7",
     "@types/pg": "^8.11.6",
     "@types/uuid": "^10.0.0",
     "pg": "^8.12.0",
     "uuid": "^10.0.0",
-    "chalk": "^5.3.0",
+    "ansis": "^3.3.2",
     "cli-table3": "^0.6.5",
     "commander": "^12.1.0",
     "pg-connection-string": "^2.6.4"

--- a/src/packages/pongo/src/commandLine/shell.ts
+++ b/src/packages/pongo/src/commandLine/shell.ts
@@ -124,7 +124,7 @@ const startRepl = async (options: {
   setLogLevel(process.env.DUMBO_LOG_LEVEL ?? options.logging.logLevel);
   setLogStyle(process.env.DUMBO_LOG_STYLE ?? options.logging.logStyle);
 
-  console.log(color.green('Starting Pongo Shell (version: 0.16.4-alpha.1)'));
+  console.log(color.green('Starting Pongo Shell (version: 0.16.4-alpha.2)'));
 
   if (options.logging.printOptions) {
     console.log(color.green('With Options:'));

--- a/src/packages/pongo/src/commandLine/shell.ts
+++ b/src/packages/pongo/src/commandLine/shell.ts
@@ -1,12 +1,12 @@
 import {
   checkConnection,
+  color,
   LogLevel,
   LogStyle,
   prettyJson,
   SQL,
   type MigrationStyle,
 } from '@event-driven-io/dumbo';
-import chalk from 'chalk';
 import Table from 'cli-table3';
 import { Command } from 'commander';
 import repl from 'node:repl';
@@ -52,7 +52,7 @@ const printOutput = (obj: any): string =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const displayResultsAsTable = (results: any[]): string => {
   if (results.length === 0) {
-    return chalk.yellow('No documents found.');
+    return color.yellow('No documents found.');
   }
 
   const columnNames = results
@@ -66,7 +66,7 @@ const displayResultsAsTable = (results: any[]): string => {
   const columnWidths = calculateColumnWidths(results, columnNames);
 
   const table = new Table({
-    head: columnNames.map((col) => chalk.cyan(col)),
+    head: columnNames.map((col) => color.cyan(col)),
     colWidths: columnWidths,
   });
 
@@ -124,10 +124,10 @@ const startRepl = async (options: {
   setLogLevel(process.env.DUMBO_LOG_LEVEL ?? options.logging.logLevel);
   setLogStyle(process.env.DUMBO_LOG_STYLE ?? options.logging.logStyle);
 
-  console.log(chalk.green('Starting Pongo Shell (version: 0.16.3)'));
+  console.log(color.green('Starting Pongo Shell (version: 0.16.4-alpha.1)'));
 
   if (options.logging.printOptions) {
-    console.log(chalk.green('With Options:'));
+    console.log(color.green('With Options:'));
     console.log(prettyJson(options));
   }
 
@@ -138,7 +138,7 @@ const startRepl = async (options: {
 
   if (!(options.connectionString ?? process.env.DB_CONNECTION_STRING)) {
     console.log(
-      chalk.yellow(
+      color.yellow(
         `No connection string provided, using: 'postgresql://postgres:postgres@localhost:5432/postgres'`,
       ),
     );
@@ -149,28 +149,28 @@ const startRepl = async (options: {
   if (!connectionCheck.successful) {
     if (connectionCheck.errorType === 'ConnectionRefused') {
       console.error(
-        chalk.red(
+        color.red(
           `Connection was refused. Check if the PostgreSQL server is running and accessible.`,
         ),
       );
     } else if (connectionCheck.errorType === 'Authentication') {
       console.error(
-        chalk.red(
+        color.red(
           `Authentication failed. Check the username and password in the connection string.`,
         ),
       );
     } else {
-      console.error(chalk.red('Error connecting to PostgreSQL server'));
+      console.error(color.red('Error connecting to PostgreSQL server'));
     }
-    console.log(chalk.red('Exiting Pongo Shell...'));
+    console.log(color.red('Exiting Pongo Shell...'));
     process.exit();
   }
 
-  console.log(chalk.green(`Successfully connected`));
-  console.log(chalk.green('Use db.<collection>.<method>() to query.'));
+  console.log(color.green(`Successfully connected`));
+  console.log(color.green('Use db.<collection>.<method>() to query.'));
 
   const shell = repl.start({
-    prompt: chalk.green('pongo> '),
+    prompt: color.green('pongo> '),
     useGlobal: true,
     breakEvalOnSigint: true,
     writer: printOutput,
@@ -237,7 +237,7 @@ const startRepl = async (options: {
 };
 
 const teardown = async () => {
-  console.log(chalk.yellow('Exiting Pongo Shell...'));
+  console.log(color.yellow('Exiting Pongo Shell...'));
   await pongo.close();
 };
 

--- a/src/packages/pongo/src/commandLine/shell.ts
+++ b/src/packages/pongo/src/commandLine/shell.ts
@@ -124,7 +124,7 @@ const startRepl = async (options: {
   setLogLevel(process.env.DUMBO_LOG_LEVEL ?? options.logging.logLevel);
   setLogStyle(process.env.DUMBO_LOG_STYLE ?? options.logging.logStyle);
 
-  console.log(color.green('Starting Pongo Shell (version: 0.16.4-alpha.2)'));
+  console.log(color.green('Starting Pongo Shell (version: 0.16.4)'));
 
   if (options.logging.printOptions) {
     console.log(color.green('With Options:'));

--- a/src/packages/pongo/tsup.config.ts
+++ b/src/packages/pongo/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   clean: true, // clean up the dist folder
   dts: true, // generate dts files
   format: ['esm', 'cjs'], // generate cjs and esm files
-  minify: true, //env === 'production',
+  minify: false, //env === 'production',
   bundle: true, //env === 'production',
   skipNodeModulesBundle: true,
   watch: env === 'development',

--- a/src/tsup.config.ts
+++ b/src/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   clean: true, // clean up the dist folder
   dts: true, // generate dts files
   format: ['cjs', 'esm'], // generate cjs and esm files
-  minify: true, //env === 'production',
+  minify: false, //env === 'production',
   bundle: true, //env === 'production',
   skipNodeModulesBundle: true,
   watch: env === 'development',


### PR DESCRIPTION
It seems that Chalk from v5 is ESModules-only