### PR TITLE
Implement 'limit' and 'skip' options in find()

### DIFF
--- a/src/packages/pongo/src/core/collection/pongoCollection.ts
+++ b/src/packages/pongo/src/core/collection/pongoCollection.ts
@@ -22,6 +22,7 @@ import {
   type DeleteManyOptions,
   type DeleteOneOptions,
   type DocumentHandler,
+  type FindOptions,
   type HandleOptions,
   type InsertManyOptions,
   type InsertOneOptions,
@@ -435,11 +436,11 @@ export const pongoCollection = <
     },
     find: async (
       filter?: PongoFilter<T>,
-      options?: CollectionOperationOptions,
+      options?: FindOptions,
     ): Promise<WithIdAndVersion<T>[]> => {
       await ensureCollectionCreated(options);
 
-      const result = await query(SqlFor.find(filter ?? {}));
+      const result = await query(SqlFor.find(filter ?? {}, options));
       return result.rows.map((row) => row.data as WithIdAndVersion<T>);
     },
     countDocuments: async (
@@ -530,7 +531,7 @@ export type PongoCollectionSQLBuilder = {
   ) => SQL;
   deleteMany: <T>(filter: PongoFilter<T> | SQL) => SQL;
   findOne: <T>(filter: PongoFilter<T> | SQL) => SQL;
-  find: <T>(filter: PongoFilter<T> | SQL) => SQL;
+  find: <T>(filter: PongoFilter<T> | SQL, options?: FindOptions) => SQL;
   countDocuments: <T>(filter: PongoFilter<T> | SQL) => SQL;
   rename: (newName: string) => SQL;
   drop: () => SQL;

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -134,6 +134,11 @@ export type DeleteManyOptions = {
   >;
 } & CollectionOperationOptions;
 
+export type FindOptions = {
+  limit?: number,
+  skip?: number,
+} & CollectionOperationOptions;
+
 export interface PongoCollection<T extends PongoDocument> {
   readonly dbName: string;
   readonly collectionName: string;
@@ -175,7 +180,7 @@ export interface PongoCollection<T extends PongoDocument> {
   ): Promise<WithIdAndVersion<T> | null>;
   find(
     filter?: PongoFilter<T> | SQL,
-    options?: CollectionOperationOptions,
+    options?: FindOptions,
   ): Promise<WithIdAndVersion<T>[]>;
   findOneAndDelete(
     filter: PongoFilter<T> | SQL,

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -135,8 +135,8 @@ export type DeleteManyOptions = {
 } & CollectionOperationOptions;
 
 export type FindOptions = {
-  limit?: number,
-  skip?: number,
+  limit?: number;
+  skip?: number;
 } & CollectionOperationOptions;
 
 export interface PongoCollection<T extends PongoDocument> {

--- a/src/packages/pongo/src/e2e/compatibilityTest.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/compatibilityTest.e2e.spec.ts
@@ -913,6 +913,112 @@ void describe('MongoDB Compatibility Tests', () => {
         })),
       );
     });
+
+    void it('should limit number of results in both PostgreSQL and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>('limitCollection');
+      const mongoCollection = mongoDb.collection<User>('limitCollection');
+      const docs = [
+        { name: 'David', age: 40 },
+        { name: 'Eve', age: 45 },
+        { name: 'Frank', age: 50 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({}, { limit: 2 }).toArray();
+      const mongoDocs = await mongoCollection.find({}, { limit: 2 }).toArray();
+
+      assert.strictEqual(pongoDocs.length, 2);
+      assert.strictEqual(mongoDocs.length, 2);
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        docs.slice(0, 2).map((d) => ({ name: d.name, age: d.age })),
+      );
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
+    void it('should skip number of results in both PostgreSQL and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>('skipCollection');
+      const mongoCollection = mongoDb.collection<User>('skipCollection');
+      const docs = [
+        { name: 'David', age: 40 },
+        { name: 'Eve', age: 45 },
+        { name: 'Frank', age: 50 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({}, { skip: 1 }).toArray();
+      const mongoDocs = await mongoCollection.find({}, { skip: 1 }).toArray();
+
+      assert.strictEqual(pongoDocs.length, 2);
+      assert.strictEqual(mongoDocs.length, 2);
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        docs.slice(1, 3).map((d) => ({ name: d.name, age: d.age })),
+      );
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
+    void it('should use limit and skip parameters to paginate results in both PostgreSQL and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>('limitSkipCollection');
+      const mongoCollection = mongoDb.collection<User>('limitSkipCollection');
+      const docs = [
+        { name: 'David', age: 40 },
+        { name: 'Eve', age: 45 },
+        { name: 'Frank', age: 50 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection
+        .find({}, { limit: 1, skip: 1 })
+        .toArray();
+      const mongoDocs = await mongoCollection
+        .find({}, { limit: 1, skip: 1 })
+        .toArray();
+
+      assert.strictEqual(pongoDocs.length, 1);
+      assert.strictEqual(mongoDocs.length, 1);
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        docs.slice(1, 2).map((d) => ({ name: d.name, age: d.age })),
+      );
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
   });
 
   void describe('Handle Operations', () => {

--- a/src/packages/pongo/src/mongo/mongoCollection.ts
+++ b/src/packages/pongo/src/mongo/mongoCollection.ts
@@ -65,6 +65,7 @@ import type {
   HandleOptions,
   PongoCollection,
   PongoFilter,
+  FindOptions as PongoFindOptions,
   PongoHandleResult,
   OptionalUnlessRequiredId as PongoOptionalUnlessRequiredId,
   PongoSession,
@@ -78,6 +79,28 @@ const toCollectionOperationOptions = (
   options?.session
     ? { session: options.session as unknown as PongoSession }
     : undefined;
+
+const toFindOptions = (
+  options: FindOptions | undefined,
+): PongoFindOptions | undefined => {
+  if (!options?.session && !options?.limit && !options?.skip) {
+    return undefined;
+  }
+
+  const pongoFindOptions: PongoFindOptions = {};
+
+  if (options?.session) {
+    pongoFindOptions.session = options.session as unknown as PongoSession;
+  }
+  if (options?.limit !== undefined) {
+    pongoFindOptions.limit = options.limit;
+  }
+  if (options?.skip !== undefined) {
+    pongoFindOptions.skip = options.skip;
+  }
+
+  return pongoFindOptions;
+};
 
 export class Collection<T extends Document> implements MongoCollection<T> {
   private collection: PongoCollection<T>;
@@ -271,10 +294,7 @@ export class Collection<T extends Document> implements MongoCollection<T> {
     options?: FindOptions<Document>,
   ): MongoFindCursor<WithId<T>> | MongoFindCursor<T> {
     return new FindCursor(
-      this.collection.find(
-        filter as PongoFilter<T>,
-        toCollectionOperationOptions(options),
-      ),
+      this.collection.find(filter as PongoFilter<T>, toFindOptions(options)),
     ) as unknown as MongoFindCursor<T>;
   }
   options(_options?: OperationOptions): Promise<Document> {

--- a/src/packages/pongo/src/storage/postgresql/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/sqlBuilder/index.ts
@@ -247,13 +247,11 @@ export const postgresSQLBuilder = (
     const filterQuery = isSQL(filter) ? filter : constructFilterQuery(filter);
     const query: SQL[] = [];
 
-    query.push(
-      sql('SELECT data FROM %I', collectionName),
-    );
+    query.push(sql('SELECT data FROM %I', collectionName));
 
-    const whereStmt = where(filterQuery)
+    const whereStmt = where(filterQuery);
     if (whereStmt.length > 0) {
-        query.push(sql('%s', whereStmt));
+      query.push(sql('%s', whereStmt));
     }
 
     if (options?.limit) {

--- a/src/packages/pongo/src/storage/postgresql/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/sqlBuilder/index.ts
@@ -248,8 +248,13 @@ export const postgresSQLBuilder = (
     const query: SQL[] = [];
 
     query.push(
-      sql('SELECT data FROM %I %s', collectionName, where(filterQuery)),
+      sql('SELECT data FROM %I', collectionName),
     );
+
+    const whereStmt = where(filterQuery)
+    if (whereStmt.length > 0) {
+        query.push(sql('%s', whereStmt));
+    }
 
     if (options?.limit) {
       query.push(sql('LIMIT %s', options.limit));

--- a/src/packages/pongo/src/storage/postgresql/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import { postgresSQLBuilder } from '.';
+
+void describe('find() query options', () => {
+  void it('should apply limit correctly', () => {
+    const query = postgresSQLBuilder('users').find({}, { limit: 4 });
+    assert.strictEqual(query, 'SELECT data FROM users  LIMIT 4;');
+  });
+
+  void it('should apply offset correctly', () => {
+    const query = postgresSQLBuilder('users').find({}, { skip: 123 });
+    assert.strictEqual(query, 'SELECT data FROM users  OFFSET 123;');
+  });
+
+  void it('should apply limit and offset in correct order', () => {
+    const query = postgresSQLBuilder('users').find(
+      {},
+      { limit: 20, skip: 123 },
+    );
+    assert.strictEqual(query, 'SELECT data FROM users  LIMIT 20 OFFSET 123;');
+  });
+});

--- a/src/packages/pongo/src/storage/postgresql/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -5,12 +5,12 @@ import { postgresSQLBuilder } from '.';
 void describe('find() query options', () => {
   void it('should apply limit correctly', () => {
     const query = postgresSQLBuilder('users').find({}, { limit: 4 });
-    assert.strictEqual(query, 'SELECT data FROM users  LIMIT 4;');
+    assert.strictEqual(query, 'SELECT data FROM users LIMIT 4;');
   });
 
   void it('should apply offset correctly', () => {
     const query = postgresSQLBuilder('users').find({}, { skip: 123 });
-    assert.strictEqual(query, 'SELECT data FROM users  OFFSET 123;');
+    assert.strictEqual(query, 'SELECT data FROM users OFFSET 123;');
   });
 
   void it('should apply limit and offset in correct order', () => {
@@ -18,6 +18,6 @@ void describe('find() query options', () => {
       {},
       { limit: 20, skip: 123 },
     );
-    assert.strictEqual(query, 'SELECT data FROM users  LIMIT 20 OFFSET 123;');
+    assert.strictEqual(query, 'SELECT data FROM users LIMIT 20 OFFSET 123;');
   });
 });


### PR DESCRIPTION
This PR introduces support for limit and skip options in the find() query method. These options allow more flexible querying by enabling pagination and result size control.