### PR TITLE
Removed deferred connection pool from Dumbo and aligned conventions around database driver with Pongo

### DIFF
--- a/src/packages/dumbo/src/benchmarks/index.ts
+++ b/src/packages/dumbo/src/benchmarks/index.ts
@@ -2,10 +2,10 @@ import 'dotenv/config';
 
 import Benchmark from 'benchmark';
 import pg from 'pg';
-import { single, SQL } from '..';
+import { dumbo, single, SQL } from '..';
 import {
   defaultPostgreSQLConnectionString,
-  dumbo,
+  pgDatabaseDriver,
   PostgreSQLConnectionString,
 } from '../pg';
 
@@ -18,7 +18,8 @@ const pooled = process.env.BENCHMARK_CONNECTION_POOLED === 'true';
 
 const pool = dumbo({
   connectionString,
-  pooled,
+  driver: pgDatabaseDriver,
+  database: '',
 });
 
 const rawPgPool = new pg.Pool({ connectionString });

--- a/src/packages/dumbo/src/benchmarks/index.ts
+++ b/src/packages/dumbo/src/benchmarks/index.ts
@@ -19,7 +19,7 @@ const pooled = process.env.BENCHMARK_CONNECTION_POOLED === 'true';
 const pool = dumbo({
   connectionString,
   driver: pgDatabaseDriver,
-  database: '',
+  pooled,
 });
 
 const rawPgPool = new pg.Pool({ connectionString });

--- a/src/packages/dumbo/src/core/connections/connection.ts
+++ b/src/packages/dumbo/src/core/connections/connection.ts
@@ -20,8 +20,7 @@ export interface Connection<
   close: () => Promise<void>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyConnection = Connection<DatabaseDriverType, any>;
+export type AnyConnection = Connection<DatabaseDriverType, unknown>;
 
 export interface ConnectionFactory<
   ConnectionType extends Connection = Connection,

--- a/src/packages/dumbo/src/core/connections/connection.ts
+++ b/src/packages/dumbo/src/core/connections/connection.ts
@@ -20,6 +20,9 @@ export interface Connection<
   close: () => Promise<void>;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyConnection = Connection<DatabaseDriverType, any>;
+
 export interface ConnectionFactory<
   ConnectionType extends Connection = Connection,
 > {

--- a/src/packages/dumbo/src/core/drivers/databaseDriver.ts
+++ b/src/packages/dumbo/src/core/drivers/databaseDriver.ts
@@ -1,3 +1,4 @@
+import type { DatabaseDriverType } from '.';
 import {
   type Dumbo,
   type DumboConnectionOptions,
@@ -5,7 +6,6 @@ import {
 } from '..';
 import type { DatabaseConnectionString } from '../../storage/all';
 import type { AnyConnection } from '../connections';
-import type { DatabaseDriverType } from '../drivers';
 import type { MigratorOptions } from '../schema';
 import type { SQLFormatter } from '../sql';
 

--- a/src/packages/dumbo/src/core/drivers/index.ts
+++ b/src/packages/dumbo/src/core/drivers/index.ts
@@ -59,3 +59,5 @@ export function getDatabaseType<T extends DatabaseType>(
   const { databaseType } = fromDatabaseDriverType(databaseDriverType);
   return databaseType;
 }
+
+export * from './databaseDriver';

--- a/src/packages/dumbo/src/core/index.ts
+++ b/src/packages/dumbo/src/core/index.ts
@@ -29,7 +29,12 @@ export type DumboConnectionOptions<
   > = DatabaseConnectionString<
     InferDriverDatabaseType<DatabaseDriver['driverType']>
   >,
-> = {
-  driver?: DatabaseDriver;
-  connectionString: string | ConnectionString;
-} & Omit<ExtractDumboDatabaseDriverOptions<DatabaseDriver>, 'driver'>;
+> =
+  ExtractDumboDatabaseDriverOptions<DatabaseDriver> extends infer Options
+    ? Options extends unknown
+      ? {
+          driver?: DatabaseDriver;
+          connectionString: string | ConnectionString;
+        } & Omit<Options, 'driver'>
+      : never
+    : never;

--- a/src/packages/dumbo/src/core/index.ts
+++ b/src/packages/dumbo/src/core/index.ts
@@ -32,9 +32,18 @@ export type DumboConnectionOptions<
 > =
   ExtractDumboDatabaseDriverOptions<DatabaseDriver> extends infer Options
     ? Options extends unknown
-      ? {
-          driver?: DatabaseDriver;
-          connectionString: string | ConnectionString;
-        } & Omit<Options, 'driver'>
+      ? (
+          | {
+              driver?: DatabaseDriver;
+              driverType?: never;
+              connectionString: string | ConnectionString;
+            }
+          | {
+              driver?: never;
+              driverType: DatabaseDriver['driverType'];
+              connectionString: string | ConnectionString;
+            }
+        ) &
+          Omit<Options, 'driver' | 'driverType' | 'connectionString'>
       : never
     : never;

--- a/src/packages/dumbo/src/core/index.ts
+++ b/src/packages/dumbo/src/core/index.ts
@@ -1,6 +1,10 @@
 import type { DatabaseConnectionString } from '../storage/all';
 import { type Connection, type ConnectionPool } from './connections';
 import type { DatabaseDriverType, InferDriverDatabaseType } from './drivers';
+import type {
+  AnyDumboDatabaseDriver,
+  ExtractDumboDatabaseDriverOptions,
+} from './plugins';
 
 export * from './connections';
 export * from './drivers';
@@ -19,11 +23,13 @@ export type Dumbo<
 > = ConnectionPool<ConnectionType>;
 
 export type DumboConnectionOptions<
-  DriverType extends DatabaseDriverType = DatabaseDriverType,
+  DatabaseDriver extends AnyDumboDatabaseDriver = AnyDumboDatabaseDriver,
   ConnectionString extends DatabaseConnectionString<
-    InferDriverDatabaseType<DatabaseDriverType>
-  > = DatabaseConnectionString<InferDriverDatabaseType<DatabaseDriverType>>,
+    InferDriverDatabaseType<DatabaseDriver['driverType']>
+  > = DatabaseConnectionString<
+    InferDriverDatabaseType<DatabaseDriver['driverType']>
+  >,
 > = {
+  driver?: DatabaseDriver;
   connectionString: string | ConnectionString;
-  driverType: DriverType;
-};
+} & Omit<ExtractDumboDatabaseDriverOptions<DatabaseDriver>, 'driver'>;

--- a/src/packages/dumbo/src/core/index.ts
+++ b/src/packages/dumbo/src/core/index.ts
@@ -1,16 +1,16 @@
 import type { DatabaseConnectionString } from '../storage/all';
 import { type Connection, type ConnectionPool } from './connections';
-import type { DatabaseDriverType, InferDriverDatabaseType } from './drivers';
 import type {
   AnyDumboDatabaseDriver,
+  DatabaseDriverType,
   ExtractDumboDatabaseDriverOptions,
-} from './plugins';
+  InferDriverDatabaseType,
+} from './drivers';
 
 export * from './connections';
 export * from './drivers';
 export * from './execute';
 export * from './locks';
-export * from './plugins';
 export * from './query';
 export * from './schema';
 export * from './serializer';

--- a/src/packages/dumbo/src/core/index.ts
+++ b/src/packages/dumbo/src/core/index.ts
@@ -32,18 +32,10 @@ export type DumboConnectionOptions<
 > =
   ExtractDumboDatabaseDriverOptions<DatabaseDriver> extends infer Options
     ? Options extends unknown
-      ? (
-          | {
-              driver?: DatabaseDriver;
-              driverType?: never;
-              connectionString: string | ConnectionString;
-            }
-          | {
-              driver?: never;
-              driverType: DatabaseDriver['driverType'];
-              connectionString: string | ConnectionString;
-            }
-        ) &
-          Omit<Options, 'driver' | 'driverType' | 'connectionString'>
+      ? {
+          driver?: DatabaseDriver;
+          driverType?: DatabaseDriver['driverType'];
+          connectionString: string | ConnectionString;
+        } & Omit<Options, 'driver' | 'driverType' | 'connectionString'>
       : never
     : never;

--- a/src/packages/dumbo/src/core/plugins/index.ts
+++ b/src/packages/dumbo/src/core/plugins/index.ts
@@ -1,1 +1,0 @@
-export * from './storagePlugin';

--- a/src/packages/dumbo/src/core/plugins/storagePlugin.ts
+++ b/src/packages/dumbo/src/core/plugins/storagePlugin.ts
@@ -89,13 +89,11 @@ export const DumboDatabaseDriverRegistry = () => {
   }: DatabaseDriverResolutionOptions) =>
     driverType
       ? drivers.get(driverType)
-      : drivers
-          .values()
-          .find(
-            (d) =>
-              typeof d !== 'function' &&
-              d.tryParseConnectionString(connectionString),
-          );
+      : [...drivers.values()].find(
+          (d) =>
+            typeof d !== 'function' &&
+            d.tryParseConnectionString(connectionString),
+        );
 
   const tryResolve = async <
     Driver extends AnyDumboDatabaseDriver = AnyDumboDatabaseDriver,

--- a/src/packages/dumbo/src/core/plugins/storagePlugin.ts
+++ b/src/packages/dumbo/src/core/plugins/storagePlugin.ts
@@ -73,6 +73,16 @@ export type ExtractDumboTypeFromDriver<DatabaseDriver> =
     ? D
     : never;
 
+export type DatabaseDriverResolutionOptions =
+  | {
+      driverType: DatabaseDriverType;
+      connectionString?: never;
+    }
+  | {
+      driverType?: never;
+      connectionString: string;
+    };
+
 export const StoragePluginRegistry = () => {
   const plugins = new Map<
     DatabaseDriverType,

--- a/src/packages/dumbo/src/core/schema/migrations.ts
+++ b/src/packages/dumbo/src/core/schema/migrations.ts
@@ -7,7 +7,7 @@ import {
   NoDatabaseLock,
 } from '../locks';
 import { mapToCamelCase, singleOrNull } from '../query';
-import { SQL, type SQLFormatter } from '../sql';
+import { getFormatter, SQL, type SQLFormatter } from '../sql';
 import { tracer } from '../tracing';
 import { schemaComponent, type SchemaComponent } from './schemaComponent';
 
@@ -141,7 +141,7 @@ export const runSQLMigrations = (
         }
 
         for (const migration of migrations) {
-          await runSQLMigration(execute, migration);
+          await runSQLMigration(databaseType, execute, migration);
         }
       },
       lockOptions,
@@ -151,11 +151,12 @@ export const runSQLMigrations = (
   });
 
 const runSQLMigration = async (
+  databaseType: DatabaseType,
   execute: SQLExecutor,
   migration: SQLMigration,
 ): Promise<void> => {
   const sqls = combineMigrations(migration);
-  const sqlHash = await getMigrationHash(migration, execute.formatter);
+  const sqlHash = await getMigrationHash(migration, getFormatter(databaseType));
 
   try {
     const newMigration = {

--- a/src/packages/dumbo/src/core/sql/formatters/sqlFormatter.ts
+++ b/src/packages/dumbo/src/core/sql/formatters/sqlFormatter.ts
@@ -64,21 +64,27 @@ export const SQLFormatter = ({
   return resultFormatter;
 };
 
-const formatters: Record<string, SQLFormatter> = {};
+declare global {
+  // eslint-disable-next-line no-var
+  var dumboSQLFormatters: Record<string, SQLFormatter>;
+}
+
+const dumboSQLFormatters = (globalThis.dumboSQLFormatters =
+  globalThis.dumboSQLFormatters ?? ({} as Record<string, SQLFormatter>));
 
 export const registerFormatter = (
   dialect: string,
   formatter: SQLFormatter,
 ): void => {
-  formatters[dialect] = formatter;
+  dumboSQLFormatters[dialect] = formatter;
 };
 
 export const getFormatter = (dialect: string): SQLFormatter => {
   const formatterKey = dialect;
-  if (!formatters[formatterKey]) {
+  if (!dumboSQLFormatters[formatterKey]) {
     throw new Error(`No SQL formatter registered for dialect: ${dialect}`);
   }
-  return formatters[formatterKey];
+  return dumboSQLFormatters[formatterKey];
 };
 
 export function formatSQL(

--- a/src/packages/dumbo/src/storage/all/index.ts
+++ b/src/packages/dumbo/src/storage/all/index.ts
@@ -1,9 +1,9 @@
-import { type DumboConnectionOptions } from '../../core';
 import {
   dumboDatabaseDriverRegistry,
   type AnyDumboDatabaseDriver,
+  type DumboConnectionOptions,
   type ExtractDumboTypeFromDriver,
-} from '../../core/plugins';
+} from '../../core';
 
 export * from './connections';
 

--- a/src/packages/dumbo/src/storage/all/index.ts
+++ b/src/packages/dumbo/src/storage/all/index.ts
@@ -35,6 +35,6 @@ export function dumbo<
 
   return driver.createPool({
     ...options,
-    driverType,
+    driverType: driver.driverType,
   }) as ExtractDumboTypeFromDriver<DatabaseDriver>;
 }

--- a/src/packages/dumbo/src/storage/all/index.ts
+++ b/src/packages/dumbo/src/storage/all/index.ts
@@ -1,40 +1,36 @@
+import { type DumboConnectionOptions } from '../../core';
 import {
-  type DatabaseDriverType,
-  type DumboConnectionOptions,
-} from '../../core';
-import {
-  storagePluginRegistry,
+  dumboDatabaseDriverRegistry,
   type AnyDumboDatabaseDriver,
   type ExtractDumboTypeFromDriver,
 } from '../../core/plugins';
-import { parseConnectionString } from './connections';
 
 export * from './connections';
 
-storagePluginRegistry.register('PostgreSQL:pg', () =>
+dumboDatabaseDriverRegistry.register('PostgreSQL:pg', () =>
   import('../postgresql/pg').then((m) => m.databaseDriver),
 );
 
-storagePluginRegistry.register('SQLite:sqlite3', () =>
+dumboDatabaseDriverRegistry.register('SQLite:sqlite3', () =>
   import('../sqlite/sqlite3').then((m) => m.databaseDriver),
 );
 
 export function dumbo<
   DatabaseDriver extends AnyDumboDatabaseDriver = AnyDumboDatabaseDriver,
-  DriverType extends DatabaseDriverType = DatabaseDriverType,
 >(
   options: DumboConnectionOptions<DatabaseDriver>,
 ): ExtractDumboTypeFromDriver<DatabaseDriver> {
-  const { connectionString } = options;
+  const { connectionString, driverType } = options;
 
-  const { databaseType, driverName } = parseConnectionString(connectionString);
-
-  const driverType = `${databaseType}:${driverName}` as DriverType;
-
-  const driver = storagePluginRegistry.tryGet<DatabaseDriver>(driverType);
+  const driver = dumboDatabaseDriverRegistry.tryGet<DatabaseDriver>({
+    driverType,
+    connectionString,
+  });
 
   if (driver === null) {
-    throw new Error(`No plugin found for database driver type: ${driverType}`);
+    throw new Error(
+      `No plugin found for connection string: ${connectionString} and driver type: ${driverType}`,
+    );
   }
 
   return driver.createPool({

--- a/src/packages/dumbo/src/storage/all/index.ts
+++ b/src/packages/dumbo/src/storage/all/index.ts
@@ -12,11 +12,11 @@ import { parseConnectionString } from './connections';
 export * from './connections';
 
 storagePluginRegistry.register('PostgreSQL:pg', () =>
-  import('../postgresql/pg').then((m) => m.storagePlugin),
+  import('../postgresql/pg').then((m) => m.databaseDriver),
 );
 
 storagePluginRegistry.register('SQLite:sqlite3', () =>
-  import('../sqlite/sqlite3').then((m) => m.storagePlugin),
+  import('../sqlite/sqlite3').then((m) => m.databaseDriver),
 );
 
 export function dumbo<

--- a/src/packages/dumbo/src/storage/all/index.ts
+++ b/src/packages/dumbo/src/storage/all/index.ts
@@ -1,5 +1,4 @@
 import {
-  createDeferredConnectionPool,
   type Connection,
   type DatabaseDriverType,
   type Dumbo,
@@ -29,20 +28,13 @@ export function dumbo<
 
   const driverType = `${databaseType}:${driverName}` as DriverType;
 
-  const importAndCreatePool = async () => {
-    const plugin = await storagePluginRegistry.tryResolve<
-      DriverType,
-      ConnectionType
-    >(driverType);
+  const plugin = storagePluginRegistry.tryGet<DriverType, ConnectionType>(
+    driverType,
+  );
 
-    if (plugin === null) {
-      throw new Error(
-        `No plugin found for database driver type: ${driverType}`,
-      );
-    }
+  if (plugin === null) {
+    throw new Error(`No plugin found for database driver type: ${driverType}`);
+  }
 
-    return plugin.createPool({ ...options, driverType });
-  };
-
-  return createDeferredConnectionPool(driverType, importAndCreatePool);
+  return plugin.createPool({ ...options, driverType });
 }

--- a/src/packages/dumbo/src/storage/postgresql/core/schema/migrations.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/schema/migrations.int.spec.ts
@@ -5,14 +5,13 @@ import {
 import assert from 'assert';
 import { after, before, beforeEach, describe, it } from 'node:test';
 import { PostgreSQLConnectionString, tableExists } from '..';
-import { type Dumbo } from '../../../..';
+import { dumbo, type Dumbo } from '../../../..';
 import { count, SQL } from '../../../../core';
 import {
   MIGRATIONS_LOCK_ID,
   runSQLMigrations,
   type SQLMigration,
 } from '../../../../core/schema';
-import { dumbo } from '../../../../pg';
 import { acquireAdvisoryLock, releaseAdvisoryLock } from '../locks';
 
 void describe('Migration Integration Tests', () => {

--- a/src/packages/dumbo/src/storage/postgresql/core/schema/migrations.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/schema/migrations.int.spec.ts
@@ -6,12 +6,14 @@ import assert from 'assert';
 import { after, before, beforeEach, describe, it } from 'node:test';
 import { PostgreSQLConnectionString, tableExists } from '..';
 import { dumbo, type Dumbo } from '../../../..';
-import { count, SQL } from '../../../../core';
 import {
+  count,
   MIGRATIONS_LOCK_ID,
   runSQLMigrations,
+  SQL,
   type SQLMigration,
-} from '../../../../core/schema';
+} from '../../../../core';
+import { pgDatabaseDriver } from '../../pg';
 import { acquireAdvisoryLock, releaseAdvisoryLock } from '../locks';
 
 void describe('Migration Integration Tests', () => {
@@ -22,7 +24,7 @@ void describe('Migration Integration Tests', () => {
   before(async () => {
     postgres = await new PostgreSqlContainer().start();
     connectionString = PostgreSQLConnectionString(postgres.getConnectionUri());
-    pool = dumbo({ connectionString });
+    pool = dumbo({ connectionString, driver: pgDatabaseDriver });
   });
 
   after(async () => {

--- a/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/sql/formatter/sqlFormatter.int.spec.ts
@@ -5,9 +5,8 @@ import {
 import assert from 'assert';
 import { after, before, describe, it } from 'node:test';
 import { PostgreSQLConnectionString } from '../..';
-import { type Dumbo } from '../../../../..';
+import { dumbo, type Dumbo } from '../../../../..';
 import { count, SQL } from '../../../../../core';
-import { dumbo } from '../../../../../pg';
 
 void describe('PostgreSQL SQL Formatter Integration Tests', () => {
   let pool: Dumbo;

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.generic.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.generic.int.spec.ts
@@ -5,9 +5,10 @@ import {
 import { after, before, describe, it } from 'node:test';
 import pg from 'pg';
 import { nodePostgresPool } from '.';
+import { pgDatabaseDriver } from '..';
 import { SQL } from '../../../../core';
-import { endPool, getPool } from './pool';
 import { dumbo } from '../../../all';
+import { endPool, getPool } from './pool';
 
 void describe('Node Postgresql', () => {
   let postgres: StartedPostgreSqlContainer;
@@ -24,7 +25,7 @@ void describe('Node Postgresql', () => {
 
   void describe('nodePostgresPool', () => {
     void it('connects using default pool', async () => {
-      const pool = dumbo({ connectionString });
+      const pool = dumbo({ connectionString, driver: pgDatabaseDriver });
       const connection = await pool.connection();
 
       try {

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.generic.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.generic.int.spec.ts
@@ -5,9 +5,9 @@ import {
 import { after, before, describe, it } from 'node:test';
 import pg from 'pg';
 import { nodePostgresPool } from '.';
-import { dumbo } from '..';
 import { SQL } from '../../../../core';
 import { endPool, getPool } from './pool';
+import { dumbo } from '../../../all';
 
 void describe('Node Postgresql', () => {
   let postgres: StartedPostgreSqlContainer;

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
@@ -139,52 +139,44 @@ export const nodePostgresAmbientClientPool = (options: {
 
 export type NodePostgresPoolPooledOptions =
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
       pooled: true;
       pool: pg.Pool;
     }
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
       pool: pg.Pool;
     }
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
       pooled: true;
     }
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
     };
 
 export type NodePostgresPoolNotPooledOptions =
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
       pooled: false;
       client: pg.Client;
     }
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
       client: pg.Client;
     }
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
       pooled: false;
     }
   | {
-      driverType?: NodePostgresDriverType;
       connectionString: string;
       database?: string;
       connection:

--- a/src/packages/dumbo/src/storage/postgresql/pg/execute/execute.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/execute/execute.ts
@@ -58,6 +58,7 @@ export const nodePostgresSQLExecutor = (): NodePostgresSQLExecutor => ({
   batchQuery: batch,
   command: batch,
   batchCommand: batch,
+  formatter: pgFormatter,
 });
 
 export type BatchQueryOptions = { timeoutMs?: number };

--- a/src/packages/dumbo/src/storage/postgresql/pg/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/formatter/sqlFormatter.int.spec.ts
@@ -4,9 +4,10 @@ import {
 } from '@testcontainers/postgresql';
 import assert from 'assert';
 import { after, before, describe, it } from 'node:test';
-import { PostgreSQLConnectionString } from '../..';
-import { dumbo, type Dumbo } from '../../../../..';
-import { count, SQL } from '../../../../../core';
+import { pgDatabaseDriver } from '..';
+import { dumbo, type Dumbo } from '../../../..';
+import { count, SQL } from '../../../../core';
+import { PostgreSQLConnectionString } from '../../core';
 
 void describe('PostgreSQL SQL Formatter Integration Tests', () => {
   let pool: Dumbo;
@@ -16,7 +17,7 @@ void describe('PostgreSQL SQL Formatter Integration Tests', () => {
   before(async () => {
     postgres = await new PostgreSqlContainer().start();
     connectionString = PostgreSQLConnectionString(postgres.getConnectionUri());
-    pool = dumbo({ connectionString });
+    pool = dumbo({ connectionString, driver: pgDatabaseDriver });
 
     await pool.execute.batchCommand([
       SQL`CREATE TABLE test_users (id SERIAL PRIMARY KEY, name TEXT)`,

--- a/src/packages/dumbo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/index.ts
@@ -1,5 +1,7 @@
-import type { DumboDatabaseDriver } from '../../../core';
-import { dumboDatabaseDriverRegistry } from '../../../core/plugins/storagePlugin';
+import {
+  type DumboDatabaseDriver,
+  dumboDatabaseDriverRegistry,
+} from '../../../core';
 import {
   defaultPostgreSQLConnectionString,
   DefaultPostgreSQLMigratorOptions,

--- a/src/packages/dumbo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/index.ts
@@ -1,4 +1,7 @@
-import type { Dumbo, DumboDatabaseDriver } from '../../../core';
+import type {
+  DumboConnectionOptions,
+  DumboDatabaseDriver,
+} from '../../../core';
 import { storagePluginRegistry } from '../../../core/plugins/storagePlugin';
 import {
   defaultPostgreSQLConnectionString,
@@ -15,7 +18,7 @@ import {
   type NodePostgresPoolOptions,
 } from './connections';
 
-export const pgStoragePlugin: DumboDatabaseDriver<
+export const pgDatabaseDriver: DumboDatabaseDriver<
   NodePostgresConnection,
   NodePostgresPoolOptions,
   PostgreSQLConnectionString
@@ -35,19 +38,17 @@ export const pgStoragePlugin: DumboDatabaseDriver<
   },
 };
 
-storagePluginRegistry.register(NodePostgresDriverType, pgStoragePlugin);
+type TestOpt = DumboConnectionOptions<typeof pgDatabaseDriver>;
+const opt: TestOpt = { connectionString: '', pooled: true };
+console.log(opt);
 
-export const dumbo = <
-  DumboOptionsType extends PostgresPoolOptions = PostgresPoolOptions,
->(
-  options: DumboOptionsType,
-): Dumbo<NodePostgresDriverType> => nodePostgresPool(options);
+storagePluginRegistry.register(NodePostgresDriverType, pgDatabaseDriver);
 
 export * from './connections';
 export * from './execute';
 export * from './serialization';
 
-export { pgStoragePlugin as storagePlugin };
+export { pgDatabaseDriver as databaseDriver };
 
 // TODO: Remove stuff below
 

--- a/src/packages/dumbo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/index.ts
@@ -1,5 +1,5 @@
 import type { DumboDatabaseDriver } from '../../../core';
-import { storagePluginRegistry } from '../../../core/plugins/storagePlugin';
+import { dumboDatabaseDriverRegistry } from '../../../core/plugins/storagePlugin';
 import {
   defaultPostgreSQLConnectionString,
   DefaultPostgreSQLMigratorOptions,
@@ -35,7 +35,7 @@ export const pgDatabaseDriver: DumboDatabaseDriver<
   },
 };
 
-storagePluginRegistry.register(NodePostgresDriverType, pgDatabaseDriver);
+dumboDatabaseDriverRegistry.register(NodePostgresDriverType, pgDatabaseDriver);
 
 export * from './connections';
 export * from './execute';

--- a/src/packages/dumbo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/index.ts
@@ -1,9 +1,12 @@
-import type { Dumbo } from '../../../core';
+import type { Dumbo, DumboDatabaseDriver } from '../../../core';
+import { storagePluginRegistry } from '../../../core/plugins/storagePlugin';
 import {
-  type StoragePlugin,
-  storagePluginRegistry,
-} from '../../../core/plugins/storagePlugin';
-import { DefaultPostgreSQLMigratorOptions, pgFormatter } from '../core';
+  defaultPostgreSQLConnectionString,
+  DefaultPostgreSQLMigratorOptions,
+  getDatabaseNameOrDefault,
+  pgFormatter,
+  PostgreSQLConnectionString,
+} from '../core';
 import {
   type NodePostgresConnection,
   NodePostgresDriverType,
@@ -12,15 +15,24 @@ import {
   type NodePostgresPoolOptions,
 } from './connections';
 
-export const pgStoragePlugin: StoragePlugin<
-  NodePostgresDriverType,
-  NodePostgresConnection
+export const pgStoragePlugin: DumboDatabaseDriver<
+  NodePostgresConnection,
+  NodePostgresPoolOptions,
+  PostgreSQLConnectionString
 > = {
   driverType: NodePostgresDriverType,
-  createPool: (options) =>
-    nodePostgresPool(options as unknown as PostgresPoolOptions),
+  createPool: (options) => nodePostgresPool(options),
   sqlFormatter: pgFormatter,
   defaultMigratorOptions: DefaultPostgreSQLMigratorOptions,
+  defaultConnectionString: defaultPostgreSQLConnectionString,
+  getDatabaseNameOrDefault,
+  tryParseConnectionString: (connectionString) => {
+    try {
+      return PostgreSQLConnectionString(connectionString);
+    } catch {
+      return null;
+    }
+  },
 };
 
 storagePluginRegistry.register(NodePostgresDriverType, pgStoragePlugin);

--- a/src/packages/dumbo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/index.ts
@@ -1,7 +1,4 @@
-import type {
-  DumboConnectionOptions,
-  DumboDatabaseDriver,
-} from '../../../core';
+import type { DumboDatabaseDriver } from '../../../core';
 import { storagePluginRegistry } from '../../../core/plugins/storagePlugin';
 import {
   defaultPostgreSQLConnectionString,
@@ -37,10 +34,6 @@ export const pgDatabaseDriver: DumboDatabaseDriver<
     }
   },
 };
-
-type TestOpt = DumboConnectionOptions<typeof pgDatabaseDriver>;
-const opt: TestOpt = { connectionString: '', pooled: true };
-console.log(opt);
 
 storagePluginRegistry.register(NodePostgresDriverType, pgDatabaseDriver);
 

--- a/src/packages/dumbo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/index.ts
@@ -35,7 +35,14 @@ export const pgDatabaseDriver: DumboDatabaseDriver<
   },
 };
 
-dumboDatabaseDriverRegistry.register(NodePostgresDriverType, pgDatabaseDriver);
+export const usePgDatabaseDriver = () => {
+  dumboDatabaseDriverRegistry.register(
+    NodePostgresDriverType,
+    pgDatabaseDriver,
+  );
+};
+
+usePgDatabaseDriver();
 
 export * from './connections';
 export * from './execute';

--- a/src/packages/dumbo/src/storage/sqlite/core/execute/execute.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/execute/execute.ts
@@ -1,6 +1,7 @@
 import type { SQLiteDriverType } from '..';
 import {
   SQL,
+  SQLFormatter,
   tracer,
   type DbSQLExecutor,
   type QueryResult,
@@ -28,12 +29,14 @@ export const sqliteSQLExecutor = <
   DriverType extends SQLiteDriverType = SQLiteDriverType,
 >(
   driverType: DriverType,
+  formatter?: SQLFormatter,
 ): SQLiteSQLExecutor<DriverType> => ({
   driverType,
   query: batch,
   batchQuery: batch,
   command: batch,
   batchCommand: batch,
+  formatter: formatter ?? sqliteFormatter,
 });
 
 export type BatchQueryOptions = { timeoutMs?: number };

--- a/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
@@ -184,13 +184,16 @@ export type SQLitePoolNotPooledOptions<
 > =
   | {
       driverType: DriverType;
-      pooled?: false;
+      connection?: never;
       client: SQLiteClient;
+      pooled?: false;
       singleton?: true;
       allowNestedTransactions?: boolean;
     }
   | {
       driverType: DriverType;
+      connection?: never;
+      client?: never;
       pooled?: boolean;
       singleton?: boolean;
       allowNestedTransactions?: boolean;
@@ -200,6 +203,7 @@ export type SQLitePoolNotPooledOptions<
       connection:
         | SQLitePoolClientConnection<DriverType>
         | SQLiteClientConnection<DriverType>;
+      client?: never;
       pooled?: false;
       singleton?: true;
       allowNestedTransactions?: boolean;

--- a/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
@@ -209,7 +209,7 @@ export type SQLitePoolNotPooledOptions<
       allowNestedTransactions?: boolean;
     };
 
-export type SQLitePoolOptions<
+export type SQLiteDumboConnectionOptions<
   DriverType extends SQLiteDriverType = SQLiteDriverType,
 > = (
   | SQLitePoolPooledOptions<DriverType>
@@ -228,7 +228,7 @@ export function sqlitePool<
 export function sqlitePool<
   DriverType extends SQLiteDriverType = SQLiteDriverType,
 >(
-  options: SQLitePoolOptions<DriverType>,
+  options: SQLiteDumboConnectionOptions<DriverType>,
 ):
   | SQLiteAmbientClientPool<DriverType>
   | SQLiteAmbientConnectionPool<DriverType> {

--- a/src/packages/dumbo/src/storage/sqlite/core/schema/migrations.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/schema/migrations.int.spec.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 import { InMemorySQLiteDatabase, SQLiteConnectionString } from '..';
 import { count, dumbo, SQL, type Dumbo } from '../../../..';
 import { runSQLMigrations, type SQLMigration } from '../../../../core/schema';
-import { tableExists } from '../../../../sqlite3';
+import { SQLite3DriverType, tableExists } from '../../../../sqlite3';
 
 void describe('Migration Integration Tests', () => {
   const inMemoryfileName = InMemorySQLiteDatabase;
@@ -30,7 +30,7 @@ void describe('Migration Integration Tests', () => {
 
     void describe(`dumbo with ${testName} database`, () => {
       beforeEach(() => {
-        pool = dumbo({ connectionString, driverType: 'SQLite:sqlite3' });
+        pool = dumbo({ connectionString, driverType: SQLite3DriverType });
       });
 
       afterEach(() => {

--- a/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/sqlFormatter.int.spec.ts
@@ -1,8 +1,7 @@
 import assert from 'assert';
 import { after, before, describe, it } from 'node:test';
-import { type Dumbo } from '../../../../..';
+import { dumbo, type Dumbo } from '../../../../..';
 import { count, SQL } from '../../../../../core';
-import { dumbo } from '../../../../../sqlite3';
 import { InMemorySQLiteDatabase } from '../../connections';
 
 void describe('SQLite SQL Formatter Integration Tests', () => {

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.int.generic.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.int.generic.spec.ts
@@ -3,7 +3,10 @@ import fs from 'fs';
 import { afterEach, describe, it } from 'node:test';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { useSqlite3DatabaseDriver } from '..';
+import {
+  useSqlite3DatabaseDriver,
+  type SQLite3DumboConnectionOptions,
+} from '..';
 import { SQL } from '../../../../core';
 import { dumbo } from '../../../all';
 import { InMemorySQLiteDatabase, SQLiteConnectionString } from '../../core';
@@ -133,11 +136,13 @@ void describe('Node SQLite pool', () => {
       });
 
       void it('connects using client', async () => {
-        const pool = dumbo({
+        const options: SQLite3DumboConnectionOptions = {
           driverType: `SQLite:sqlite3`,
           connectionString,
           pooled: false,
-        });
+        };
+
+        const pool = dumbo(options);
         const connection = await pool.connection();
 
         try {

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.int.generic.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.int.generic.spec.ts
@@ -3,12 +3,15 @@ import fs from 'fs';
 import { afterEach, describe, it } from 'node:test';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { useSqlite3DatabaseDriver } from '..';
 import { SQL } from '../../../../core';
 import { dumbo } from '../../../all';
 import { InMemorySQLiteDatabase, SQLiteConnectionString } from '../../core';
 import { sqlite3Client } from './connection';
 
 void describe('Node SQLite pool', () => {
+  useSqlite3DatabaseDriver();
+
   const inMemoryfileName = InMemorySQLiteDatabase;
 
   const testDatabasePath = path.resolve(

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/formatter/sqlFormatter.int.spec.ts
@@ -1,8 +1,9 @@
 import assert from 'assert';
 import { after, before, describe, it } from 'node:test';
-import { dumbo, type Dumbo } from '../../../../..';
-import { count, SQL } from '../../../../../core';
-import { InMemorySQLiteDatabase } from '../../connections';
+import { sqlite3DatabaseDriver } from '..';
+import { dumbo, type Dumbo } from '../../../..';
+import { count, SQL } from '../../../../core';
+import { InMemorySQLiteDatabase } from '../../core/connections';
 
 void describe('SQLite SQL Formatter Integration Tests', () => {
   let pool: Dumbo;
@@ -10,7 +11,7 @@ void describe('SQLite SQL Formatter Integration Tests', () => {
   before(() => {
     pool = dumbo({
       connectionString: InMemorySQLiteDatabase,
-      driverType: 'SQLite:sqlite3',
+      driver: sqlite3DatabaseDriver,
     });
   });
 

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -36,7 +36,14 @@ export const sqlite3DatabaseDriver: DumboDatabaseDriver<
   },
 };
 
-dumboDatabaseDriverRegistry.register(SQLite3DriverType, sqlite3DatabaseDriver);
+export const useSqlite3DatabaseDriver = () => {
+  dumboDatabaseDriverRegistry.register(
+    SQLite3DriverType,
+    sqlite3DatabaseDriver,
+  );
+};
+
+useSqlite3DatabaseDriver();
 
 export { sqlite3DatabaseDriver as databaseDriver, sqliteClient };
 

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -1,6 +1,8 @@
 export * from './connections';
-import type { DumboDatabaseDriver } from '../../../core';
-import { dumboDatabaseDriverRegistry } from '../../../core/plugins/storagePlugin';
+import {
+  dumboDatabaseDriverRegistry,
+  type DumboDatabaseDriver,
+} from '../../../core';
 import {
   DefaultSQLiteMigratorOptions,
   InMemorySQLiteDatabase,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -1,11 +1,10 @@
 export * from './connections';
-import type { Dumbo } from '../../../core';
-import {
-  storagePluginRegistry,
-  type StoragePlugin,
-} from '../../../core/plugins/storagePlugin';
+import type { Dumbo, DumboDatabaseDriver } from '../../../core';
+import { storagePluginRegistry } from '../../../core/plugins/storagePlugin';
 import {
   DefaultSQLiteMigratorOptions,
+  InMemorySQLiteDatabase,
+  SQLiteConnectionString,
   sqliteFormatter,
   sqlitePool,
   type SQLiteConnection,
@@ -16,15 +15,25 @@ import {
   sqlite3Client as sqliteClient,
 } from './connections';
 
-const sqlite3StoragePlugin: StoragePlugin<
-  SQLite3DriverType,
-  SQLiteConnection<SQLite3DriverType>
+const sqlite3StoragePlugin: DumboDatabaseDriver<
+  SQLiteConnection<SQLite3DriverType>,
+  SQLitePoolOptions<SQLite3DriverType>,
+  SQLiteConnectionString
 > = {
   driverType: SQLite3DriverType,
   createPool: (options) =>
     sqlitePool(options as unknown as SQLitePoolOptions<SQLite3DriverType>),
   sqlFormatter: sqliteFormatter,
   defaultMigratorOptions: DefaultSQLiteMigratorOptions,
+  getDatabaseNameOrDefault: () => InMemorySQLiteDatabase,
+  defaultConnectionString: InMemorySQLiteDatabase,
+  tryParseConnectionString: (connectionString) => {
+    try {
+      return SQLiteConnectionString(connectionString);
+    } catch {
+      return null;
+    }
+  },
 };
 
 storagePluginRegistry.register(SQLite3DriverType, sqlite3StoragePlugin);

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -1,6 +1,7 @@
 export * from './connections';
 import {
   dumboDatabaseDriverRegistry,
+  type DumboConnectionOptions,
   type DumboDatabaseDriver,
 } from '../../../core';
 import {
@@ -10,21 +11,17 @@ import {
   sqliteFormatter,
   sqlitePool,
   type SQLiteConnection,
-  type SQLitePoolOptions,
+  type SQLiteDumboConnectionOptions,
 } from '../core';
 import {
   SQLite3DriverType,
   sqlite3Client as sqliteClient,
 } from './connections';
 
-export const sqlite3DatabaseDriver: DumboDatabaseDriver<
-  SQLiteConnection<SQLite3DriverType>,
-  SQLitePoolOptions<SQLite3DriverType>,
-  SQLiteConnectionString
-> = {
-  driverType: SQLite3DriverType,
+export const sqlite3DatabaseDriver = {
+  driverType: 'SQLite:sqlite3' as const,
   createPool: (options) =>
-    sqlitePool(options as SQLitePoolOptions<SQLite3DriverType>),
+    sqlitePool(options as SQLiteDumboConnectionOptions<SQLite3DriverType>),
   sqlFormatter: sqliteFormatter,
   defaultMigratorOptions: DefaultSQLiteMigratorOptions,
   getDatabaseNameOrDefault: () => InMemorySQLiteDatabase,
@@ -36,7 +33,11 @@ export const sqlite3DatabaseDriver: DumboDatabaseDriver<
       return null;
     }
   },
-};
+} satisfies DumboDatabaseDriver<
+  SQLiteConnection<SQLite3DriverType>,
+  SQLiteDumboConnectionOptions<SQLite3DriverType>,
+  SQLiteConnectionString
+>;
 
 export const useSqlite3DatabaseDriver = () => {
   dumboDatabaseDriverRegistry.register(
@@ -44,6 +45,10 @@ export const useSqlite3DatabaseDriver = () => {
     sqlite3DatabaseDriver,
   );
 };
+
+export type SQLite3DumboConnectionOptions = DumboConnectionOptions<
+  typeof sqlite3DatabaseDriver
+>;
 
 useSqlite3DatabaseDriver();
 

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -1,6 +1,6 @@
 export * from './connections';
 import type { DumboDatabaseDriver } from '../../../core';
-import { storagePluginRegistry } from '../../../core/plugins/storagePlugin';
+import { dumboDatabaseDriverRegistry } from '../../../core/plugins/storagePlugin';
 import {
   DefaultSQLiteMigratorOptions,
   InMemorySQLiteDatabase,
@@ -36,7 +36,7 @@ export const sqlite3DatabaseDriver: DumboDatabaseDriver<
   },
 };
 
-storagePluginRegistry.register(SQLite3DriverType, sqlite3DatabaseDriver);
+dumboDatabaseDriverRegistry.register(SQLite3DriverType, sqlite3DatabaseDriver);
 
 export { sqlite3DatabaseDriver as databaseDriver, sqliteClient };
 

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -22,7 +22,7 @@ export const sqlite3DatabaseDriver: DumboDatabaseDriver<
 > = {
   driverType: SQLite3DriverType,
   createPool: (options) =>
-    sqlitePool(options as unknown as SQLitePoolOptions<SQLite3DriverType>),
+    sqlitePool(options as SQLitePoolOptions<SQLite3DriverType>),
   sqlFormatter: sqliteFormatter,
   defaultMigratorOptions: DefaultSQLiteMigratorOptions,
   getDatabaseNameOrDefault: () => InMemorySQLiteDatabase,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -1,5 +1,5 @@
 export * from './connections';
-import type { Dumbo, DumboDatabaseDriver } from '../../../core';
+import type { DumboDatabaseDriver } from '../../../core';
 import { storagePluginRegistry } from '../../../core/plugins/storagePlugin';
 import {
   DefaultSQLiteMigratorOptions,
@@ -15,7 +15,7 @@ import {
   sqlite3Client as sqliteClient,
 } from './connections';
 
-const sqlite3StoragePlugin: DumboDatabaseDriver<
+export const sqlite3DatabaseDriver: DumboDatabaseDriver<
   SQLiteConnection<SQLite3DriverType>,
   SQLitePoolOptions<SQLite3DriverType>,
   SQLiteConnectionString
@@ -36,16 +36,8 @@ const sqlite3StoragePlugin: DumboDatabaseDriver<
   },
 };
 
-storagePluginRegistry.register(SQLite3DriverType, sqlite3StoragePlugin);
+storagePluginRegistry.register(SQLite3DriverType, sqlite3DatabaseDriver);
 
-export { sqliteClient, sqlite3StoragePlugin as storagePlugin };
+export { sqlite3DatabaseDriver as databaseDriver, sqliteClient };
 
 export const connectionPool = sqlitePool;
-
-export const dumbo = <
-  DumboOptionsType extends
-    SQLitePoolOptions<SQLite3DriverType> = SQLitePoolOptions<SQLite3DriverType>,
->(
-  options: DumboOptionsType,
-): Dumbo<SQLite3DriverType, SQLiteConnection<SQLite3DriverType>> =>
-  sqlitePool(options);

--- a/src/packages/pongo/src/core/drivers/databaseDriver.ts
+++ b/src/packages/pongo/src/core/drivers/databaseDriver.ts
@@ -54,11 +54,11 @@ export type AnyPongoDatabaseDriver = PongoDatabaseDriver<
   AnyPongoDatabaseDriverOptions
 >;
 
-export type ExtractDatabaseDriverOptions<DatabaseDriver> =
+export type ExtractPongoDatabaseDriverOptions<DatabaseDriver> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   DatabaseDriver extends PongoDatabaseDriver<any, infer O> ? O : never;
 
-export type ExtractDatabaseTypeFromDriver<DatabaseDriver> =
+export type ExtractPongoDatabaseTypeFromDriver<DatabaseDriver> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   DatabaseDriver extends PongoDatabaseDriver<infer D, any> ? D : never;
 

--- a/src/packages/pongo/src/core/pongoClient.connections.int.spec.ts
+++ b/src/packages/pongo/src/core/pongoClient.connections.int.spec.ts
@@ -1,5 +1,5 @@
+import { dumbo } from '@event-driven-io/dumbo';
 import {
-  dumbo,
   isNodePostgresNativePool,
   PostgreSQLConnectionString,
 } from '@event-driven-io/dumbo/pg';

--- a/src/packages/pongo/src/core/pongoClient.ts
+++ b/src/packages/pongo/src/core/pongoClient.ts
@@ -5,7 +5,7 @@ import {
 import { PongoDatabaseCache } from './database';
 import type {
   AnyPongoDatabaseDriver,
-  ExtractDatabaseTypeFromDriver,
+  ExtractPongoDatabaseTypeFromDriver,
 } from './drivers';
 import { pongoSession } from './pongoSession';
 import {
@@ -34,7 +34,7 @@ export const pongoClient = <
   >,
 ): PongoClient<
   DatabaseDriver['driverType'],
-  ExtractDatabaseTypeFromDriver<DatabaseDriver>
+  ExtractPongoDatabaseTypeFromDriver<DatabaseDriver>
 > &
   PongoClientWithSchema<TypedClientSchema> => {
   const { driver, connectionString, schema, errors, ...connectionOptions } =
@@ -47,9 +47,8 @@ export const pongoClient = <
 
   const pongoClient: PongoClient<
     DatabaseDriver['driverType'],
-    ExtractDatabaseTypeFromDriver<DatabaseDriver>
+    ExtractPongoDatabaseTypeFromDriver<DatabaseDriver>
   > = {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     driverType: driver.driverType,
     connect: async () => {
       await dbClients.forAll((db) => db.connect());
@@ -58,7 +57,9 @@ export const pongoClient = <
     close: async () => {
       await dbClients.forAll((db) => db.close());
     },
-    db: (dbName?: string): ExtractDatabaseTypeFromDriver<DatabaseDriver> => {
+    db: (
+      dbName?: string,
+    ): ExtractPongoDatabaseTypeFromDriver<DatabaseDriver> => {
       const db = dbClients.getOrCreate({
         ...connectionOptions,
         connectionString,
@@ -66,8 +67,7 @@ export const pongoClient = <
         errors,
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return db as ExtractDatabaseTypeFromDriver<DatabaseDriver>;
+      return db as ExtractPongoDatabaseTypeFromDriver<DatabaseDriver>;
     },
     startSession: pongoSession,
     withSession: async <T>(

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -16,7 +16,7 @@ import type { PongoCollectionSchemaComponent } from '../collection';
 import type { PongoDatabaseSchemaComponent } from '../database/pongoDatabaseSchemaComponent';
 import type {
   AnyPongoDatabaseDriver,
-  ExtractDatabaseDriverOptions,
+  ExtractPongoDatabaseDriverOptions,
 } from '../drivers';
 import { ConcurrencyError } from '../errors';
 import type { PongoClientSchema } from '../schema';
@@ -55,7 +55,7 @@ export type PongoClientOptions<
     | { autoMigration?: MigrationStyle; definition?: TypedClientSchema }
     | undefined;
   errors?: { throwOnOperationFailures?: boolean } | undefined;
-} & Omit<ExtractDatabaseDriverOptions<DatabaseDriver>, 'driver'>;
+} & Omit<ExtractPongoDatabaseDriverOptions<DatabaseDriver>, 'driver'>;
 
 export declare interface PongoTransactionOptions {
   get snapshotEnabled(): boolean;

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -48,14 +48,19 @@ export type PongoClientOptions<
     InferDriverDatabaseType<DatabaseDriver['driverType']>
   >,
   TypedClientSchema extends PongoClientSchema = PongoClientSchema,
-> = {
-  driver: DatabaseDriver;
-  connectionString: ConnectionString | string;
-  schema?:
-    | { autoMigration?: MigrationStyle; definition?: TypedClientSchema }
-    | undefined;
-  errors?: { throwOnOperationFailures?: boolean } | undefined;
-} & Omit<ExtractPongoDatabaseDriverOptions<DatabaseDriver>, 'driver'>;
+> =
+  ExtractPongoDatabaseDriverOptions<DatabaseDriver> extends infer Options
+    ? Options extends unknown
+      ? {
+          driver: DatabaseDriver;
+          connectionString: ConnectionString | string;
+          schema?:
+            | { autoMigration?: MigrationStyle; definition?: TypedClientSchema }
+            | undefined;
+          errors?: { throwOnOperationFailures?: boolean } | undefined;
+        } & Omit<Options, 'driver'>
+      : never
+    : never;
 
 export declare interface PongoTransactionOptions {
   get snapshotEnabled(): boolean;

--- a/src/packages/pongo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/pg/index.ts
@@ -1,5 +1,6 @@
 import { dumbo } from '@event-driven-io/dumbo';
 import {
+  pgDatabaseDriver as dumboDriver,
   getDatabaseNameOrDefault,
   NodePostgresDriverType,
   type NodePostgresConnection,
@@ -70,6 +71,7 @@ const pgDatabaseDriver: PongoDatabaseDriver<
       ...options,
       pool: dumbo({
         connectionString: options.connectionString,
+        driver: dumboDriver,
         ...options.connectionOptions,
       }),
       schemaComponent: PongoDatabaseSchemaComponent({

--- a/src/packages/pongo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/pg/index.ts
@@ -1,5 +1,5 @@
+import { dumbo } from '@event-driven-io/dumbo';
 import {
-  dumbo,
   getDatabaseNameOrDefault,
   NodePostgresDriverType,
   type NodePostgresConnection,

--- a/src/packages/pongo/src/storage/postgresql/pg/migrations/migrations.int.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/pg/migrations/migrations.int.spec.ts
@@ -1,6 +1,5 @@
-import { SQL, type Dumbo } from '@event-driven-io/dumbo';
+import { dumbo, SQL, type Dumbo } from '@event-driven-io/dumbo';
 import {
-  dumbo,
   PostgreSQLConnectionString,
   tableExists,
 } from '@event-driven-io/dumbo/pg';


### PR DESCRIPTION
It's a follow-up to https://github.com/event-driven-io/Pongo/pull/127, where the Pongo database driver was introduced.

Dumbo now has a single function and either gets:
- driver,
- driver type,
- connection string.

For driverType and connection string, it has to do the resolution, and they need to be preregistered.
