### PR TITLE
Added transaction levels to Dumbo

### DIFF
--- a/src/packages/dumbo/src/core/connections/connection.ts
+++ b/src/packages/dumbo/src/core/connections/connection.ts
@@ -69,6 +69,10 @@ export type ConnectionFactory<
   ConnectionType extends AnyConnection = AnyConnection,
 > = (options: ConnectionOptions<ConnectionType>) => ConnectionType;
 
+export type WithConnectionOptions = {
+  readonly?: boolean;
+};
+
 export interface WithConnectionFactory<
   ConnectionType extends AnyConnection = AnyConnection,
 > {
@@ -76,6 +80,7 @@ export interface WithConnectionFactory<
 
   withConnection: <Result = unknown>(
     handle: (connection: ConnectionType) => Promise<Result>,
+    options?: WithConnectionOptions,
   ) => Promise<Result>;
 }
 

--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -9,6 +9,7 @@ import type {
   AnyConnection,
   InferDbClientFromConnection,
   WithConnectionFactory,
+  WithConnectionOptions,
 } from './connection';
 import {
   transactionFactoryWithAmbientConnection,
@@ -55,7 +56,7 @@ export const createAmbientConnectionPool = <
     getConnection: () => connection,
     execute: connection.execute,
     transaction: (options) => connection.transaction(options),
-    withConnection: (handle) => handle(connection),
+    withConnection: (handle, _options?) => handle(connection),
     withTransaction: (handle, options) =>
       connection.withTransaction(handle, options),
   });
@@ -92,6 +93,7 @@ export const createSingletonConnectionPool = <
     }),
     withConnection: <Result>(
       handle: (connection: ConnectionType) => Promise<Result>,
+      _options?: WithConnectionOptions,
     ) =>
       executeInAmbientConnection<ConnectionType, Result>(handle, {
         connection: getExistingOrNewConnectionAsync,
@@ -178,7 +180,10 @@ export const createConnectionPool = <ConnectionType extends AnyConnection>(
   const withConnection =
     'withConnection' in pool
       ? pool.withConnection
-      : <Result>(handle: (connection: ConnectionType) => Promise<Result>) =>
+      : <Result>(
+          handle: (connection: ConnectionType) => Promise<Result>,
+          _options?: WithConnectionOptions,
+        ) =>
           executeInNewConnection<ConnectionType, Result>(handle, {
             connection,
           });

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -20,6 +20,7 @@ export type AnyDatabaseTransaction = DatabaseTransaction<any>;
 
 export type DatabaseTransactionOptions = {
   allowNestedTransactions?: boolean;
+  readonly?: boolean;
 };
 
 export interface WithDatabaseTransactionFactory<

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
@@ -1,9 +1,13 @@
 import pg from 'pg';
 import type { JSONSerializer } from '../../../../core';
-import { createConnection, type Connection } from '../../../../core';
+import {
+  createConnection,
+  type Connection,
+  type DatabaseTransaction,
+} from '../../../../core';
 import type { PostgreSQLDriverType } from '../../core';
 import { pgSQLExecutor } from '../execute';
-import { pgTransaction } from './transaction';
+import { pgTransaction, type PgTransactionOptions } from './transaction';
 
 export type PgDriverType = PostgreSQLDriverType<'pg'>;
 export const PgDriverType: PgDriverType = 'PostgreSQL:pg';
@@ -18,13 +22,17 @@ export type PgPoolOrClient = pg.Pool | PgPoolClient | PgClient;
 export type PgClientConnection = Connection<
   PgClientConnection,
   PgDriverType,
-  PgClient
+  PgClient,
+  DatabaseTransaction<PgClientConnection>,
+  PgTransactionOptions
 >;
 
 export type PgPoolClientConnection = Connection<
   PgPoolClientConnection,
   PgDriverType,
-  PgPoolClient
+  PgPoolClient,
+  DatabaseTransaction<PgPoolClientConnection>,
+  PgTransactionOptions
 >;
 
 export type PgConnection = PgPoolClientConnection | PgClientConnection;

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
@@ -5,6 +5,8 @@ import {
   JSONSerializer,
   tracer,
   type ConnectionPool,
+  type InferTransactionFromConnection,
+  type InferTransactionOptionsFromConnection,
   type JSONSerializationOptions,
 } from '../../../../core';
 import { defaultPostgreSqlDatabase, parseDatabaseName } from '../../core';
@@ -16,9 +18,17 @@ import {
   type PgPoolClientConnection,
 } from './connection';
 
-export type PgNativePool = ConnectionPool<PgPoolClientConnection>;
+export type PgNativePool = ConnectionPool<
+  PgPoolClientConnection,
+  InferTransactionFromConnection<PgPoolClientConnection>,
+  InferTransactionOptionsFromConnection<PgPoolClientConnection>
+>;
 
-export type PgAmbientClientPool = ConnectionPool<PgClientConnection>;
+export type PgAmbientClientPool = ConnectionPool<
+  PgClientConnection,
+  InferTransactionFromConnection<PgClientConnection>,
+  InferTransactionOptionsFromConnection<PgClientConnection>
+>;
 
 export type PgAmbientConnectionPool = ConnectionPool<
   PgPoolClientConnection | PgClientConnection

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
@@ -14,6 +14,16 @@ import {
 
 export type PgTransaction = DatabaseTransaction<PgConnection>;
 
+export type PgIsolationLevel =
+  | 'READ UNCOMMITTED'
+  | 'READ COMMITTED'
+  | 'REPEATABLE READ'
+  | 'SERIALIZABLE';
+
+export type PgTransactionOptions = DatabaseTransactionOptions & {
+  isolationLevel?: PgIsolationLevel;
+};
+
 export const pgTransaction =
   <ConnectionType extends AnyConnection = AnyConnection>(
     connection: () => ConnectionType,
@@ -23,13 +33,20 @@ export const pgTransaction =
     getClient: Promise<DbClient>,
     options?: {
       close: (client: DbClient, error?: unknown) => Promise<void>;
-    } & DatabaseTransactionOptions,
+    } & PgTransactionOptions,
   ): DatabaseTransaction<ConnectionType> => ({
     connection: connection(),
     driverType: PgDriverType,
     begin: async () => {
       const client = await getClient;
-      await client.query('BEGIN');
+      const parts = ['BEGIN'];
+      if (options?.isolationLevel) {
+        parts.push(`ISOLATION LEVEL ${options.isolationLevel}`);
+      }
+      if (options?.readonly) {
+        parts.push('READ ONLY');
+      }
+      await client.query(parts.join(' '));
     },
     commit: async () => {
       const client = await getClient;

--- a/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
@@ -11,6 +11,8 @@ import {
   createAmbientConnectionPool,
   createSingletonConnectionPool,
   type ConnectionPool,
+  type InferTransactionFromConnection,
+  type InferTransactionOptionsFromConnection,
 } from '../../../../core';
 
 export type SQLiteFileNameOrConnectionString =
@@ -37,7 +39,11 @@ export const isInMemoryDatabase = (
 
 export type SQLiteAmbientConnectionPool<
   SQLiteConnectionType extends AnySQLiteConnection = AnySQLiteConnection,
-> = ConnectionPool<SQLiteConnectionType>;
+> = ConnectionPool<
+  SQLiteConnectionType,
+  InferTransactionFromConnection<SQLiteConnectionType>,
+  InferTransactionOptionsFromConnection<SQLiteConnectionType>
+>;
 
 type SQLiteAmbientConnectionPoolOptions<
   SQLiteConnectionType extends AnySQLiteConnection = AnySQLiteConnection,
@@ -61,7 +67,9 @@ export const sqliteAmbientConnectionPool = <
   return createAmbientConnectionPool<SQLiteConnectionType>({
     driverType,
     connection: connection,
-  });
+  }) as unknown as SQLiteAmbientConnectionPool<
+    SQLiteConnectionType['driverType']
+  >;
 };
 
 type SQLiteSingletonConnectionPoolOptions<
@@ -80,7 +88,11 @@ type SQLiteSingletonConnectionPoolOptions<
 
 export type SQLiteSingletonConnectionPool<
   SQLiteConnectionType extends AnySQLiteConnection = AnySQLiteConnection,
-> = ConnectionPool<SQLiteConnectionType>;
+> = ConnectionPool<
+  SQLiteConnectionType,
+  InferTransactionFromConnection<SQLiteConnectionType>,
+  InferTransactionOptionsFromConnection<SQLiteConnectionType>
+>;
 
 export const sqliteSingletonConnectionPool = <
   SQLiteConnectionType extends AnySQLiteConnection = AnySQLiteConnection,
@@ -99,7 +111,7 @@ export const sqliteSingletonConnectionPool = <
   return createSingletonConnectionPool<SQLiteConnectionType>({
     driverType,
     getConnection: () => sqliteConnectionFactory(connectionOptions),
-  });
+  }) as unknown as SQLiteSingletonConnectionPool<SQLiteConnectionType>;
 };
 
 type SQLiteAlwaysNewPoolOptions<
@@ -118,7 +130,11 @@ type SQLiteAlwaysNewPoolOptions<
 
 export type SQLiteAlwaysNewConnectionPool<
   SQLiteConnectionType extends AnySQLiteConnection = AnySQLiteConnection,
-> = ConnectionPool<SQLiteConnectionType>;
+> = ConnectionPool<
+  SQLiteConnectionType,
+  InferTransactionFromConnection<SQLiteConnectionType>,
+  InferTransactionOptionsFromConnection<SQLiteConnectionType>
+>;
 
 export const sqliteAlwaysNewConnectionPool = <
   SQLiteConnectionType extends AnySQLiteConnection = AnySQLiteConnection,
@@ -134,7 +150,7 @@ export const sqliteAlwaysNewConnectionPool = <
   return createAlwaysNewConnectionPool<SQLiteConnectionType>({
     driverType,
     getConnection: () => sqliteConnectionFactory(connectionOptions),
-  });
+  }) as unknown as SQLiteAlwaysNewConnectionPool<SQLiteConnectionType>;
 };
 
 export type SQLitePoolOptions<
@@ -205,19 +221,19 @@ export function sqlitePool<
     return createAmbientConnectionPool<SQLiteConnectionType>({
       driverType,
       connection: options.connection,
-    });
+    }) as unknown as SQLitePool<SQLiteConnectionType>;
 
   if (options.singleton === true && options.sqliteConnectionFactory) {
     return createSingletonConnectionPool({
       driverType,
       getConnection: () =>
         options.sqliteConnectionFactory(options.connectionOptions),
-    });
+    }) as unknown as SQLitePool<SQLiteConnectionType>;
   }
 
   return createAlwaysNewConnectionPool({
     driverType,
     getConnection: () =>
       options.sqliteConnectionFactory!(options.connectionOptions!),
-  });
+  }) as unknown as SQLitePool<SQLiteConnectionType>;
 }

--- a/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
@@ -17,6 +17,12 @@ export type SQLiteTransaction<
   ConnectionType extends AnySQLiteConnection = AnySQLiteConnection,
 > = DatabaseTransaction<ConnectionType>;
 
+export type SQLiteTransactionMode = 'DEFERRED' | 'IMMEDIATE' | 'EXCLUSIVE';
+
+export type SQLiteTransactionOptions = DatabaseTransactionOptions & {
+  mode?: SQLiteTransactionMode;
+};
+
 export const sqliteTransaction =
   <ConnectionType extends AnySQLiteConnection = AnySQLiteConnection>(
     driverType: ConnectionType['driverType'],

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.ts
@@ -4,7 +4,6 @@ import {
   BatchCommandNoChangesError,
   SQL,
   type Connection,
-  type DatabaseTransactionOptions,
   type QueryResult,
   type QueryResultRow,
   type SQLQueryOptions,
@@ -16,6 +15,7 @@ import type {
   SQLiteDriverType,
   SQLiteFileNameOrConnectionString,
   SQLiteTransaction,
+  SQLiteTransactionOptions,
 } from '../../core';
 import {
   InMemorySQLiteDatabase,
@@ -54,7 +54,7 @@ export type SQLite3Connection<
   SQLite3DriverType,
   ClientType,
   SQLiteTransaction<SQLite3Connection>,
-  DatabaseTransactionOptions
+  SQLiteTransactionOptions
 >;
 
 export const sqlite3Client = (

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/transactions/transactions.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/transactions/transactions.int.spec.ts
@@ -354,6 +354,131 @@ void describe('SQLite3 Transactions', () => {
           await pool.close();
         }
       });
+
+      void it('accepts transaction mode DEFERRED', async () => {
+        const pool = sqlite3Pool({ fileName });
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE test_mode (id INTEGER PRIMARY KEY, value TEXT)`,
+          );
+          await pool.execute.command(
+            SQL`INSERT INTO test_mode (id, value) VALUES (1, 'test')`,
+          );
+
+          await pool.withTransaction<void>(
+            async (tx) => {
+              const result = await tx.execute.query(
+                SQL`SELECT value FROM test_mode WHERE id = 1`,
+              );
+              assert.strictEqual(result.rows[0]?.value, 'test');
+              return { success: true, result: undefined };
+            },
+            { mode: 'DEFERRED' },
+          );
+        } finally {
+          await pool.close();
+        }
+      });
+
+      void it('accepts transaction mode IMMEDIATE', async () => {
+        const pool = sqlite3Pool({ fileName });
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE test_mode_imm (id INTEGER PRIMARY KEY, value TEXT)`,
+          );
+          await pool.execute.command(
+            SQL`INSERT INTO test_mode_imm (id, value) VALUES (1, 'test')`,
+          );
+
+          await pool.withTransaction<void>(
+            async (tx) => {
+              const result = await tx.execute.query(
+                SQL`SELECT value FROM test_mode_imm WHERE id = 1`,
+              );
+              assert.strictEqual(result.rows[0]?.value, 'test');
+              return { success: true, result: undefined };
+            },
+            { mode: 'IMMEDIATE' },
+          );
+        } finally {
+          await pool.close();
+        }
+      });
+
+      void it('accepts transaction mode EXCLUSIVE', async () => {
+        const pool = sqlite3Pool({ fileName });
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE test_mode_exc (id INTEGER PRIMARY KEY, value TEXT)`,
+          );
+          await pool.execute.command(
+            SQL`INSERT INTO test_mode_exc (id, value) VALUES (1, 'test')`,
+          );
+
+          await pool.withTransaction<void>(
+            async (tx) => {
+              const result = await tx.execute.query(
+                SQL`SELECT value FROM test_mode_exc WHERE id = 1`,
+              );
+              assert.strictEqual(result.rows[0]?.value, 'test');
+              return { success: true, result: undefined };
+            },
+            { mode: 'EXCLUSIVE' },
+          );
+        } finally {
+          await pool.close();
+        }
+      });
+
+      void it('accepts readonly in transaction options', async () => {
+        const pool = sqlite3Pool({ fileName });
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE test_readonly (id INTEGER PRIMARY KEY, value TEXT)`,
+          );
+          await pool.execute.command(
+            SQL`INSERT INTO test_readonly (id, value) VALUES (1, 'test')`,
+          );
+
+          await pool.withTransaction<void>(
+            async (tx) => {
+              const result = await tx.execute.query(
+                SQL`SELECT value FROM test_readonly WHERE id = 1`,
+              );
+              assert.strictEqual(result.rows[0]?.value, 'test');
+              return { success: true, result: undefined };
+            },
+            { readonly: true },
+          );
+        } finally {
+          await pool.close();
+        }
+      });
+
+      void it('accepts both mode and readonly in transaction options', async () => {
+        const pool = sqlite3Pool({ fileName });
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE test_mode_readonly (id INTEGER PRIMARY KEY, value TEXT)`,
+          );
+          await pool.execute.command(
+            SQL`INSERT INTO test_mode_readonly (id, value) VALUES (1, 'test')`,
+          );
+
+          await pool.withTransaction<void>(
+            async (tx) => {
+              const result = await tx.execute.query(
+                SQL`SELECT value FROM test_mode_readonly WHERE id = 1`,
+              );
+              assert.strictEqual(result.rows[0]?.value, 'test');
+              return { success: true, result: undefined };
+            },
+            { mode: 'DEFERRED', readonly: true },
+          );
+        } finally {
+          await pool.close();
+        }
+      });
     });
   }
 });


### PR DESCRIPTION
![](https://media.tenor.com/-BoBrZCA9x4AAAAM/nba-basketball.gif)

Added also (naive sudo, but still) options to specify whether the connection is read-only. (This will be expanded later on.

**_Note:_** Currently, tests are super naive as they just check if the transaction didn't fail. I won't be testing transaction levels, but I'll need to add SQL tracker to check what's sent to the client. Still, I wasn't great at small PRs recently, so let's keep it out of scope for this one.