### PR TITLE
Fix short form flags in Pongo CLI

### DIFF
--- a/src/packages/pongo/src/commandLine/configFile.ts
+++ b/src/packages/pongo/src/commandLine/configFile.ts
@@ -148,7 +148,7 @@ configCommand
   .command('sample')
   .description('Generate or print sample configuration')
   .option(
-    '-col, --collection <name>',
+    '--col, --collection <name>',
     'Specify the collection name',
     (value: string, previous: string[]) => {
       // Accumulate collection names into an array (explicitly typing `previous` as `string[]`)

--- a/src/packages/pongo/src/commandLine/migrate.ts
+++ b/src/packages/pongo/src/commandLine/migrate.ts
@@ -45,25 +45,25 @@ migrateCommand
   .command('run')
   .description('Run database migrations')
   .option(
-    '-dbt, --database-type <string>',
+    '--dbt, --database-type <string>',
     'Database type that should be used for connection (e.g., PostgreSQL or SQLite)',
     undefined,
   )
   .option(
-    '-drv, --database-driver <string>',
+    '--drv, --database-driver <string>',
     'Database driver that should be used for connection (e.g., "pg" for PostgreSQL, "sqlite3" for SQLite)',
   )
   .option(
-    '-dbn, --database-name <string>',
+    '--dbn, --database-name <string>',
     'Database name to connect to',
     undefined,
   )
   .option(
-    '-cs, --connection-string <string>',
+    '--cs, --connection-string <string>',
     'Connection string for the database',
   )
   .option(
-    '-col, --collection <name>',
+    '--col, --collection <name>',
     'Specify the collection name',
     (value: string, previous: string[]) => {
       // Accumulate collection names into an array (explicitly typing `previous` as `string[]`)
@@ -72,7 +72,7 @@ migrateCommand
     [] as string[],
   )
   .option('-f, --config <path>', 'Path to configuration file with Pongo config')
-  .option('-dr, --dryRun', 'Perform dry run without commiting changes', false)
+  .option('--dr, --dryRun', 'Perform dry run without commiting changes', false)
   .action(async (options: MigrateRunOptions) => {
     const { collection, dryRun, databaseName, databaseDriver } = options;
     const connectionString =
@@ -125,20 +125,20 @@ migrateCommand
   .command('sql')
   .description('Generate SQL for database migration')
   .option(
-    '-dbt, --database-type <string>',
+    '--dbt, --database-type <string>',
     'Database type that should be used for connection (e.g., PostgreSQL or SQLite)',
   )
   .option(
-    '-drv, --database-driver <string>',
+    '--drv, --database-driver <string>',
     'Database driver that should be used for connection (e.g., "pg" for PostgreSQL, "sqlite3" for SQLite)',
   )
   .option(
-    '-dbn, --database-name <string>',
+    '--dbn, --database-name <string>',
     'Database name to connect to',
     undefined,
   )
   .option(
-    '-col, --collection <name>',
+    '--col, --collection <name>',
     'Specify the collection name',
     (value: string, previous: string[]) => {
       // Accumulate collection names into an array (explicitly typing `previous` as `string[]`)

--- a/src/packages/pongo/src/commandLine/shell.ts
+++ b/src/packages/pongo/src/commandLine/shell.ts
@@ -299,17 +299,17 @@ interface ShellOptions {
 const shellCommand = new Command('shell')
   .description('Start an interactive Pongo shell')
   .option(
-    '-drv, --database-driver <string>',
+    '--drv, --database-driver <string>',
     'Database driver that should be used for connection (e.g., "pg" for PostgreSQL, "sqlite3" for SQLite)',
     'pg',
   )
   .option(
-    '-cs, --connectionString <string>',
+    '--cs, --connectionString <string>',
     'Connection string for the database',
   )
-  .option('-db, --database <string>', 'Database name to connect', 'postgres')
+  .option('--db, --database <string>', 'Database name to connect', 'postgres')
   .option(
-    '-col, --collection <name>',
+    '--col, --collection <name>',
     'Specify the collection name',
     (value: string, previous: string[]) => {
       // Accumulate collection names into an array (explicitly typing `previous` as `string[]`)
@@ -318,16 +318,16 @@ const shellCommand = new Command('shell')
     [] as string[],
   )
   .option(
-    '-no-migrations, --disable-auto-migrations',
+    '--no-migrations, --disable-auto-migrations',
     'Disable automatic migrations',
   )
   .option('-o, --print-options', 'Print shell options')
   .option(
-    '-ll, --log-level <logLevel>',
+    '--ll, --log-level <logLevel>',
     'Log level: DISABLED, INFO, LOG, WARN, ERROR',
     'DISABLED',
   )
-  .option('-ls, --log-style', 'Log style: RAW, PRETTY', 'RAW')
+  .option('--ls, --log-style', 'Log style: RAW, PRETTY', 'RAW')
   .option('-p, --pretty-log', 'Turn on logging with prettified output')
   .action(async (options: ShellOptions) => {
     const { collection, database } = options;


### PR DESCRIPTION
According to the docs, short flags should be single character if meant to be used with a single dash (https://www.npmjs.com/package/commander#options). I noticed that when I tried to use the CLI and got this error:

```
Error: option creation failed due to '-col' in option flags '-col, --collection <name>'
```