### PR TITLE
Set License to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,13 @@
-MIT License
+Copyright (c) Oskar Dudycz and Contributors
 
-Copyright (c) 2024 event-driven.io
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+    http://www.apache.org/licenses/LICENSE-2.0
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
We're making an important change to our project's license, moving from MIT to Apache 2.0. I wanted to take a moment to explain this change and why we believe it's beneficial for our community.

## Why We're Making This Change

After careful consideration, we've decided to adopt the Apache 2.0 license for several good reasons:

### Clearer Terms

Apache 2.0 provides more detailed guidelines around contributions, modifications, and usage rights. This clarity benefits everyone by reducing potential misunderstandings as our project grows.

### Community Standard

Many established open-source projects use Apache 2.0, particularly in enterprise settings. Adopting this license aligns us with common practices in the broader open-source community.

### Better Patent Protection

The Apache 2.0 license includes an express patent grant that MIT doesn't offer. This provides everyone with clearer protection against patent claims related to the project's code, creating a more secure environment for collaboration.

### Improved Compatibility

While both licenses are permissive, Apache 2.0 is more compatible with a wider range of open-source projects. This means our code can be more easily integrated into diverse ecosystems, furthering our goal of creating widely useful software.

## What This Means For You

For most users and contributors, this change will have minimal practical impact:

- The license remains permissive - you can still use, modify, and distribute the software freely
- No royalties or fees are required
- Commercial use is still fully supported
- The main attribution requirements remain similar

The primary difference is the additional patent protection, which actually provides you with greater security when using and contributing to the project.

## For Existing Users

If you're already using our software under the MIT license, you can continue using that version under those terms. The license change applies to future releases going forward.

We believe this change strengthens our project's foundation while maintaining the open and accessible spirit that's always been central to our work. If you have any questions or concerns, please don't hesitate to open an issue or reach out directly.

Thank you for being part of our community.