### PR TITLE
Refactored SQL parsing to generate parametrised queries instead of raw ones

### DIFF
--- a/src/packages/dumbo/src/core/query/selectors.ts
+++ b/src/packages/dumbo/src/core/query/selectors.ts
@@ -53,7 +53,7 @@ export const count = async (
 ): Promise<number> => {
   const result = await single(getResult);
 
-  return result.count;
+  return Number(result.count);
 };
 
 export type ExistsSQLQueryResult = { exists: boolean | 1 | 0 };

--- a/src/packages/dumbo/src/core/schema/migrations.ts
+++ b/src/packages/dumbo/src/core/schema/migrations.ts
@@ -113,7 +113,7 @@ const getMigrationHash = async (
   sqlMigration: SQLMigration,
   sqlFormatter: SQLFormatter,
 ): Promise<string> => {
-  const content = sqlFormatter.format(sqlMigration.sqls);
+  const content = sqlFormatter.formatRaw(sqlMigration.sqls);
 
   const encoder = new TextEncoder();
   const data = encoder.encode(content);

--- a/src/packages/dumbo/src/core/sql/index.ts
+++ b/src/packages/dumbo/src/core/sql/index.ts
@@ -1,2 +1,3 @@
+export * from './parametrizedSQL';
 export * from './sql';
 export * from './sqlFormatter';

--- a/src/packages/dumbo/src/core/sql/parametrizedSQL.ts
+++ b/src/packages/dumbo/src/core/sql/parametrizedSQL.ts
@@ -1,0 +1,80 @@
+import { SQL } from './sql';
+
+export interface ParametrizedSQL {
+  __brand: 'parametrized-sql';
+  sql: string;
+  params: unknown[];
+}
+
+export const ParametrizedSQL = (
+  strings: TemplateStringsArray,
+  values: unknown[],
+): ParametrizedSQL => {
+  let resultSql = '';
+  const params: unknown[] = [];
+  let paramIndex = 1;
+
+  for (let i = 0; i < strings.length; i++) {
+    resultSql += strings[i];
+
+    if (i < values.length) {
+      const value = values[i];
+
+      if (SQL.isPlain(value)) {
+        // Raw values should be inlined immediately, not parametrized
+        resultSql += value.value;
+      } else if (isParametrizedSQL(value)) {
+        const adjustedSql = adjustParameterNumbers(value.sql, paramIndex - 1);
+        resultSql += adjustedSql.sql;
+        params.push(...value.params);
+        paramIndex += value.params.length;
+      } else {
+        resultSql += `__P${paramIndex}__`;
+        params.push(value);
+        paramIndex++;
+      }
+    }
+  }
+
+  return {
+    __brand: 'parametrized-sql',
+    sql: resultSql,
+    params,
+  };
+};
+
+export const parametrizeSQL = (sql: SQL): ParametrizedSQL => {
+  if (isParametrizedSQL(sql)) {
+    return sql as unknown as ParametrizedSQL;
+  }
+
+  return ParametrizedSQL(
+    [sql as string] as unknown as TemplateStringsArray,
+    [],
+  );
+};
+
+export const isParametrizedSQL = (value: unknown): value is ParametrizedSQL => {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    '__brand' in value &&
+    value.__brand === 'parametrized-sql'
+  );
+};
+
+const adjustParameterNumbers = (
+  sql: string,
+  offset: number,
+): { sql: string } => {
+  if (offset === 0) {
+    return { sql };
+  }
+
+  return {
+    sql: sql.replace(/__P(\d+)__/g, (_match, num: string) => {
+      const newNum = parseInt(num, 10) + offset;
+      return `__P${newNum}__`;
+    }),
+  };
+};

--- a/src/packages/dumbo/src/core/sql/parametrizedSQL.unit.spec.ts
+++ b/src/packages/dumbo/src/core/sql/parametrizedSQL.unit.spec.ts
@@ -1,0 +1,281 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { isParametrizedSQL, type ParametrizedSQL } from './parametrizedSQL';
+import { SQL } from './sql';
+
+const asParametrizedSQL = (sql: SQL): ParametrizedSQL =>
+  sql as unknown as ParametrizedSQL;
+
+void describe('SQL Parametrizer', () => {
+  void describe('ParametrizedSQL interface structure', () => {
+    void it('should have correct interface structure', () => {
+      const result = asParametrizedSQL(SQL`SELECT * FROM users`);
+
+      assert.ok(isParametrizedSQL(result));
+      assert.equal(result.__brand, 'parametrized-sql');
+      assert.equal(typeof result.sql, 'string');
+      assert.ok(Array.isArray(result.params));
+    });
+  });
+
+  void describe('basic template literal parametrization', () => {
+    void it('should parametrize simple value interpolation', () => {
+      const result = asParametrizedSQL(
+        SQL`SELECT * FROM users WHERE id = ${123}`,
+      );
+
+      assert.equal(result.sql, 'SELECT * FROM users WHERE id = __P1__');
+      assert.deepEqual(result.params, [123]);
+    });
+
+    void it('should handle multiple parameters', () => {
+      const result = asParametrizedSQL(
+        SQL`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`,
+      );
+
+      assert.equal(
+        result.sql,
+        'SELECT * FROM users WHERE id = __P1__ AND name = __P2__',
+      );
+      assert.deepEqual(result.params, [123, 'John']);
+    });
+
+    void it('should handle no parameters', () => {
+      const result = asParametrizedSQL(SQL`SELECT * FROM users`);
+
+      assert.equal(result.sql, 'SELECT * FROM users');
+      assert.deepEqual(result.params, []);
+    });
+  });
+
+  void describe('placeholder generation', () => {
+    void it('should generate sequential placeholders', () => {
+      const result = asParametrizedSQL(
+        SQL`INSERT INTO users (id, name, age) VALUES (${1}, ${'Alice'}, ${30})`,
+      );
+
+      assert.equal(
+        result.sql,
+        'INSERT INTO users (id, name, age) VALUES (__P1__, __P2__, __P3__)',
+      );
+      assert.deepEqual(result.params, [1, 'Alice', 30]);
+    });
+
+    void it('should handle many parameters', () => {
+      const values = Array.from({ length: 10 }, (_, i) => i + 1);
+      const result = asParametrizedSQL(
+        SQL`SELECT * FROM table WHERE id IN (${values[0]}, ${values[1]}, ${values[2]}, ${values[3]}, ${values[4]}, ${values[5]}, ${values[6]}, ${values[7]}, ${values[8]}, ${values[9]})`,
+      );
+
+      const expectedPlaceholders = values
+        .map((_, i) => `__P${i + 1}__`)
+        .join(', ');
+      assert.equal(
+        result.sql,
+        `SELECT * FROM table WHERE id IN (${expectedPlaceholders})`,
+      );
+      assert.deepEqual(result.params, values);
+    });
+  });
+
+  void describe('parameter array extraction', () => {
+    void it('should extract different value types', () => {
+      const date = new Date('2024-01-01');
+      const result = asParametrizedSQL(
+        SQL`INSERT INTO logs (id, message, created_at, count) VALUES (${123}, ${'test'}, ${date}, ${null})`,
+      );
+
+      assert.equal(
+        result.sql,
+        'INSERT INTO logs (id, message, created_at, count) VALUES (__P1__, __P2__, __P3__, __P4__)',
+      );
+      assert.deepEqual(result.params, [123, 'test', date, null]);
+    });
+
+    void it('should handle undefined values', () => {
+      const result = asParametrizedSQL(
+        SQL`SELECT * FROM users WHERE status = ${undefined}`,
+      );
+
+      assert.equal(result.sql, 'SELECT * FROM users WHERE status = __P1__');
+      assert.deepEqual(result.params, [undefined]);
+    });
+  });
+
+  void describe('nested SQL template flattening', () => {
+    void it('should flatten simple nested SQL', () => {
+      const subQuery = SQL`SELECT id FROM roles WHERE name = ${'admin'}`;
+      const mainQuery = asParametrizedSQL(
+        SQL`SELECT * FROM users WHERE role_id IN (${subQuery})`,
+      );
+
+      assert.equal(
+        mainQuery.sql,
+        'SELECT * FROM users WHERE role_id IN (SELECT id FROM roles WHERE name = __P1__)',
+      );
+      assert.deepEqual(mainQuery.params, ['admin']);
+    });
+
+    void it('should handle deeply nested SQL', () => {
+      const inner = SQL`SELECT id FROM permissions WHERE name = ${'read'}`;
+      const middle = SQL`SELECT role_id FROM role_permissions WHERE permission_id IN (${inner})`;
+      const outer = asParametrizedSQL(
+        SQL`SELECT * FROM users WHERE role_id IN (${middle})`,
+      );
+
+      assert.equal(
+        outer.sql,
+        'SELECT * FROM users WHERE role_id IN (SELECT role_id FROM role_permissions WHERE permission_id IN (SELECT id FROM permissions WHERE name = __P1__))',
+      );
+      assert.deepEqual(outer.params, ['read']);
+    });
+
+    void it('should handle multiple nested SQL with parameters', () => {
+      const subQuery1 = SQL`SELECT id FROM roles WHERE name = ${'admin'}`;
+      const subQuery2 = SQL`SELECT id FROM departments WHERE code = ${'IT'}`;
+      const mainQuery = asParametrizedSQL(
+        SQL`SELECT * FROM users WHERE role_id IN (${subQuery1}) AND dept_id IN (${subQuery2})`,
+      );
+
+      assert.equal(
+        mainQuery.sql,
+        'SELECT * FROM users WHERE role_id IN (SELECT id FROM roles WHERE name = __P1__) AND dept_id IN (SELECT id FROM departments WHERE code = __P2__)',
+      );
+      assert.deepEqual(mainQuery.params, ['admin', 'IT']);
+    });
+  });
+
+  void describe('special value types', () => {
+    void describe('literal() values', () => {
+      void it('should pass through literal values as parameters', () => {
+        const result = asParametrizedSQL(
+          SQL`SELECT * FROM users WHERE name = ${SQL.literal('John')}`,
+        );
+
+        assert.equal(result.sql, 'SELECT * FROM users WHERE name = __P1__');
+        assert.deepEqual(result.params, [SQL.literal('John')]);
+      });
+
+      void it('should pass through multiple literal values as parameters', () => {
+        const result = asParametrizedSQL(
+          SQL`INSERT INTO users (name, age) VALUES (${SQL.literal('Alice')}, ${SQL.literal(25)})`,
+        );
+
+        assert.equal(
+          result.sql,
+          'INSERT INTO users (name, age) VALUES (__P1__, __P2__)',
+        );
+        assert.deepEqual(result.params, [
+          SQL.literal('Alice'),
+          SQL.literal(25),
+        ]);
+      });
+    });
+
+    void describe('identifier() values', () => {
+      void it('should pass through identifier values as parameters', () => {
+        const result = asParametrizedSQL(
+          SQL`SELECT * FROM ${SQL.identifier('users')}`,
+        );
+
+        assert.equal(result.sql, 'SELECT * FROM __P1__');
+        assert.deepEqual(result.params, [SQL.identifier('users')]);
+      });
+
+      void it('should pass through all values as parameters', () => {
+        const result = asParametrizedSQL(
+          SQL`SELECT ${SQL.identifier('name')}, ${SQL.identifier('age')} FROM ${SQL.identifier('users')} WHERE id = ${123}`,
+        );
+
+        assert.equal(
+          result.sql,
+          'SELECT __P1__, __P2__ FROM __P3__ WHERE id = __P4__',
+        );
+        assert.deepEqual(result.params, [
+          SQL.identifier('name'),
+          SQL.identifier('age'),
+          SQL.identifier('users'),
+          123,
+        ]);
+      });
+    });
+
+    void describe('raw() values', () => {
+      void it('should inline raw SQL immediately', () => {
+        const result = asParametrizedSQL(
+          SQL`SELECT * FROM users ${SQL.plain('ORDER BY created_at DESC')}`,
+        );
+
+        assert.equal(
+          result.sql,
+          'SELECT * FROM users ORDER BY created_at DESC',
+        );
+        assert.deepEqual(result.params, []);
+      });
+
+      void it('should inline raw values and parametrize other values', () => {
+        const result = asParametrizedSQL(
+          SQL`SELECT * FROM users WHERE ${SQL.plain("status = 'active'")} AND id = ${123}`,
+        );
+
+        assert.equal(
+          result.sql,
+          "SELECT * FROM users WHERE status = 'active' AND id = __P1__",
+        );
+        assert.deepEqual(result.params, [123]);
+      });
+    });
+
+    void describe('mixed special value types', () => {
+      void it('should pass through all special types as parameters', () => {
+        const result = asParametrizedSQL(SQL`
+          SELECT ${SQL.identifier('id')}, ${SQL.identifier('name')}
+          FROM ${SQL.identifier('users')}
+          WHERE status = ${SQL.literal('active')}
+            AND id > ${100}
+            ${SQL.plain("AND created_at > NOW() - INTERVAL '7 days'")}
+        `);
+
+        assert.equal(
+          result.sql,
+          `
+          SELECT __P1__, __P2__
+          FROM __P3__
+          WHERE status = __P4__
+            AND id > __P5__
+            AND created_at > NOW() - INTERVAL '7 days'
+        `,
+        );
+        assert.deepEqual(result.params, [
+          SQL.identifier('id'),
+          SQL.identifier('name'),
+          SQL.identifier('users'),
+          SQL.literal('active'),
+          100,
+        ]);
+      });
+
+      void it('should maintain sequential parameter numbering', () => {
+        const result = asParametrizedSQL(SQL`
+          INSERT INTO ${SQL.identifier('logs')} (${SQL.identifier('level')}, message, user_id, ${SQL.plain('created_at')})
+          VALUES (${SQL.literal('ERROR')}, ${'Database connection failed'}, ${42}, ${SQL.plain('NOW()')})
+        `);
+
+        assert.equal(
+          result.sql,
+          `
+          INSERT INTO __P1__ (__P2__, message, user_id, created_at)
+          VALUES (__P3__, __P4__, __P5__, NOW())
+        `,
+        );
+        assert.deepEqual(result.params, [
+          SQL.identifier('logs'),
+          SQL.identifier('level'),
+          SQL.literal('ERROR'),
+          'Database connection failed',
+          42,
+        ]);
+      });
+    });
+  });
+});

--- a/src/packages/dumbo/src/core/sql/sql.ts
+++ b/src/packages/dumbo/src/core/sql/sql.ts
@@ -1,59 +1,39 @@
+import { ParametrizedSQL, isParametrizedSQL } from './parametrizedSQL';
 import { formatSQL } from './sqlFormatter';
 
 export type SQL = string & { __brand: 'sql' };
 
-export interface DeferredSQL {
-  __brand: 'deferred-sql';
-  strings: TemplateStringsArray;
-  values: unknown[];
-}
-
-export interface RawSQL {
-  __brand: 'sql';
-  sql: string;
-}
-
 export function SQL(strings: TemplateStringsArray, ...values: unknown[]): SQL {
-  return strings.length === 1 && values.length === 0
-    ? rawSql(strings[0] as string)
-    : deferredSQL(strings, values);
+  const parametrized = ParametrizedSQL(strings, values);
+  return parametrized as unknown as SQL;
 }
+
+export const isSQL = (value: unknown): value is SQL => {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  return isParametrizedSQL(value);
+};
 
 const ID = Symbol.for('SQL_IDENTIFIER');
 const RAW = Symbol.for('SQL_RAW');
 const LITERAL = Symbol.for('SQL_LITERAL');
 
 type SQLIdentifier = { [ID]: true; value: string };
-type SQLRaw = { [RAW]: true; value: string };
+type SQLPlain = { [RAW]: true; value: string };
 type SQLLiteral = { [LITERAL]: true; value: unknown };
 
-const deferredSQL = (strings: TemplateStringsArray, values: unknown[]): SQL => {
-  const deferredSql: DeferredSQL = {
-    __brand: 'deferred-sql',
-    strings,
-    values,
-  };
+const emptySQL = (): SQL => SQL([''] as unknown as TemplateStringsArray);
 
-  return deferredSql as unknown as SQL;
-};
-
-const rawSql = (sqlQuery: string): SQL => {
-  const rawSQL: RawSQL = {
-    __brand: 'sql',
-    sql: sqlQuery,
-  };
-
-  return rawSQL as unknown as SQL;
-};
-
-export const mergeSQL = (sqls: SQL[], separator: string = ' '): SQL => {
+const mergeSQL = (sqls: SQL[], separator: string = ' '): SQL => {
   if (!Array.isArray(sqls)) return sqls;
-  if (sqls.length === 0) return rawSql('');
+  if (sqls.length === 0) return emptySQL();
   if (sqls.length === 1) return sqls[0]!;
 
   // Filter out empty SQL parts
   const nonEmptySqls = sqls.filter((sql) => !isEmpty(sql));
-  if (nonEmptySqls.length === 0) return rawSql('');
+  if (nonEmptySqls.length === 0) return emptySQL();
   if (nonEmptySqls.length === 1) return nonEmptySqls[0]!;
 
   const strings: string[] = [''];
@@ -62,7 +42,7 @@ export const mergeSQL = (sqls: SQL[], separator: string = ' '): SQL => {
   nonEmptySqls.forEach((sql, index) => {
     if (index > 0) {
       strings.push('');
-      values.push(rawSql(separator));
+      values.push(SQL([separator] as unknown as TemplateStringsArray));
     }
     strings.push('');
     values.push(sql);
@@ -72,8 +52,8 @@ export const mergeSQL = (sqls: SQL[], separator: string = ' '): SQL => {
   return SQL(strings as unknown as TemplateStringsArray, ...values);
 };
 
-export const concatSQL = (...sqls: SQL[]): SQL => {
-  if (sqls.length === 0) return SQL.empty;
+const concatSQL = (...sqls: SQL[]): SQL => {
+  if (sqls.length === 0) return SQL.EMPTY;
   if (sqls.length === 1) return sqls[0]!;
 
   const strings: string[] = [''];
@@ -89,100 +69,62 @@ export const concatSQL = (...sqls: SQL[]): SQL => {
 };
 
 const isEmpty = (sql: SQL): boolean => {
-  if (typeof sql === 'string') return sql.trim() === '';
-
-  if (isDeferredSQL(sql)) {
-    const deferred = sql as DeferredSQL;
-    const hasContent =
-      deferred.strings.some((s) => s.trim() !== '') ||
-      deferred.values.length > 0;
-    return !hasContent;
-  }
-
-  if (isRawSQL(sql)) {
-    const raw = sql as RawSQL;
-    return raw.sql.trim() === '';
+  if (isParametrizedSQL(sql)) {
+    const parametrized = sql as unknown as ParametrizedSQL;
+    return parametrized.sql.trim() === '' && parametrized.params.length === 0;
   }
 
   return false;
 };
 
-SQL.empty = rawSql('');
-SQL.concat = concatSQL;
-SQL.merge = mergeSQL;
-SQL.isEmpty = isEmpty;
-SQL.format = formatSQL;
-
-export function identifier(value: string): SQLIdentifier {
+function identifier(value: string): SQLIdentifier {
   return { [ID]: true, value };
 }
 
-export function raw(value: string): SQLRaw {
+function plain(value: string): SQLPlain {
   return { [RAW]: true, value };
 }
 
-//TODO: remove it
-export const plainString = raw;
-
-export function literal(value: unknown): SQLLiteral {
+function literal(value: unknown): SQLLiteral {
   return { [LITERAL]: true, value };
 }
 
 // Type guards
-export const isIdentifier = (value: unknown): value is SQLIdentifier => {
+const isIdentifier = (value: unknown): value is SQLIdentifier => {
   return value !== null && typeof value === 'object' && ID in value;
 };
 
-export const isRaw = (value: unknown): value is SQLRaw => {
+const isPlain = (value: unknown): value is SQLPlain => {
   return value !== null && typeof value === 'object' && RAW in value;
 };
 
-export const isLiteral = (value: unknown): value is SQLLiteral => {
+const isLiteral = (value: unknown): value is SQLLiteral => {
   return value !== null && typeof value === 'object' && LITERAL in value;
 };
 
-export const isDeferredSQL = (value: unknown): value is DeferredSQL => {
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    '__brand' in value &&
-    value.__brand === 'deferred-sql'
-  );
-};
+const SQLIN = Symbol.for('SQL_IN');
+type SQLIn = { [SQLIN]: true; column: string; values: unknown[] };
 
-export const isRawSQL = (value: unknown): value is RawSQL => {
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    '__brand' in value &&
-    value.__brand === 'sql'
-  );
-};
-
-export const isReserved = (
-  value: string,
-  reservedWords: Record<string, boolean>,
-): boolean => !!reservedWords[value.toUpperCase()];
-
-// Helper to format arrays as lists
-export function arrayToList(
-  useSpace: boolean,
-  array: unknown[],
-  formatter: (value: unknown) => string,
-): string {
-  let sql = '';
-  sql += useSpace ? ' (' : '(';
-  for (let i = 0; i < array.length; i++) {
-    sql += (i === 0 ? '' : ', ') + formatter(array[i]);
-  }
-  sql += ')';
-  return sql;
+function sqlIn(column: string, values: unknown[]): SQLIn {
+  return { [SQLIN]: true, column, values };
 }
 
-export const isSQL = (value: unknown): value is SQL => {
-  if (value === undefined || value === null) {
-    return false;
-  }
-
-  return isDeferredSQL(value) || isRawSQL(value);
+const isSQLIn = (value: unknown): value is SQLIn => {
+  return value !== null && typeof value === 'object' && SQLIN in value;
 };
+
+SQL.EMPTY = emptySQL();
+SQL.concat = concatSQL;
+SQL.merge = mergeSQL;
+SQL.isEmpty = isEmpty;
+SQL.format = formatSQL;
+SQL.in = sqlIn;
+SQL.isSQL = isSQL;
+SQL.identifier = identifier;
+SQL.isIdentifier = isIdentifier;
+SQL.plain = plain;
+SQL.isPlain = isPlain;
+SQL.literal = literal;
+SQL.isLiteral = isLiteral;
+SQL.in = sqlIn;
+SQL.isIn = isSQLIn;

--- a/src/packages/dumbo/src/core/sql/sqlFormatter.ts
+++ b/src/packages/dumbo/src/core/sql/sqlFormatter.ts
@@ -1,13 +1,10 @@
-import {
-  isDeferredSQL,
-  isIdentifier,
-  isLiteral,
-  isRaw,
-  isRawSQL,
-  isSQL,
-  SQL,
-  type DeferredSQL,
-} from './sql';
+import { type ParametrizedSQL, isParametrizedSQL } from './parametrizedSQL';
+import { SQL, isSQL } from './sql';
+
+export interface ParametrizedQuery {
+  query: string;
+  params: unknown[];
+}
 
 export interface SQLFormatter {
   formatIdentifier: (value: unknown) => string;
@@ -20,7 +17,15 @@ export interface SQLFormatter {
   formatDate?: (value: Date) => string;
   formatObject?: (value: object) => string;
   formatBigInt?: (value: bigint) => string;
-  format: (sql: SQL | SQL[]) => string;
+  formatSQLIn?: (
+    column: string,
+    values: unknown[],
+    placeholderGenerator: (index: number) => string,
+    startIndex: number,
+  ) => { sql: string; params: unknown[] };
+  mapSQLValue: (value: unknown) => unknown;
+  format: (sql: SQL | SQL[]) => ParametrizedQuery;
+  formatRaw: (sql: SQL | SQL[]) => string;
 }
 const formatters: Record<string, SQLFormatter> = {};
 
@@ -44,18 +49,18 @@ export const formatSQL = (sql: SQL | SQL[], formatter: SQLFormatter): string =>
     ? sql.map((s) => processSQL(s, formatter)).join('\n')
     : processSQL(sql, formatter);
 
-function formatValue(value: unknown, formatter: SQLFormatter): string {
+function formatSQLValue(value: unknown, formatter: SQLFormatter): string {
   // Handle SQL wrapper types first
-  if (isIdentifier(value)) {
+  if (SQL.isIdentifier(value)) {
     return formatter.formatIdentifier(value.value);
-  } else if (isRaw(value)) {
+  } else if (SQL.isPlain(value)) {
     return value.value;
-  } else if (isLiteral(value)) {
+  } else if (SQL.isLiteral(value)) {
     return formatter.formatLiteral(value.value);
-  } else if (isSQL(value)) {
-    return isRawSQL(value)
-      ? value.sql
-      : processSQL(value as unknown as SQL, formatter);
+  } else if (SQL.isIn(value)) {
+    return formatSQLIn(value, formatter);
+  } else if (SQL.isSQL(value)) {
+    return processSQL(value as unknown as SQL, formatter);
   }
 
   // Handle specific types directly
@@ -65,7 +70,7 @@ function formatValue(value: unknown, formatter: SQLFormatter): string {
     return value.toString();
   } else if (Array.isArray(value)) {
     return formatter.formatArray
-      ? formatter.formatArray(value, (item) => formatValue(item, formatter))
+      ? formatter.formatArray(value, (item) => formatSQLValue(item, formatter))
       : formatter.formatLiteral(value);
   } else if (typeof value === 'bigint') {
     // Format BigInt as a quoted string to match test expectations
@@ -89,22 +94,184 @@ function formatValue(value: unknown, formatter: SQLFormatter): string {
   return formatter.formatLiteral(value);
 }
 
-function processSQL(sql: SQL, formatter: SQLFormatter): string {
-  if (isRawSQL(sql)) return sql.sql;
+function formatSQLIn(
+  sqlIn: { column: string; values: unknown[] },
+  formatter: SQLFormatter,
+): string {
+  const { column, values } = sqlIn;
 
-  if (!isDeferredSQL(sql)) return sql;
+  if (values.length === 0) {
+    return 'TRUE';
+  }
 
-  const { strings, values } = sql as DeferredSQL;
+  const formattedColumn = formatter.formatIdentifier(column);
+  const formattedValues = values
+    .map((v) => formatSQLValue(v, formatter))
+    .join(', ');
+  return `${formattedColumn} IN (${formattedValues})`;
+}
 
-  // Process the template
-  let result = '';
-  strings.forEach((string, i) => {
-    result += string;
+function formatSQLInParametrized(
+  sqlIn: { column: string; values: unknown[] },
+  formatter: SQLFormatter,
+  placeholderGenerator: (index: number) => string,
+  startIndex: number,
+): { sql: string; params: unknown[] } {
+  const { column, values } = sqlIn;
 
-    if (i < values.length) {
-      result += formatValue(values[i], formatter);
+  if (values.length === 0) {
+    return { sql: 'FALSE', params: [] };
+  }
+
+  if (formatter.formatSQLIn) {
+    return formatter.formatSQLIn(
+      column,
+      values,
+      placeholderGenerator,
+      startIndex,
+    );
+  }
+
+  // Fallback: standard IN clause with parameterized values
+  const formattedColumn = formatter.formatIdentifier(column);
+  const placeholders = values.map((_, index) =>
+    placeholderGenerator(startIndex + index),
+  );
+  const sql = `${formattedColumn} IN (${placeholders.join(', ')})`;
+
+  return { sql, params: values };
+}
+
+export function formatParametrizedQuery(
+  sql: SQL | SQL[],
+  placeholderGenerator: (index: number) => string,
+  formatter: SQLFormatter,
+): ParametrizedQuery {
+  // Handle array by merging with newline separator
+  const merged = Array.isArray(sql) ? SQL.merge(sql, '\n') : sql;
+
+  if (!isParametrizedSQL(merged)) {
+    throw new Error('Expected ParametrizedSQL, got string-based SQL');
+  }
+
+  const parametrized = merged as unknown as ParametrizedSQL;
+  let query = parametrized.sql;
+  const finalParams: unknown[] = [];
+  let paramIndex = 0;
+
+  // Process each parameter
+  parametrized.params.forEach((param, index) => {
+    const placeholder = `__P${index + 1}__`;
+
+    if (SQL.isIdentifier(param)) {
+      // Identifiers must be inlined in the SQL, not bound as parameters
+      const inlinedIdentifier = formatter.formatIdentifier(param.value);
+      query = query.replace(new RegExp(placeholder, 'g'), inlinedIdentifier);
+    } else if (SQL.isIn(param)) {
+      // SQL.in helper - handle empty arrays gracefully
+      const sqlInResult = formatSQLInParametrized(
+        param,
+        formatter,
+        placeholderGenerator,
+        paramIndex,
+      );
+      query = query.replace(new RegExp(placeholder, 'g'), sqlInResult.sql);
+      finalParams.push(...sqlInResult.params);
+      paramIndex += sqlInResult.params.length;
+    } else if (Array.isArray(param)) {
+      // Arrays - expand to individual parameters for universal compatibility
+      if (param.length === 0) {
+        // Empty arrays should use SQL.in helper for proper handling
+        throw new Error(
+          'Empty arrays in IN clauses are not supported. Use SQL.in(column, array) helper instead.',
+        );
+      } else {
+        // Non-empty array - expand to individual parameters
+        const expandedPlaceholders = param.map(() =>
+          placeholderGenerator(paramIndex++),
+        );
+        const expandedPlaceholderString = `(${expandedPlaceholders.join(', ')})`;
+        query = query.replace(
+          new RegExp(placeholder, 'g'),
+          expandedPlaceholderString,
+        );
+        finalParams.push(...(param as unknown[]));
+      }
+    } else {
+      // Regular parameters get database-specific placeholders and are added to params
+      const dbPlaceholder = placeholderGenerator(paramIndex);
+      query = query.replace(new RegExp(placeholder, 'g'), dbPlaceholder);
+      finalParams.push(param);
+      paramIndex++;
     }
   });
 
-  return result;
+  return { query, params: finalParams };
+}
+
+export function mapSQLValue(value: unknown, formatter: SQLFormatter): unknown {
+  // Handle SQL wrapper types first - these need special processing for parameters
+  if (SQL.isIdentifier(value)) {
+    // For parameter binding, identifiers should be processed by the formatter
+    return formatter.formatIdentifier(value.value);
+  } else if (SQL.isPlain(value)) {
+    // Raw values should be processed by the formatter
+    return value.value;
+  } else if (SQL.isLiteral(value)) {
+    // Literals should be processed by the formatter
+    return formatter.formatLiteral(value.value);
+  } else if (isSQL(value)) {
+    // Nested SQL should be processed
+    return formatSQL(value, formatter);
+  }
+
+  // For primitive types, return as-is for parameter binding
+  if (value === null || value === undefined) {
+    return null;
+  } else if (typeof value === 'number') {
+    return value;
+  } else if (typeof value === 'string') {
+    return value;
+  }
+
+  // For complex types, let formatter handle them
+  if (Array.isArray(value)) {
+    return formatter.formatArray
+      ? formatter.formatArray(value, (item) => String(item))
+      : formatter.formatLiteral(value);
+  } else if (typeof value === 'bigint') {
+    return formatter.formatBigInt
+      ? formatter.formatBigInt(value)
+      : formatter.formatLiteral(value);
+  } else if (value instanceof Date) {
+    return formatter.formatDate
+      ? formatter.formatDate(value)
+      : formatter.formatLiteral(value);
+  } else if (typeof value === 'object') {
+    return formatter.formatObject
+      ? formatter.formatObject(value)
+      : formatter.formatLiteral(value);
+  }
+
+  // Fallback to literal formatting
+  return formatter.formatLiteral(value);
+}
+
+function processSQL(sql: SQL, formatter: SQLFormatter): string {
+  if (isParametrizedSQL(sql)) {
+    const parametrized = sql as unknown as ParametrizedSQL;
+    let result = parametrized.sql;
+
+    // Replace __P1__, __P2__, etc. with formatted parameter values
+    parametrized.params.forEach((param, index) => {
+      const placeholder = `__P${index + 1}__`;
+      const formattedValue = formatSQLValue(param, formatter);
+      result = result.replace(new RegExp(placeholder, 'g'), formattedValue);
+    });
+
+    return result;
+  }
+
+  // Fallback for string-based SQL
+  return sql;
 }

--- a/src/packages/dumbo/src/storage/postgresql/core/locks/advisoryLocks.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/locks/advisoryLocks.ts
@@ -1,6 +1,5 @@
 import {
   defaultDatabaseLockOptions,
-  plainString,
   single,
   SQL,
   type AcquireDatabaseLockMode,
@@ -23,7 +22,7 @@ export const tryAcquireAdvisoryLock = async (
   try {
     await single(
       execute.query<{ locked: boolean }>(
-        SQL`SELECT ${plainString(advisoryLock)}(${options.lockId}) AS locked`,
+        SQL`SELECT ${SQL.plain(advisoryLock)}(${options.lockId}) AS locked`,
         { timeoutMs },
       ),
     );

--- a/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/index.ts
@@ -3,6 +3,8 @@ import {
   JSONSerializer,
   formatSQL,
   registerFormatter,
+  mapSQLValue,
+  formatParametrizedQuery,
 } from '../../../../../core';
 import format from './pgFormat';
 
@@ -53,7 +55,33 @@ const pgFormatter: SQLFormatter = {
   formatObject: (value: object): string => {
     return `'${JSONSerializer.serialize(value).replace(/'/g, "''")}'`;
   },
-  format: (sql) => formatSQL(sql, pgFormatter),
+
+  formatSQLIn: (
+    column: string,
+    values: unknown[],
+    placeholderGenerator: (index: number) => string,
+    startIndex: number,
+  ): { sql: string; params: unknown[] } => {
+    // For PostgreSQL, use ANY with array for better performance
+    const formattedColumn = format.ident(column);
+    const placeholder = placeholderGenerator(startIndex);
+    const sql = `${formattedColumn} = ANY(${placeholder})`;
+    return { sql, params: [values] };
+  },
+
+  mapSQLValue: (value: unknown): unknown => {
+    // PostgreSQL doesn't need special type conversions, use base function
+    return mapSQLValue(value, pgFormatter);
+  },
+  format: (sql) => {
+    // Use base function with PostgreSQL-specific placeholder generator
+    return formatParametrizedQuery(
+      sql,
+      (index) => `$${index + 1}`,
+      pgFormatter,
+    );
+  },
+  formatRaw: (sql) => formatSQL(sql, pgFormatter),
 };
 
 registerFormatter('PostgreSQL', pgFormatter);

--- a/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/parametrizedFormatter.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/parametrizedFormatter.unit.spec.ts
@@ -1,0 +1,206 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { SQL } from '../../../../../core/sql/sql';
+// Tests for PostgreSQL parametrized formatter
+import { pgFormatter } from './index';
+
+void describe('PostgreSQL Parametrized Formatter', () => {
+  void describe('format method', () => {
+    void it('should convert basic parametrized SQL to PostgreSQL format', () => {
+      const sql = SQL`SELECT * FROM users WHERE id = ${123}`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users WHERE id = $1',
+        params: [123],
+      });
+    });
+
+    void it('should handle identifiers by inlining them', () => {
+      const sql = SQL`CREATE TABLE ${SQL.identifier('users')} (id INTEGER, name TEXT)`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'CREATE TABLE users (id INTEGER, name TEXT)',
+        params: [],
+      });
+    });
+
+    void it('should handle quoted identifiers correctly', () => {
+      const sql = SQL`CREATE TABLE ${SQL.identifier('User Table')} (id INTEGER)`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'CREATE TABLE "User Table" (id INTEGER)',
+        params: [],
+      });
+    });
+
+    void it('should mix identifiers and parameters correctly', () => {
+      const sql = SQL`SELECT ${SQL.identifier('name')} FROM ${SQL.identifier('users')} WHERE id = ${123}`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT name FROM users WHERE id = $1',
+        params: [123],
+      });
+    });
+
+    void it('should handle arrays by expanding to individual parameters', () => {
+      const ids = ['id1', 'id2', 'id3'];
+      const sql = SQL`SELECT * FROM users WHERE _id IN ${ids}`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: `SELECT * FROM users WHERE _id IN ($1, $2, $3)`,
+        params: ['id1', 'id2', 'id3'],
+      });
+    });
+
+    void it('should throw error for empty arrays in IN clauses', () => {
+      const ids: string[] = [];
+      const sql = SQL`SELECT * FROM users WHERE _id IN ${ids}`;
+
+      assert.throws(
+        () => pgFormatter.format(sql),
+        /Empty arrays in IN clauses are not supported/,
+      );
+    });
+
+    void it('should handle multiple parameters', () => {
+      const sql = SQL`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users WHERE id = $1 AND name = $2',
+        params: [123, 'John'],
+      });
+    });
+
+    void it('should handle nested SQL', () => {
+      const innerSql = SQL`status = ${'active'}`;
+      const outerSql = SQL`SELECT * FROM users WHERE ${innerSql} AND id = ${456}`;
+      const result = pgFormatter.format(outerSql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users WHERE status = $1 AND id = $2',
+        params: ['active', 456],
+      });
+    });
+
+    void it('should handle array of SQL', () => {
+      const sql1 = SQL`INSERT INTO users (name) VALUES (${'Alice'})`;
+      const sql2 = SQL`INSERT INTO users (name) VALUES (${'Bob'})`;
+      const result = pgFormatter.format([sql1, sql2]);
+
+      assert.deepStrictEqual(result, {
+        query:
+          'INSERT INTO users (name) VALUES ($1)\nINSERT INTO users (name) VALUES ($2)',
+        params: ['Alice', 'Bob'],
+      });
+    });
+
+    void it('should handle special value types', () => {
+      const date = new Date('2023-01-01T00:00:00.000Z');
+      const bigint = BigInt(123456789012345);
+      const obj = { key: 'value' };
+
+      const sql = SQL`INSERT INTO test (date, bigint, json) VALUES (${date}, ${bigint}, ${obj})`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'INSERT INTO test (date, bigint, json) VALUES ($1, $2, $3)',
+        params: [date, bigint, obj],
+      });
+    });
+
+    void it('should handle empty parameters', () => {
+      const sql = SQL`SELECT * FROM users`;
+      const result = pgFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users',
+        params: [],
+      });
+    });
+
+    void it('should throw error for non-parametrized SQL', () => {
+      assert.throws(() => {
+        pgFormatter.format('SELECT * FROM users' as SQL);
+      }, /Expected ParametrizedSQL, got string-based SQL/);
+    });
+  });
+
+  void describe('formatRaw method', () => {
+    void it('should return inline formatted SQL string', () => {
+      const sql = SQL`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`;
+      const result = pgFormatter.formatRaw(sql);
+
+      assert.strictEqual(typeof result, 'string');
+      assert.ok(result.includes('123'));
+      assert.ok(result.includes('John'));
+    });
+
+    void it('should handle array of SQL', () => {
+      const sql1 = SQL`SELECT ${123}`;
+      const sql2 = SQL`SELECT ${'test'}`;
+      const result = pgFormatter.formatRaw([sql1, sql2]);
+
+      assert.strictEqual(typeof result, 'string');
+      assert.ok(result.includes('123'));
+      assert.ok(result.includes('test'));
+      assert.ok(result.includes('\n'));
+    });
+  });
+
+  void describe('mapSQLValue method', () => {
+    void it('should handle basic types', () => {
+      assert.strictEqual(pgFormatter.mapSQLValue(123), 123);
+      assert.strictEqual(pgFormatter.mapSQLValue('test'), 'test');
+      assert.strictEqual(pgFormatter.mapSQLValue(null), null);
+      assert.strictEqual(pgFormatter.mapSQLValue(undefined), null);
+    });
+
+    void it('should handle SQL wrapper types', () => {
+      // Valid unquoted identifier (lowercase, no special chars)
+      const validIdentResult = pgFormatter.mapSQLValue(
+        SQL.identifier('table_name'),
+      );
+      assert.strictEqual(validIdentResult, 'table_name');
+
+      // Invalid identifier that needs quoting (mixed case)
+      const quotedIdentResult = pgFormatter.mapSQLValue(
+        SQL.identifier('TableName'),
+      );
+      assert.strictEqual(quotedIdentResult, '"TableName"');
+
+      const literalResult = pgFormatter.mapSQLValue(SQL.literal('value'));
+      assert.strictEqual(literalResult, "'value'");
+
+      const rawResult = pgFormatter.mapSQLValue(SQL.plain('CURRENT_TIMESTAMP'));
+      assert.strictEqual(rawResult, 'CURRENT_TIMESTAMP');
+    });
+
+    void it('should handle nested SQL', () => {
+      const nestedSql = SQL`SELECT ${123}`;
+      const result = pgFormatter.mapSQLValue(nestedSql);
+      assert.strictEqual(typeof result, 'string');
+      assert.ok((result as string).includes('123'));
+    });
+
+    void it('should handle complex types', () => {
+      const date = new Date('2023-01-01T00:00:00.000Z');
+      const dateResult = pgFormatter.mapSQLValue(date);
+      assert.strictEqual(dateResult, "'2023-01-01 00:00:00.000+00'");
+
+      const bigint = BigInt(123456789012345);
+      const bigintResult = pgFormatter.mapSQLValue(bigint);
+      assert.ok(typeof bigintResult === 'string');
+
+      const obj = { key: 'value' };
+      const objResult = pgFormatter.mapSQLValue(obj);
+      assert.ok(typeof objResult === 'string');
+      assert.ok(objResult.includes('{"key":"value"}'));
+    });
+  });
+});

--- a/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/sqlFormatter.int.spec.ts
@@ -1,0 +1,109 @@
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import assert from 'assert';
+import { after, before, describe, it } from 'node:test';
+import { PostgreSQLConnectionString } from '../..';
+import { type Dumbo } from '../../../../..';
+import { count, SQL } from '../../../../../core';
+import { dumbo } from '../../../../../pg';
+
+void describe('PostgreSQL SQL Formatter Integration Tests', () => {
+  let pool: Dumbo;
+  let postgres: StartedPostgreSqlContainer;
+  let connectionString: PostgreSQLConnectionString;
+
+  before(async () => {
+    postgres = await new PostgreSqlContainer().start();
+    connectionString = PostgreSQLConnectionString(postgres.getConnectionUri());
+    pool = dumbo({ connectionString });
+
+    await pool.execute.batchCommand([
+      SQL`CREATE TABLE test_users (id SERIAL PRIMARY KEY, name TEXT)`,
+      SQL`INSERT INTO test_users (name) VALUES ('Alice'), ('Bob')`,
+    ]);
+  });
+
+  after(async () => {
+    await pool.close();
+    await postgres.stop();
+  });
+
+  void describe('Direct Array Handling', () => {
+    void it('should throw error for empty arrays in IN clauses', async () => {
+      const emptyIds: number[] = [];
+
+      try {
+        await pool.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE id IN ${emptyIds}`,
+        );
+        assert.fail('Should have thrown error for empty array');
+      } catch (error) {
+        assert.ok(error instanceof Error);
+        assert.ok(
+          error.message.includes(
+            'Empty arrays in IN clauses are not supported',
+          ),
+        );
+      }
+    });
+
+    void it('should handle non-empty arrays correctly', async () => {
+      const ids = [1];
+      const result = await count(
+        pool.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE id IN ${ids}`,
+        ),
+      );
+
+      assert.strictEqual(result, 1);
+    });
+  });
+
+  void describe('SQL.in Helper', () => {
+    void it('should handle empty arrays by returning FALSE, so no records', async () => {
+      const emptyIds: number[] = [];
+      const result = await count(
+        pool.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('id', emptyIds)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 0);
+    });
+
+    void it('should handle non-empty arrays with PostgreSQL ANY optimization', async () => {
+      const ids = [1];
+      const result = await count(
+        pool.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('id', ids)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 1);
+    });
+
+    void it('should handle string arrays correctly', async () => {
+      const names = ['Alice'];
+      const result = await count(
+        pool.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('name', names)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 1);
+    });
+
+    void it('should handle empty string arrays', async () => {
+      const emptyNames: string[] = [];
+      const result = await count(
+        pool.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('name', emptyNames)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 0);
+    });
+  });
+});

--- a/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/sqlFormatter.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/sqlFormatter.unit.spec.ts
@@ -1,14 +1,7 @@
 import assert from 'assert';
 import { describe, it } from 'node:test';
 import { pgFormatter } from '.';
-import {
-  SQL,
-  formatSQL,
-  identifier,
-  isSQL,
-  literal,
-  plainString,
-} from '../../../../../core';
+import { SQL, formatSQL, isSQL } from '../../../../../core';
 
 export function processSQLForTesting(sql: SQL): string {
   const formatter = pgFormatter;
@@ -18,7 +11,7 @@ export function processSQLForTesting(sql: SQL): string {
 void describe('SQL Tagged Template Literal', () => {
   void it('should format literals correctly', () => {
     const name: string = 'John Doe';
-    const query = SQL`SELECT * FROM users WHERE name = ${literal(name)};`;
+    const query = SQL`SELECT * FROM users WHERE name = ${SQL.literal(name)};`;
 
     // Expected output directly without using pg-format
     assert.strictEqual(
@@ -30,7 +23,7 @@ void describe('SQL Tagged Template Literal', () => {
   void it('should format identifiers correctly', () => {
     const tableName: string = 'users';
     const columnName: string = 'name';
-    const query = SQL`SELECT ${identifier(columnName)} FROM ${identifier(tableName)};`;
+    const query = SQL`SELECT ${SQL.identifier(columnName)} FROM ${SQL.identifier(tableName)};`;
 
     // Expected output directly without using pg-format
     assert.strictEqual(processSQLForTesting(query), 'SELECT name FROM users;');
@@ -39,7 +32,7 @@ void describe('SQL Tagged Template Literal', () => {
   void it('should format identifiers with CAPS correctly', () => {
     const tableName: string = 'Users';
     const columnName: string = 'Name';
-    const query = SQL`SELECT ${identifier(columnName)} FROM ${identifier(tableName)};`;
+    const query = SQL`SELECT ${SQL.identifier(columnName)} FROM ${SQL.identifier(tableName)};`;
 
     // Expected output directly without using pg-format
     assert.strictEqual(
@@ -50,7 +43,7 @@ void describe('SQL Tagged Template Literal', () => {
 
   void it('should NOT format plain strings without escaping', () => {
     const unsafeString: string = "some'unsafe";
-    const query = SQL`SELECT ${plainString(unsafeString)};`;
+    const query = SQL`SELECT ${SQL.plain(unsafeString)};`;
 
     // Plain string without escaping
     assert.strictEqual(processSQLForTesting(query), "SELECT some'unsafe;");
@@ -73,8 +66,8 @@ void describe('SQL Tagged Template Literal', () => {
     const age: number = 30;
     const table: string = 'users';
     const query = SQL`
-      INSERT INTO ${identifier(table)} (name, age)
-      VALUES (${literal(name)}, ${age})
+      INSERT INTO ${SQL.identifier(table)} (name, age)
+      VALUES (${SQL.literal(name)}, ${age})
       RETURNING name, age;
     `;
 
@@ -107,7 +100,7 @@ void describe('SQL Tagged Template Literal', () => {
 
   void it('should escape special characters in literals', () => {
     const unsafeValue: string = "O'Reilly";
-    const query = SQL`SELECT * FROM users WHERE name = ${literal(unsafeValue)};`;
+    const query = SQL`SELECT * FROM users WHERE name = ${SQL.literal(unsafeValue)};`;
 
     // SQL-safe escaping of single quote characters
     assert.strictEqual(
@@ -122,7 +115,7 @@ void describe('SQL Tagged Template Literal', () => {
     const zeroValue: number = 0;
 
     const query = SQL`INSERT INTO test (col1, col2, col3)
-      VALUES (${literal(emptyString)}, ${literal(nullValue)}, ${literal(zeroValue)});`;
+      VALUES (${SQL.literal(emptyString)}, ${SQL.literal(nullValue)}, ${SQL.literal(zeroValue)});`;
 
     // Handle empty string, null, and zero correctly
     assert.strictEqual(
@@ -135,7 +128,7 @@ void describe('SQL Tagged Template Literal', () => {
   void it('should handle arrays of values using literals', () => {
     const values: string[] = ['John', 'Doe', '30'];
     const query = SQL`INSERT INTO users (first_name, last_name, age)
-      VALUES (${literal(values[0])}, ${literal(values[1])}, ${literal(values[2])});`;
+      VALUES (${SQL.literal(values[0])}, ${SQL.literal(values[1])}, ${SQL.literal(values[2])});`;
 
     // Handle array elements using literal formatting
     assert.strictEqual(
@@ -147,7 +140,7 @@ void describe('SQL Tagged Template Literal', () => {
 
   void it('should handle SQL injections attempts safely', () => {
     const unsafeInput: string = "'; DROP TABLE users; --";
-    const query = SQL`SELECT * FROM users WHERE name = ${literal(unsafeInput)};`;
+    const query = SQL`SELECT * FROM users WHERE name = ${SQL.literal(unsafeInput)};`;
 
     // Escape SQL injection attempts correctly
     assert.strictEqual(

--- a/src/packages/dumbo/src/storage/postgresql/pg/execute/execute.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/execute/execute.ts
@@ -89,9 +89,13 @@ async function batch<Result extends QueryResultRow = QueryResultRow>(
 
   //TODO: make it smarter at some point
   for (let i = 0; i < sqls.length; i++) {
-    tracer.info('db:sql:query', { sql: sqls[i]! });
-    //console.log(pgFormatter.format(sqls[i]!));
-    const result = await client.query<Result>(pgFormatter.format(sqls[i]!));
+    const { query, params } = pgFormatter.format(sqls[i]!);
+    tracer.info('db:sql:query', {
+      query,
+      params,
+      debugSQL: pgFormatter.formatRaw(sqls[i]!),
+    });
+    const result = await client.query<Result>(query, params);
     results[i] = { rowCount: result.rowCount, rows: result.rows };
   }
   return Array.isArray(sqlOrSqls) ? results : results[0]!;

--- a/src/packages/dumbo/src/storage/sqlite/core/execute/execute.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/execute/execute.ts
@@ -6,7 +6,7 @@ import {
   type QueryResult,
   type QueryResultRow,
 } from '../../../../core';
-import type { SQLiteClient } from '../connections';
+import type { SQLiteClient, Parameters } from '../connections';
 import { sqliteFormatter } from '../sql/formatter';
 
 export const sqliteExecute = async <Result = void>(
@@ -68,9 +68,14 @@ async function batch<Result extends QueryResultRow = QueryResultRow>(
 
   //TODO: make it smarter at some point
   for (let i = 0; i < sqls.length; i++) {
-    tracer.info('db:sql:query', { sql: sqls[i]! });
+    const { query, params } = sqliteFormatter.format(sqls[i]!);
+    tracer.info('db:sql:query', {
+      query,
+      params,
+      debugSQL: sqliteFormatter.formatRaw(sqls[i]!),
+    });
 
-    const result = await client.query<Result>(sqliteFormatter.format(sqls[i]!));
+    const result = await client.query<Result>(query, params as Parameters[]);
 
     results[i] = { rowCount: result.length, rows: result };
   }

--- a/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/parametrizedFormatter.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/parametrizedFormatter.unit.spec.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { SQL } from '../../../../../core/sql/sql';
+// Tests for SQLite parametrized formatter
+import { sqliteFormatter } from './index';
+
+void describe('SQLite Parametrized Formatter', () => {
+  void describe('format method', () => {
+    void it('should convert basic parametrized SQL to SQLite format', () => {
+      const sql = SQL`SELECT * FROM users WHERE id = ${123}`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users WHERE id = ?',
+        params: [123],
+      });
+    });
+
+    void it('should handle identifiers by inlining them', () => {
+      const sql = SQL`CREATE TABLE ${SQL.identifier('users')} (id INTEGER, name TEXT)`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'CREATE TABLE users (id INTEGER, name TEXT)',
+        params: [],
+      });
+    });
+
+    void it('should handle quoted identifiers correctly', () => {
+      const sql = SQL`CREATE TABLE ${SQL.identifier('User Table')} (id INTEGER)`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'CREATE TABLE "User Table" (id INTEGER)',
+        params: [],
+      });
+    });
+
+    void it('should mix identifiers and parameters correctly', () => {
+      const sql = SQL`SELECT ${SQL.identifier('name')} FROM ${SQL.identifier('users')} WHERE id = ${123}`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT name FROM users WHERE id = ?',
+        params: [123],
+      });
+    });
+
+    void it('should handle arrays by expanding to individual parameters', () => {
+      const ids = ['id1', 'id2', 'id3'];
+      const sql = SQL`SELECT * FROM users WHERE _id IN ${ids}`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: `SELECT * FROM users WHERE _id IN (?, ?, ?)`,
+        params: ['id1', 'id2', 'id3'],
+      });
+    });
+
+    void it('should throw error for empty arrays in IN clauses', () => {
+      const ids: string[] = [];
+      const sql = SQL`SELECT * FROM users WHERE _id IN ${ids}`;
+
+      assert.throws(
+        () => sqliteFormatter.format(sql),
+        /Empty arrays in IN clauses are not supported/,
+      );
+    });
+
+    void it('should handle multiple parameters', () => {
+      const sql = SQL`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users WHERE id = ? AND name = ?',
+        params: [123, 'John'],
+      });
+    });
+
+    void it('should handle nested SQL', () => {
+      const innerSql = SQL`status = ${'active'}`;
+      const outerSql = SQL`SELECT * FROM users WHERE ${innerSql} AND id = ${456}`;
+      const result = sqliteFormatter.format(outerSql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users WHERE status = ? AND id = ?',
+        params: ['active', 456],
+      });
+    });
+
+    void it('should handle array of SQL', () => {
+      const sql1 = SQL`INSERT INTO users (name) VALUES (${'Alice'})`;
+      const sql2 = SQL`INSERT INTO users (name) VALUES (${'Bob'})`;
+      const result = sqliteFormatter.format([sql1, sql2]);
+
+      assert.deepStrictEqual(result, {
+        query:
+          'INSERT INTO users (name) VALUES (?)\nINSERT INTO users (name) VALUES (?)',
+        params: ['Alice', 'Bob'],
+      });
+    });
+
+    void it('should handle special value types', () => {
+      const date = new Date('2023-01-01T00:00:00.000Z');
+      const bigint = BigInt(123456789012345);
+      const obj = { key: 'value' };
+
+      const sql = SQL`INSERT INTO test (date, bigint, json) VALUES (${date}, ${bigint}, ${obj})`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'INSERT INTO test (date, bigint, json) VALUES (?, ?, ?)',
+        params: [
+          '2023-01-01T00:00:00.000Z', // SQLite date as ISO string
+          '123456789012345', // SQLite BigInt as string
+          '{"key":"value"}', // SQLite object as JSON
+        ],
+      });
+    });
+
+    void it('should handle boolean values', () => {
+      const sql = SQL`INSERT INTO test (active, inactive) VALUES (${true}, ${false})`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'INSERT INTO test (active, inactive) VALUES (?, ?)',
+        params: [1, 0], // SQLite booleans as 1/0
+      });
+    });
+
+    void it('should handle empty parameters', () => {
+      const sql = SQL`SELECT * FROM users`;
+      const result = sqliteFormatter.format(sql);
+
+      assert.deepStrictEqual(result, {
+        query: 'SELECT * FROM users',
+        params: [],
+      });
+    });
+
+    void it('should throw error for non-parametrized SQL', () => {
+      assert.throws(() => {
+        sqliteFormatter.format('SELECT * FROM users' as SQL);
+      }, /Expected ParametrizedSQL, got string-based SQL/);
+    });
+  });
+
+  void describe('formatRaw method', () => {
+    void it('should return inline formatted SQL string', () => {
+      const sql = SQL`SELECT * FROM users WHERE id = ${123} AND name = ${'John'}`;
+      const result = sqliteFormatter.formatRaw(sql);
+
+      assert.strictEqual(typeof result, 'string');
+      assert.ok(result.includes('123'));
+      assert.ok(result.includes('John'));
+    });
+
+    void it('should handle array of SQL', () => {
+      const sql1 = SQL`SELECT ${123}`;
+      const sql2 = SQL`SELECT ${'test'}`;
+      const result = sqliteFormatter.formatRaw([sql1, sql2]);
+
+      assert.strictEqual(typeof result, 'string');
+      assert.ok(result.includes('123'));
+      assert.ok(result.includes('test'));
+      assert.ok(result.includes('\n'));
+    });
+  });
+
+  void describe('mapSQLValue method', () => {
+    void it('should handle basic types', () => {
+      assert.strictEqual(sqliteFormatter.mapSQLValue(123), 123);
+      assert.strictEqual(sqliteFormatter.mapSQLValue('test'), 'test');
+      assert.strictEqual(sqliteFormatter.mapSQLValue(null), null);
+      assert.strictEqual(sqliteFormatter.mapSQLValue(undefined), null);
+    });
+
+    void it('should handle SQLite-specific type conversions', () => {
+      // Boolean conversion
+      assert.strictEqual(sqliteFormatter.mapSQLValue(true), 1);
+      assert.strictEqual(sqliteFormatter.mapSQLValue(false), 0);
+
+      // Date conversion
+      const date = new Date('2023-01-01T00:00:00.000Z');
+      assert.strictEqual(
+        sqliteFormatter.mapSQLValue(date),
+        '2023-01-01T00:00:00.000Z',
+      );
+
+      // BigInt conversion
+      const bigint = BigInt(123456789012345);
+      assert.strictEqual(
+        sqliteFormatter.mapSQLValue(bigint),
+        '123456789012345',
+      );
+    });
+
+    void it('should handle SQL wrapper types', () => {
+      // Valid unquoted identifier (lowercase, no special chars)
+      const validIdentResult = sqliteFormatter.mapSQLValue(
+        SQL.identifier('table_name'),
+      );
+      assert.strictEqual(validIdentResult, 'table_name');
+
+      // Invalid identifier that needs quoting (mixed case)
+      const quotedIdentResult = sqliteFormatter.mapSQLValue(
+        SQL.identifier('TableName'),
+      );
+      assert.strictEqual(quotedIdentResult, '"TableName"');
+
+      const literalResult = sqliteFormatter.mapSQLValue(SQL.literal('value'));
+      assert.strictEqual(literalResult, "'value'");
+
+      const rawResult = sqliteFormatter.mapSQLValue(
+        SQL.plain('CURRENT_TIMESTAMP'),
+      );
+      assert.strictEqual(rawResult, 'CURRENT_TIMESTAMP');
+    });
+
+    void it('should handle nested SQL', () => {
+      const nestedSql = SQL`SELECT ${123}`;
+      const result = sqliteFormatter.mapSQLValue(nestedSql);
+      assert.strictEqual(typeof result, 'string');
+      assert.ok((result as string).includes('123'));
+    });
+
+    void it('should handle complex types', () => {
+      const obj = { key: 'value' };
+      const objResult = sqliteFormatter.mapSQLValue(obj);
+      assert.ok(typeof objResult === 'string');
+      assert.ok(objResult.includes('{"key":"value"}'));
+    });
+  });
+});

--- a/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/sqlFormatter.int.spec.ts
@@ -1,0 +1,113 @@
+import assert from 'assert';
+import { after, before, describe, it } from 'node:test';
+import { type Dumbo } from '../../../../..';
+import { count, SQL } from '../../../../../core';
+import { dumbo } from '../../../../../sqlite3';
+import { InMemorySQLiteDatabase } from '../../connections';
+
+void describe('SQLite SQL Formatter Integration Tests', () => {
+  let db: Dumbo;
+
+  before(() => {
+    // Use in-memory database for testing
+    db = dumbo({
+      connectionString: InMemorySQLiteDatabase,
+      connector: 'SQLite:sqlite3',
+    });
+  });
+
+  after(async () => {
+    await db.close();
+  });
+
+  before(async () => {
+    // Create test table for all tests
+    await db.execute.query(
+      SQL`CREATE TABLE test_users (id INTEGER PRIMARY KEY, name TEXT)`,
+    );
+
+    // Insert test data
+    await db.execute.query(
+      SQL`INSERT INTO test_users (name) VALUES ('Alice'), ('Bob')`,
+    );
+  });
+
+  void describe('Direct Array Handling', () => {
+    void it('should throw error for empty arrays in IN clauses', async () => {
+      const emptyIds: number[] = [];
+
+      try {
+        await db.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE id IN ${emptyIds}`,
+        );
+        assert.fail('Should have thrown error for empty array');
+      } catch (error) {
+        assert.ok(error instanceof Error);
+        assert.ok(
+          error.message.includes(
+            'Empty arrays in IN clauses are not supported',
+          ),
+        );
+      }
+    });
+
+    void it('should handle non-empty arrays correctly', async () => {
+      // Non-empty arrays should still work
+      const names = ['Alice'];
+      const result = await count(
+        db.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE name IN ${names}`,
+        ),
+      );
+
+      assert.strictEqual(result, 1);
+    });
+  });
+
+  void describe('SQL.in Helper', () => {
+    void it('should handle empty arrays by returning FALSE, so no records', async () => {
+      const emptyIds: number[] = [];
+      const result = await count(
+        db.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('id', emptyIds)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 0);
+    });
+
+    void it('should handle non-empty arrays with standard IN clause', async () => {
+      // Non-empty array should use standard IN clause for SQLite
+      const ids = [1];
+      const result = await count(
+        db.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('id', ids)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 1);
+    });
+
+    void it('should handle string arrays correctly', async () => {
+      const names = ['Alice'];
+      const result = await count(
+        db.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('name', names)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 1);
+    });
+
+    void it('should handle empty string arrays', async () => {
+      const emptyNames: string[] = [];
+      const result = await count(
+        db.execute.query(
+          SQL`SELECT COUNT(*) as count FROM test_users WHERE ${SQL.in('name', emptyNames)}`,
+        ),
+      );
+
+      assert.strictEqual(result, 0);
+    });
+  });
+});

--- a/src/packages/pongo/src/storage/postgresql/sqlBuilder/update/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/sqlBuilder/update/index.ts
@@ -1,4 +1,4 @@
-import { JSONSerializer, plainString, SQL } from '@event-driven-io/dumbo';
+import { JSONSerializer, SQL } from '@event-driven-io/dumbo';
 import {
   objectEntries,
   type $inc,
@@ -45,8 +45,8 @@ export const buildIncQuery = <T>(
   for (const [key, value] of Object.entries(inc)) {
     currentUpdateQuery =
       typeof value === 'bigint'
-        ? SQL`jsonb_set(${currentUpdateQuery}, '{${plainString(key)}}', to_jsonb((COALESCE((data->>'${plainString(key)}')::BIGINT, 0) + ${value})::TEXT), true)`
-        : SQL`jsonb_set(${currentUpdateQuery}, '{${plainString(key)}}', to_jsonb(COALESCE((data->>'${plainString(key)}')::NUMERIC, 0) + ${value}), true)`;
+        ? SQL`jsonb_set(${currentUpdateQuery}, '{${SQL.plain(key)}}', to_jsonb((COALESCE((data->>'${SQL.plain(key)}')::BIGINT, 0) + ${value})::TEXT), true)`
+        : SQL`jsonb_set(${currentUpdateQuery}, '{${SQL.plain(key)}}', to_jsonb(COALESCE((data->>'${SQL.plain(key)}')::NUMERIC, 0) + ${value}), true)`;
   }
   return currentUpdateQuery;
 };
@@ -57,7 +57,7 @@ export const buildPushQuery = <T>(
 ): SQL => {
   for (const [key, value] of Object.entries(push)) {
     const serializedValue = JSONSerializer.serialize([value]);
-    currentUpdateQuery = SQL`jsonb_set(${currentUpdateQuery}, '{${plainString(key)}}', (coalesce(data->'${plainString(key)}', '[]'::jsonb) || ${serializedValue}::jsonb), true)`;
+    currentUpdateQuery = SQL`jsonb_set(${currentUpdateQuery}, '{${SQL.plain(key)}}', (coalesce(data->'${SQL.plain(key)}', '[]'::jsonb) || ${serializedValue}::jsonb), true)`;
   }
   return currentUpdateQuery;
 };


### PR DESCRIPTION
Thanks to that, we can get better performance by benefiting from query plan caching. This also enables using prepared statements later on.