### PR TITLE
Simplified schema component migrations to be an array instead of function with connector type

### DIFF
--- a/src/packages/dumbo/src/core/schema/migrations.ts
+++ b/src/packages/dumbo/src/core/schema/migrations.ts
@@ -104,9 +104,7 @@ export const runSQLMigrations = (
       ...rest,
     };
 
-    const coreMigrations = options.schema.migrationTable.migrations({
-      connector: pool.connector,
-    });
+    const coreMigrations = options.schema.migrationTable.migrations;
 
     await databaseLock.withAcquire(
       execute,

--- a/src/packages/dumbo/src/storage/postgresql/core/schema/migrations.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/schema/migrations.ts
@@ -23,9 +23,7 @@ const migrationTableSQL = SQL`
 export const migrationTableSchemaComponent = schemaComponent(
   'dumbo:schema-component:migrations-table',
   {
-    migrations: () => [
-      sqlMigration('dumbo:migrationTable:001', [migrationTableSQL]),
-    ],
+    migrations: [sqlMigration('dumbo:migrationTable:001', [migrationTableSQL])],
   },
 );
 

--- a/src/packages/dumbo/src/storage/sqlite/core/schema/migrations.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/schema/migrations.ts
@@ -23,9 +23,7 @@ const migrationTableSQL = SQL`
 export const migrationTableSchemaComponent = schemaComponent(
   'dumbo:schema-component:migrations-table',
   {
-    migrations: () => [
-      sqlMigration('dumbo:migrationTable:001', [migrationTableSQL]),
-    ],
+    migrations: [sqlMigration('dumbo:migrationTable:001', [migrationTableSQL])],
   },
 );
 

--- a/src/packages/pongo/src/commandLine/migrate.ts
+++ b/src/packages/pongo/src/commandLine/migrate.ts
@@ -4,7 +4,7 @@ import {
   getDefaultMigratorOptionsFromRegistry,
   parseConnectionString,
   runSQLMigrations,
-  type ConnectorType,
+  type DatabaseType,
 } from '@event-driven-io/dumbo';
 import { Command } from 'commander';
 import { pongoCollectionSchemaComponent } from '../core';
@@ -84,10 +84,9 @@ migrateCommand
 
     const pool = dumbo({ connectionString, connector });
 
-    const migrations = collectionNames.flatMap((collectionsName) =>
-      pongoCollectionSchemaComponent(collectionsName).migrations({
-        connector,
-      }),
+    const migrations = collectionNames.flatMap(
+      (collectionsName) =>
+        pongoCollectionSchemaComponent(collectionsName).migrations,
     );
 
     await runSQLMigrations(pool, migrations, {
@@ -128,20 +127,17 @@ migrateCommand
       process.exit(1);
     }
     // TODO: Provide connector here
-    const connector: ConnectorType = 'PostgreSQL:pg';
+    const database: DatabaseType = 'PostgreSQL';
 
-    const coreMigrations = getDefaultMigratorOptionsFromRegistry(
-      'PostgreSQL',
-    ).schema.migrationTable.migrations({
-      connector,
-    });
+    const coreMigrations =
+      getDefaultMigratorOptionsFromRegistry(database).schema.migrationTable
+        .migrations;
 
     const migrations = [
       ...coreMigrations,
-      ...collectionNames.flatMap((collectionName) =>
-        pongoCollectionSchemaComponent(collectionName).migrations({
-          connector,
-        }),
+      ...collectionNames.flatMap(
+        (collectionName) =>
+          pongoCollectionSchemaComponent(collectionName).migrations,
       ),
     ];
 

--- a/src/packages/pongo/src/core/collection/pongoCollection.ts
+++ b/src/packages/pongo/src/core/collection/pongoCollection.ts
@@ -491,7 +491,7 @@ export const pongoCollection = <
     schema: {
       get component(): SchemaComponent {
         return schemaComponent('pongo:schema_component:collection', {
-          migrations: SqlFor.migrations,
+          migrations: SqlFor.migrations(),
         });
       },
       migrate: () => runSQLMigrations(pool, SqlFor.migrations()),
@@ -503,7 +503,7 @@ export const pongoCollection = <
 
 export const pongoCollectionSchemaComponent = (collectionName: string) =>
   schemaComponent('pongo:schema_component:collection', {
-    migrations: () => pongoCollectionPostgreSQLMigrations(collectionName), // TODO: This needs to change to support more connectors
+    migrations: pongoCollectionPostgreSQLMigrations(collectionName), // TODO: This needs to change to support more connectors
   });
 
 export type PongoCollectionSQLBuilder = {

--- a/src/packages/pongo/src/core/pongoDb.ts
+++ b/src/packages/pongo/src/core/pongoDb.ts
@@ -108,8 +108,8 @@ export const getPongoDb = <
       migrate: () =>
         runSQLMigrations(
           pool,
-          [...collections.values()].flatMap((c) =>
-            c.schema.component.migrations({ connector: pool.connector }),
+          [...collections.values()].flatMap(
+            (c) => c.schema.component.migrations,
           ),
         ),
     },


### PR DESCRIPTION
After recent changes in https://github.com/event-driven-io/Pongo/pull/118 we don't need to pass the connector anymore, as it'll be resolved when running migrations based on the passed dumbo instance.