### PR TITLE
Renamed NodePostgresql types and methods to pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pongo
 
-Pongo - Mongo but on Postgres and with strong consistency benefits.
+Pongo - Mongo but on PostgreSQL and with strong consistency benefits.
 
 ## Getting Started
 

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ![](/logo.png)
 
-Pongo is a MongoDB on Postgres and with strong consistency benefits.
+Pongo is a MongoDB on PostgreSQL and with strong consistency benefits.
 
 ## Getting Started
 

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 
 hero:
   name: 'Pongo'
-  text: 'Like Mongo<br/>But on Postgres<br/>And With<br/>Strong Consistency'
+  text: 'Like Mongo<br/>But on PostgreSQL<br/>And With<br/>Strong Consistency'
   tagline: 'Flexibility or Consistency? Why not both!'
   image:
     src: /logo.png

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/pongo-core",
   "version": "0.17.0-beta.8",
-  "description": "Pongo - Mongo with strong consistency on top of Postgres",
+  "description": "Pongo - Mongo with strong consistency on top of PostgreSQL",
   "type": "module",
   "engines": {
     "node": ">=22.20.0"

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.generic.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.generic.int.spec.ts
@@ -4,13 +4,13 @@ import {
 } from '@testcontainers/postgresql';
 import { after, before, describe, it } from 'node:test';
 import pg from 'pg';
-import { nodePostgresPool } from '.';
+import { pgPool } from '.';
 import { pgDatabaseDriver } from '..';
 import { SQL } from '../../../../core';
 import { dumbo } from '../../../all';
 import { endPool, getPool } from './pool';
 
-void describe('Node Postgresql', () => {
+void describe('pg', () => {
   let postgres: StartedPostgreSqlContainer;
   let connectionString: string;
 
@@ -23,7 +23,7 @@ void describe('Node Postgresql', () => {
     await postgres.stop();
   });
 
-  void describe('nodePostgresPool', () => {
+  void describe('pgPool', () => {
     void it('connects using default pool', async () => {
       const pool = dumbo({ connectionString, driver: pgDatabaseDriver });
       const connection = await pool.connection();
@@ -40,7 +40,7 @@ void describe('Node Postgresql', () => {
 
     void it('connects using ambient pool', async () => {
       const nativePool = getPool(connectionString);
-      const pool = nodePostgresPool({ connectionString, pool: nativePool });
+      const pool = pgPool({ connectionString, pool: nativePool });
       const connection = await pool.connection();
 
       try {
@@ -53,7 +53,7 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using client', async () => {
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         pooled: false,
       });
@@ -71,7 +71,7 @@ void describe('Node Postgresql', () => {
       const existingClient = new pg.Client({ connectionString });
       await existingClient.connect();
 
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         client: existingClient,
       });
@@ -87,11 +87,11 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using connected ambient connected connection', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
       await ambientConnection.open();
 
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         connection: ambientConnection,
       });
@@ -106,10 +106,10 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using connected ambient not-connected connection', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
 
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         connection: ambientConnection,
       });
@@ -124,13 +124,13 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient connected connection with transaction', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
       await ambientConnection.open();
 
       try {
         await ambientConnection.withTransaction<void>(async () => {
-          const pool = nodePostgresPool({
+          const pool = pgPool({
             connectionString,
             connection: ambientConnection,
           });
@@ -149,12 +149,12 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient not-connected connection with transaction', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
 
       try {
         await ambientConnection.withTransaction<void>(async () => {
-          const pool = nodePostgresPool({
+          const pool = pgPool({
             connectionString,
             connection: ambientConnection,
           });
@@ -173,10 +173,10 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient connection in withConnection scope', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       try {
         await ambientPool.withConnection(async (ambientConnection) => {
-          const pool = nodePostgresPool({
+          const pool = pgPool({
             connectionString,
             connection: ambientConnection,
           });
@@ -194,11 +194,11 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient connection in withConnection and withTransaction scope', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       try {
         await ambientPool.withConnection((ambientConnection) =>
           ambientConnection.withTransaction<void>(async () => {
-            const pool = nodePostgresPool({
+            const pool = pgPool({
               connectionString,
               connection: ambientConnection,
             });

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.int.spec.ts
@@ -4,11 +4,11 @@ import {
 } from '@testcontainers/postgresql';
 import { after, before, describe, it } from 'node:test';
 import pg from 'pg';
-import { nodePostgresPool } from '.';
+import { pgPool } from '.';
 import { SQL } from '../../../../core';
 import { endPool, getPool } from './pool';
 
-void describe('Node Postgresql', () => {
+void describe('pg', () => {
   let postgres: StartedPostgreSqlContainer;
   let connectionString: string;
 
@@ -21,9 +21,9 @@ void describe('Node Postgresql', () => {
     await postgres.stop();
   });
 
-  void describe('nodePostgresPool', () => {
+  void describe('pgPool', () => {
     void it('connects using default pool', async () => {
-      const pool = nodePostgresPool({ connectionString });
+      const pool = pgPool({ connectionString });
       const connection = await pool.connection();
 
       try {
@@ -38,7 +38,7 @@ void describe('Node Postgresql', () => {
 
     void it('connects using ambient pool', async () => {
       const nativePool = getPool(connectionString);
-      const pool = nodePostgresPool({ connectionString, pool: nativePool });
+      const pool = pgPool({ connectionString, pool: nativePool });
       const connection = await pool.connection();
 
       try {
@@ -51,7 +51,7 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using client', async () => {
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         pooled: false,
       });
@@ -69,7 +69,7 @@ void describe('Node Postgresql', () => {
       const existingClient = new pg.Client({ connectionString });
       await existingClient.connect();
 
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         client: existingClient,
       });
@@ -85,11 +85,11 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using connected ambient connected connection', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
       await ambientConnection.open();
 
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         connection: ambientConnection,
       });
@@ -104,10 +104,10 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using connected ambient not-connected connection', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
 
-      const pool = nodePostgresPool({
+      const pool = pgPool({
         connectionString,
         connection: ambientConnection,
       });
@@ -122,13 +122,13 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient connected connection with transaction', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
       await ambientConnection.open();
 
       try {
         await ambientConnection.withTransaction<void>(async () => {
-          const pool = nodePostgresPool({
+          const pool = pgPool({
             connectionString,
             connection: ambientConnection,
           });
@@ -147,12 +147,12 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient not-connected connection with transaction', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       const ambientConnection = await ambientPool.connection();
 
       try {
         await ambientConnection.withTransaction<void>(async () => {
-          const pool = nodePostgresPool({
+          const pool = pgPool({
             connectionString,
             connection: ambientConnection,
           });
@@ -171,10 +171,10 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient connection in withConnection scope', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       try {
         await ambientPool.withConnection(async (ambientConnection) => {
-          const pool = nodePostgresPool({
+          const pool = pgPool({
             connectionString,
             connection: ambientConnection,
           });
@@ -192,11 +192,11 @@ void describe('Node Postgresql', () => {
     });
 
     void it('connects using ambient connection in withConnection and withTransaction scope', async () => {
-      const ambientPool = nodePostgresPool({ connectionString });
+      const ambientPool = pgPool({ connectionString });
       try {
         await ambientPool.withConnection((ambientConnection) =>
           ambientConnection.withTransaction<void>(async () => {
-            const pool = nodePostgresPool({
+            const pool = pgPool({
               connectionString,
               connection: ambientConnection,
             });

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
@@ -1,92 +1,83 @@
 import pg from 'pg';
 import { createConnection, type Connection } from '../../../../core';
 import type { PostgreSQLDriverType } from '../../core';
-import { nodePostgresSQLExecutor } from '../execute';
-import { nodePostgresTransaction } from './transaction';
+import { pgSQLExecutor } from '../execute';
+import { pgTransaction } from './transaction';
 
-export type NodePostgresDriverType = PostgreSQLDriverType<'pg'>;
-export const NodePostgresDriverType: NodePostgresDriverType = 'PostgreSQL:pg';
+export type PgDriverType = PostgreSQLDriverType<'pg'>;
+export const PgDriverType: PgDriverType = 'PostgreSQL:pg';
 
-export type NodePostgresPoolClient = pg.PoolClient;
-export type NodePostgresClient = pg.Client;
+export type PgPoolClient = pg.PoolClient;
+export type PgClient = pg.Client;
 
-export type NodePostgresClientOrPoolClient =
-  | NodePostgresPoolClient
-  | NodePostgresClient;
+export type PgClientOrPoolClient = PgPoolClient | PgClient;
 
-export type NodePostgresPoolOrClient =
-  | pg.Pool
-  | NodePostgresPoolClient
-  | NodePostgresClient;
+export type PgPoolOrClient = pg.Pool | PgPoolClient | PgClient;
 
-export type NodePostgresClientConnection = Connection<
-  NodePostgresClientConnection,
-  NodePostgresDriverType,
-  NodePostgresClient
+export type PgClientConnection = Connection<
+  PgClientConnection,
+  PgDriverType,
+  PgClient
 >;
 
-export type NodePostgresPoolClientConnection = Connection<
-  NodePostgresPoolClientConnection,
-  NodePostgresDriverType,
-  NodePostgresPoolClient
+export type PgPoolClientConnection = Connection<
+  PgPoolClientConnection,
+  PgDriverType,
+  PgPoolClient
 >;
 
-export type NodePostgresConnection =
-  | NodePostgresPoolClientConnection
-  | NodePostgresClientConnection;
+export type PgConnection = PgPoolClientConnection | PgClientConnection;
 
-export type NodePostgresPoolClientOptions = {
+export type PgPoolClientOptions = {
   type: 'PoolClient';
-  connect: () => Promise<NodePostgresPoolClient>;
-  close: (client: NodePostgresPoolClient) => Promise<void>;
+  connect: () => Promise<PgPoolClient>;
+  close: (client: PgPoolClient) => Promise<void>;
 };
 
-export type NodePostgresClientOptions = {
+export type PgClientOptions = {
   type: 'Client';
-  connect: () => Promise<NodePostgresClient>;
-  close: (client: NodePostgresClient) => Promise<void>;
+  connect: () => Promise<PgClient>;
+  close: (client: PgClient) => Promise<void>;
 };
 
-export const nodePostgresClientConnection = (
-  options: NodePostgresClientOptions,
-): NodePostgresClientConnection => {
+export const pgClientConnection = (
+  options: PgClientOptions,
+): PgClientConnection => {
   const { connect, close } = options;
 
   return createConnection({
-    driverType: NodePostgresDriverType,
+    driverType: PgDriverType,
     connect,
     close,
-    initTransaction: (connection) => nodePostgresTransaction(connection),
-    executor: nodePostgresSQLExecutor,
+    initTransaction: (connection) => pgTransaction(connection),
+    executor: pgSQLExecutor,
   });
 };
 
-export const nodePostgresPoolClientConnection = (
-  options: NodePostgresPoolClientOptions,
-): NodePostgresPoolClientConnection => {
+export const pgPoolClientConnection = (
+  options: PgPoolClientOptions,
+): PgPoolClientConnection => {
   const { connect, close } = options;
 
   return createConnection({
-    driverType: NodePostgresDriverType,
+    driverType: PgDriverType,
     connect,
     close,
-    initTransaction: (connection) => nodePostgresTransaction(connection),
-    executor: nodePostgresSQLExecutor,
+    initTransaction: (connection) => pgTransaction(connection),
+    executor: pgSQLExecutor,
   });
 };
 
-export function nodePostgresConnection(
-  options: NodePostgresPoolClientOptions,
-): NodePostgresPoolClientConnection;
-export function nodePostgresConnection(
-  options: NodePostgresClientOptions,
-): NodePostgresClientConnection;
-export function nodePostgresConnection(
-  options: NodePostgresPoolClientOptions | NodePostgresClientOptions,
-): NodePostgresPoolClientConnection | NodePostgresClientConnection {
+export function pgConnection(
+  options: PgPoolClientOptions,
+): PgPoolClientConnection;
+export function pgConnection(options: PgClientOptions): PgClientConnection;
+export function pgConnection(
+  options: PgPoolClientOptions | PgClientOptions,
+): PgPoolClientConnection | PgClientConnection {
   return options.type === 'Client'
-    ? nodePostgresClientConnection(options)
-    : nodePostgresPoolClientConnection(options);
+    ? pgClientConnection(options)
+    : pgPoolClientConnection(options);
 }
 
 export type ConnectionCheckResult =

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
@@ -4,28 +4,27 @@ import {
   type DatabaseTransaction,
   type DatabaseTransactionOptions,
 } from '../../../../core';
-import { nodePostgresSQLExecutor } from '../execute';
+import { pgSQLExecutor } from '../execute';
 import {
-  NodePostgresDriverType,
-  type NodePostgresConnection,
-  type NodePostgresPoolOrClient,
+  PgDriverType,
+  type PgConnection,
+  type PgPoolOrClient,
 } from './connection';
 
-export type NodePostgresTransaction =
-  DatabaseTransaction<NodePostgresConnection>;
+export type PgTransaction = DatabaseTransaction<PgConnection>;
 
-export const nodePostgresTransaction =
+export const pgTransaction =
   <ConnectionType extends AnyConnection = AnyConnection>(
     connection: () => ConnectionType,
   ) =>
-  <DbClient extends NodePostgresPoolOrClient = NodePostgresPoolOrClient>(
+  <DbClient extends PgPoolOrClient = PgPoolOrClient>(
     getClient: Promise<DbClient>,
     options?: {
       close: (client: DbClient, error?: unknown) => Promise<void>;
     } & DatabaseTransactionOptions,
   ): DatabaseTransaction<ConnectionType> => ({
     connection: connection(),
-    driverType: NodePostgresDriverType,
+    driverType: PgDriverType,
     begin: async () => {
       const client = await getClient;
       await client.query('BEGIN');
@@ -47,7 +46,7 @@ export const nodePostgresTransaction =
         if (options?.close) await options?.close(client, error);
       }
     },
-    execute: sqlExecutor(nodePostgresSQLExecutor(), {
+    execute: sqlExecutor(pgSQLExecutor(), {
       connect: () => getClient,
     }),
   });

--- a/src/packages/dumbo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/index.ts
@@ -10,11 +10,11 @@ import {
   PostgreSQLConnectionString,
 } from '../core';
 import {
-  type NodePostgresConnection,
-  NodePostgresDriverType,
-  type NodePostgresPool,
-  nodePostgresPool,
-  type NodePostgresPoolOptions,
+  type PgConnection,
+  PgDriverType,
+  pgPool,
+  type PgPool,
+  type PgPoolOptions,
 } from './connections';
 
 const tryParseConnectionString = (connectionString: string) => {
@@ -26,25 +26,22 @@ const tryParseConnectionString = (connectionString: string) => {
 };
 
 export const pgDatabaseDriver: DumboDatabaseDriver<
-  NodePostgresConnection,
-  NodePostgresPoolOptions
+  PgConnection,
+  PgPoolOptions
 > = {
-  driverType: NodePostgresDriverType,
-  createPool: (options) => nodePostgresPool(options as NodePostgresPoolOptions),
+  driverType: PgDriverType,
+  createPool: (options) => pgPool(options as PgPoolOptions),
   sqlFormatter: pgFormatter,
   defaultMigratorOptions: DefaultPostgreSQLMigratorOptions,
   getDatabaseNameOrDefault,
   canHandle: canHandleDriverWithConnectionString(
-    NodePostgresDriverType,
+    PgDriverType,
     tryParseConnectionString,
   ),
 };
 
 export const usePgDatabaseDriver = () => {
-  dumboDatabaseDriverRegistry.register(
-    NodePostgresDriverType,
-    pgDatabaseDriver,
-  );
+  dumboDatabaseDriverRegistry.register(PgDriverType, pgDatabaseDriver);
 };
 
 usePgDatabaseDriver();
@@ -55,13 +52,10 @@ export * from './serialization';
 
 export { pgDatabaseDriver as databaseDriver };
 
-// TODO: Remove stuff below
+export type PostgreSQLPool = PgPool;
+export type PostgreSQLConnection = PgConnection;
 
-export type PostgresDriverType = NodePostgresDriverType;
-export type PostgresPool = NodePostgresPool;
-export type PostgresConnection = NodePostgresConnection;
-
-export type PostgresPoolOptions = NodePostgresPoolOptions;
-export const postgresPool = nodePostgresPool;
+export type PostgreSQLPoolOptions = PgPoolOptions;
+export const postgresPool = pgPool;
 
 export const connectionPool = postgresPool;

--- a/src/packages/dumbo/src/storage/postgresql/pg/serialization/index.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/serialization/index.ts
@@ -1,7 +1,7 @@
 import pg from 'pg';
 import { JSONSerializer } from '../../../../core/serializer';
 
-export const setNodePostgresTypeParser = (jsonSerializer: JSONSerializer) => {
+export const setPgTypeParser = (jsonSerializer: JSONSerializer) => {
   // BigInt
   pg.types.setTypeParser(20, (val) => BigInt(val));
 

--- a/src/packages/pongo/package.json
+++ b/src/packages/pongo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@event-driven-io/pongo",
   "version": "0.17.0-beta.8",
-  "description": "Pongo - Mongo with strong consistency on top of Postgres",
+  "description": "Pongo - Mongo with strong consistency on top of PostgreSQL",
   "type": "module",
   "scripts": {
     "build": "tsup",

--- a/src/packages/pongo/src/core/pongoClient.connections.int.spec.ts
+++ b/src/packages/pongo/src/core/pongoClient.connections.int.spec.ts
@@ -1,6 +1,6 @@
 import { dumbo } from '@event-driven-io/dumbo';
 import {
-  isNodePostgresNativePool,
+  isPgNativePool,
   PostgreSQLConnectionString,
 } from '@event-driven-io/dumbo/pg';
 import {
@@ -37,7 +37,7 @@ void describe('Pongo collection', () => {
     const pongo = pongoClient({
       driver: databaseDriver,
       connectionString,
-      connectionOptions: isNodePostgresNativePool(poolOrClient)
+      connectionOptions: isPgNativePool(poolOrClient)
         ? undefined
         : {
             client: poolOrClient,

--- a/src/packages/pongo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/pg/index.ts
@@ -2,8 +2,8 @@ import { dumbo } from '@event-driven-io/dumbo';
 import {
   pgDatabaseDriver as dumboDriver,
   getDatabaseNameOrDefault,
-  NodePostgresDriverType,
-  type NodePostgresConnection,
+  PgDriverType,
+  type PgConnection,
 } from '@event-driven-io/dumbo/pg';
 import pg from 'pg';
 import {
@@ -21,7 +21,7 @@ import {
   postgresSQLBuilder,
 } from '../core';
 
-export type NodePostgresPongoClientOptions =
+export type PgPongoClientOptions =
   | PooledPongoClientOptions
   | NotPooledPongoOptions;
 
@@ -50,21 +50,21 @@ export type NotPooledPongoOptions =
       pooled: false;
     }
   | {
-      connection: NodePostgresConnection;
+      connection: PgConnection;
       pooled?: false;
     };
 
-type NodePostgresDatabaseDriverOptions =
-  PongoDatabaseDriverOptions<NodePostgresPongoClientOptions> & {
+type PgDatabaseDriverOptions =
+  PongoDatabaseDriverOptions<PgPongoClientOptions> & {
     databaseName?: string | undefined;
     connectionString: string;
   };
 
 const pgDatabaseDriver: PongoDatabaseDriver<
-  PongoDb<NodePostgresDriverType>,
-  NodePostgresDatabaseDriverOptions
+  PongoDb<PgDriverType>,
+  PgDatabaseDriverOptions
 > = {
-  driverType: NodePostgresDriverType,
+  driverType: PgDriverType,
   databaseFactory: (options) => {
     const databaseName =
       options.databaseName ??
@@ -78,10 +78,10 @@ const pgDatabaseDriver: PongoDatabaseDriver<
         ...options.connectionOptions,
       }),
       schemaComponent: PongoDatabaseSchemaComponent({
-        driverType: NodePostgresDriverType,
+        driverType: PgDriverType,
         collectionFactory: (schema) =>
           PongoCollectionSchemaComponent({
-            driverType: NodePostgresDriverType,
+            driverType: PgDriverType,
             definition: schema,
             migrationsOrSchemaComponents: {
               migrations: pongoCollectionPostgreSQLMigrations(schema.name),
@@ -103,10 +103,7 @@ const pgDatabaseDriver: PongoDatabaseDriver<
 };
 
 export const usePgDatabaseDriver = () => {
-  pongoDatabaseDriverRegistry.register(
-    NodePostgresDriverType,
-    pgDatabaseDriver,
-  );
+  pongoDatabaseDriverRegistry.register(PgDriverType, pgDatabaseDriver);
 };
 
 usePgDatabaseDriver();


### PR DESCRIPTION
This will make a consistent convention and more intuitive based on the driver NPM package name.

This is a breaking change, but we'll have more in 0.17.0, and I planned to clean it up for a longer time.