### PR TITLE
Enabled schema component migrations to be resolved lazily based on the database type

### DIFF
--- a/src/packages/dumbo/src/core/schema/migrations.ts
+++ b/src/packages/dumbo/src/core/schema/migrations.ts
@@ -71,9 +71,8 @@ export const runSQLMigrations = (
   partialOptions?: Partial<MigratorOptions>,
 ): Promise<void> =>
   pool.withTransaction(async ({ execute }) => {
-    const defaultOptions = getDefaultMigratorOptionsFromRegistry(
-      fromConnectorType(pool.connector).databaseType,
-    );
+    const databaseType = fromConnectorType(pool.connector).databaseType;
+    const defaultOptions = getDefaultMigratorOptionsFromRegistry(databaseType);
     partialOptions ??= {};
 
     const options: MigratorOptions = {
@@ -104,7 +103,10 @@ export const runSQLMigrations = (
       ...rest,
     };
 
-    const coreMigrations = options.schema.migrationTable.migrations;
+    const coreMigrations =
+      await options.schema.migrationTable.resolveMigrations({
+        databaseType,
+      });
 
     await databaseLock.withAcquire(
       execute,

--- a/src/packages/pongo/src/core/pongoDb.ts
+++ b/src/packages/pongo/src/core/pongoDb.ts
@@ -1,5 +1,6 @@
 import {
   dumbo,
+  fromConnectorType,
   runSQLMigrations,
   schemaComponent,
   SQL,
@@ -80,6 +81,8 @@ export const getPongoDb = <
       sql,
     );
 
+  const databaseType = fromConnectorType(pool.connector).databaseType;
+
   const db: PongoDb<Connector> = {
     connector: options.connector,
     databaseName,
@@ -105,12 +108,14 @@ export const getPongoDb = <
           components: [...collections.values()].map((c) => c.schema.component),
         });
       },
-      migrate: () =>
+      migrate: async () =>
         runSQLMigrations(
           pool,
-          [...collections.values()].flatMap(
-            (c) => c.schema.component.migrations,
-          ),
+          await pongoDbSchemaComponent(
+            [...collections.values()].map((c) => c.schema.component),
+          ).resolveMigrations({
+            databaseType,
+          }),
         ),
     },
 


### PR DESCRIPTION
Thanks to that, we can add abstractions on top of the schema component (like Table, Index, etc.) that will be defined in a database-agnostic way and have the final SQL resolved upon running.

That opens the possibility to have a pluggable way to define default migration, Pongo collection, etc., without a big hassle.