### PR TITLE
Fixed error mapping in Cloudflare D1 transactions

### DIFF
--- a/src/packages/dumbo/src/storage/postgresql/core/errors/errorMapper.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/errors/errorMapper.ts
@@ -49,6 +49,8 @@ const asError = (error: unknown): Error | undefined =>
  * Falls back to a generic DumboError (500) if the error is not a recognized PostgreSQL error.
  */
 export const mapPostgresError = (error: unknown): DumboError => {
+  if (DumboError.isInstanceOf<DumboError>(error)) return error;
+
   const code = getPostgresErrorCode(error);
   if (!code)
     return new DumboError({

--- a/src/packages/dumbo/src/storage/postgresql/core/errors/errorMapper.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/core/errors/errorMapper.unit.spec.ts
@@ -357,4 +357,27 @@ void describe('mapPostgresError', () => {
       assert.strictEqual(result.errorCode, 500);
     });
   });
+
+  void describe('DumboError passthrough', () => {
+    void it('returns the same DumboError if error is already a DumboError', () => {
+      const original = new UniqueConstraintError('already mapped');
+      const result = mapPostgresError(original);
+      assert.strictEqual(result, original);
+    });
+
+    void it('returns the same IntegrityConstraintViolationError', () => {
+      const original = new IntegrityConstraintViolationError('already mapped');
+      const result = mapPostgresError(original);
+      assert.strictEqual(result, original);
+    });
+
+    void it('returns the same generic DumboError', () => {
+      const original = new DumboError({
+        errorCode: 500,
+        message: 'already mapped',
+      });
+      const result = mapPostgresError(original);
+      assert.strictEqual(result, original);
+    });
+  });
 });

--- a/src/packages/dumbo/src/storage/sqlite/core/errors/errorMapper.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/errors/errorMapper.ts
@@ -85,6 +85,8 @@ const mapConstraintError = (
  * Falls back to a generic DumboError (500) if the error is not a recognized SQLite error.
  */
 export const mapSqliteError = (error: unknown): DumboError => {
+  if (DumboError.isInstanceOf<DumboError>(error)) return error;
+
   const code = getSqliteErrorCode(error);
   if (!code)
     return new DumboError({

--- a/src/packages/dumbo/src/storage/sqlite/core/errors/errorMapper.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/errors/errorMapper.unit.spec.ts
@@ -484,4 +484,27 @@ void describe('mapSqliteError', () => {
       );
     });
   });
+
+  void describe('DumboError passthrough', () => {
+    void it('returns the same DumboError if error is already a DumboError', () => {
+      const original = new UniqueConstraintError('already mapped');
+      const result = mapSqliteError(original);
+      assert.strictEqual(result, original);
+    });
+
+    void it('returns the same IntegrityConstraintViolationError', () => {
+      const original = new IntegrityConstraintViolationError('already mapped');
+      const result = mapSqliteError(original);
+      assert.strictEqual(result, original);
+    });
+
+    void it('returns the same generic DumboError', () => {
+      const original = new DumboError({
+        errorCode: 500,
+        message: 'already mapped',
+      });
+      const result = mapSqliteError(original);
+      assert.strictEqual(result, original);
+    });
+  });
 });

--- a/src/packages/dumbo/src/storage/sqlite/d1/errors/errorMapper.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/errors/errorMapper.ts
@@ -159,6 +159,8 @@ const mapEmbeddedSqliteCode = (
  * Falls back to a generic DumboError (500) if the error is not a recognized D1 error.
  */
 export const mapD1Error = (error: unknown): DumboError => {
+  if (DumboError.isInstanceOf<DumboError>(error)) return error;
+
   const message = getErrorMessage(error);
   if (!message)
     return new DumboError({

--- a/src/packages/dumbo/src/storage/sqlite/d1/errors/errorMapper.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/errors/errorMapper.unit.spec.ts
@@ -551,4 +551,27 @@ void describe('mapD1Error', () => {
       assert.strictEqual(result.message, msg);
     });
   });
+
+  void describe('DumboError passthrough', () => {
+    void it('returns the same DumboError if error is already a DumboError', () => {
+      const original = new UniqueConstraintError('already mapped');
+      const result = mapD1Error(original);
+      assert.strictEqual(result, original);
+    });
+
+    void it('returns the same IntegrityConstraintViolationError', () => {
+      const original = new IntegrityConstraintViolationError('already mapped');
+      const result = mapD1Error(original);
+      assert.strictEqual(result, original);
+    });
+
+    void it('returns the same generic DumboError', () => {
+      const original = new DumboError({
+        errorCode: 500,
+        message: 'already mapped',
+      });
+      const result = mapD1Error(original);
+      assert.strictEqual(result, original);
+    });
+  });
 });

--- a/src/packages/dumbo/src/storage/sqlite/d1/execute/d1SqlExecutor.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/execute/d1SqlExecutor.ts
@@ -11,10 +11,8 @@ import { sqliteFormatter } from '../../core';
 import type { D1Client, D1DriverType } from '../connections';
 import { mapD1Error } from '../errors/errorMapper';
 
-export const d1SQLExecutor = (
-  driverType: D1DriverType,
-): DbSQLExecutor<D1DriverType, D1Client> => ({
-  driverType,
+export const d1SQLExecutor = (): DbSQLExecutor<D1DriverType, D1Client> => ({
+  driverType: 'SQLite:d1',
   formatter: sqliteFormatter,
 
   query: async <Result extends QueryResultRow>(

--- a/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
@@ -4,13 +4,14 @@ import {
   type DatabaseTransaction,
   type DatabaseTransactionOptions,
 } from '../../../../core';
-import { sqliteSQLExecutor, transactionNestingCounter } from '../../core';
+import { transactionNestingCounter } from '../../core';
 import {
   D1DriverType,
   type D1Client,
   type D1Connection,
   type D1SessionOptions,
 } from '../connections';
+import { d1SQLExecutor } from '../execute';
 
 export type D1Transaction = DatabaseTransaction<D1Connection>;
 
@@ -116,7 +117,7 @@ export const d1Transaction =
           if (options?.close) await options?.close(client, error);
         }
       },
-      execute: sqlExecutor(sqliteSQLExecutor(D1DriverType, serializer), {
+      execute: sqlExecutor(d1SQLExecutor(), {
         connect: () => {
           if (!sessionClient) {
             throw new Error(


### PR DESCRIPTION
Also ensured that Dumbo errors are passed through error mapping.

A follow up to https://github.com/event-driven-io/Pongo/pull/155.