### PR TITLE
Added lazy resolution of Pongo driver type

### DIFF
--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -43,12 +43,17 @@ export type ConnectionPoolFactory<
   ConnectionPoolOptions = unknown,
 > = (options: ConnectionPoolOptions) => ConnectionPoolType;
 
+export type AmbientConnectionPoolOptions<ConnectionType extends AnyConnection> =
+  {
+    driverType: ConnectionType['driverType'];
+    connection: ConnectionType;
+  };
+
 export const createAmbientConnectionPool = <
   ConnectionType extends AnyConnection,
->(options: {
-  driverType: ConnectionType['driverType'];
-  connection: ConnectionType;
-}): ConnectionPool<ConnectionType> => {
+>(
+  options: AmbientConnectionPoolOptions<ConnectionType>,
+): ConnectionPool<ConnectionType> => {
   const { driverType, connection } = options;
 
   return createConnectionPool<ConnectionType>({
@@ -62,7 +67,7 @@ export const createAmbientConnectionPool = <
   });
 };
 
-export type CreateSingletonConnectionPoolOptions<
+export type SingletonConnectionPoolOptions<
   ConnectionType extends AnyConnection,
 > = {
   driverType: ConnectionType['driverType'];
@@ -73,7 +78,7 @@ export type CreateSingletonConnectionPoolOptions<
 export const createSingletonConnectionPool = <
   ConnectionType extends AnyConnection,
 >(
-  options: CreateSingletonConnectionPoolOptions<ConnectionType>,
+  options: SingletonConnectionPoolOptions<ConnectionType>,
 ): ConnectionPool<ConnectionType> => {
   const { driverType, getConnection } = options;
   let connection: ConnectionType | null = null;
@@ -107,7 +112,7 @@ export const createSingletonConnectionPool = <
   return result;
 };
 
-export type CreateSingletonClientPoolOptions<
+export type SingletonClientConnectionPoolOptions<
   ConnectionType extends AnyConnection,
 > = {
   driverType: ConnectionType['driverType'];
@@ -117,8 +122,10 @@ export type CreateSingletonClientPoolOptions<
   }) => ConnectionType;
 };
 
-export const createSingletonClientPool = <ConnectionType extends AnyConnection>(
-  options: CreateSingletonClientPoolOptions<ConnectionType>,
+export const createSingletonClientConnectionPool = <
+  ConnectionType extends AnyConnection,
+>(
+  options: SingletonClientConnectionPoolOptions<ConnectionType>,
 ): ConnectionPool<ConnectionType> => {
   const { driverType, dbClient } = options;
 

--- a/src/packages/pongo/src/commandLine/migrate.ts
+++ b/src/packages/pongo/src/commandLine/migrate.ts
@@ -8,9 +8,9 @@ import {
 } from '@event-driven-io/dumbo';
 import { Command } from 'commander';
 import {
-  pongoDatabaseDriverRegistry,
+  pongoDriverRegistry,
   pongoSchema,
-  type AnyPongoDatabaseDriverOptions,
+  type AnyPongoDriverOptions,
   type PongoCollectionSchema,
   type PongoDatabaseFactoryOptions,
   type PongoDocument,
@@ -199,7 +199,7 @@ const getMigrations = ({
   databaseName: string | undefined;
   collectionNames: string[];
 }) => {
-  const driver = pongoDatabaseDriverRegistry.tryGet(driverType);
+  const driver = pongoDriverRegistry.tryGet(driverType);
 
   if (driver === null) {
     console.error(
@@ -212,7 +212,7 @@ const getMigrations = ({
 
   const driverOptions: PongoDatabaseFactoryOptions<
     Record<string, PongoCollectionSchema<PongoDocument>>,
-    AnyPongoDatabaseDriverOptions
+    AnyPongoDriverOptions
   > = {
     schema: { definition: dbDefinition },
     serializer: JSONSerializer,

--- a/src/packages/pongo/src/commandLine/shell.ts
+++ b/src/packages/pongo/src/commandLine/shell.ts
@@ -13,7 +13,7 @@ import { Command } from 'commander';
 import repl from 'node:repl';
 import {
   pongoClient,
-  pongoDatabaseDriverRegistry,
+  pongoDriverRegistry,
   pongoSchema,
   type PongoClient,
   type PongoClientOptions,
@@ -151,7 +151,7 @@ const startRepl = async (options: {
   const { databaseType } = parseConnectionString(connectionString);
   const driverType = `${databaseType}:${options.databaseDriver}` as const;
 
-  const driver = pongoDatabaseDriverRegistry.tryGet(driverType);
+  const driver = pongoDriverRegistry.tryGet(driverType);
 
   if (driver === null) {
     console.error(

--- a/src/packages/pongo/src/core/database/pongoDatabaseCache.ts
+++ b/src/packages/pongo/src/core/database/pongoDatabaseCache.ts
@@ -4,10 +4,7 @@ import {
   type JSONSerializationOptions,
   type MigrationStyle,
 } from '@event-driven-io/dumbo';
-import type {
-  PongoDatabaseDriver,
-  PongoDatabaseFactoryOptions,
-} from '../drivers';
+import type { PongoDatabaseFactoryOptions, PongoDriver } from '../drivers';
 import type { PongoClientSchema, PongoCollectionSchema } from '../schema';
 import type { PongoDb } from '../typing';
 
@@ -18,7 +15,7 @@ export const PongoDatabaseCache = <
   driver,
   typedSchema,
 }: {
-  driver: PongoDatabaseDriver<Database>;
+  driver: PongoDriver<Database>;
   typedSchema?: TypedClientSchema | undefined;
 }) => {
   const dbClients = new Map<string, PongoDb>();

--- a/src/packages/pongo/src/core/pongoClient.connections.int.spec.ts
+++ b/src/packages/pongo/src/core/pongoClient.connections.int.spec.ts
@@ -10,7 +10,7 @@ import {
 import { randomUUID } from 'node:crypto';
 import { after, before, describe, it } from 'node:test';
 import pg from 'pg';
-import { databaseDriver } from '../pg';
+import { pongoDriver } from '../pg';
 import { pongoClient } from './pongoClient';
 
 type User = {
@@ -35,7 +35,7 @@ void describe('Pongo collection', () => {
     poolOrClient: pg.Pool | pg.PoolClient | pg.Client,
   ) => {
     const pongo = pongoClient({
-      driver: databaseDriver,
+      driver: pongoDriver,
       connectionString,
       connectionOptions: isPgNativePool(poolOrClient)
         ? undefined
@@ -94,7 +94,7 @@ void describe('Pongo collection', () => {
       try {
         await pool.withConnection(async (connection) => {
           const pongo = pongoClient({
-            driver: databaseDriver,
+            driver: pongoDriver,
             connectionString,
             connectionOptions: {
               connection,
@@ -117,7 +117,7 @@ void describe('Pongo collection', () => {
       try {
         await pool.withTransaction(async ({ connection }) => {
           const pongo = pongoClient({
-            driver: databaseDriver,
+            driver: pongoDriver,
             connectionString,
             connectionOptions: { connection },
           });

--- a/src/packages/pongo/src/core/pongoClient.ts
+++ b/src/packages/pongo/src/core/pongoClient.ts
@@ -1,7 +1,7 @@
 import { JSONSerializer } from '@event-driven-io/dumbo';
 import { PongoDatabaseCache } from './database';
 import type {
-  AnyPongoDatabaseDriver,
+  AnyPongoDriver,
   ExtractPongoDatabaseTypeFromDriver,
 } from './drivers';
 import { pongoSession } from './pongoSession';
@@ -18,7 +18,7 @@ import type {
 } from './typing';
 
 export const pongoClient = <
-  DatabaseDriver extends AnyPongoDatabaseDriver,
+  DatabaseDriver extends AnyPongoDriver,
   TypedClientSchema extends PongoClientSchema = PongoClientSchema,
 >(
   options: PongoClientOptions<DatabaseDriver, TypedClientSchema>,

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -1,9 +1,9 @@
-import type { JSONSerializer } from '@event-driven-io/dumbo';
 import type {
   AnyConnection,
   DatabaseDriverType,
   DatabaseTransaction,
   JSONSerializationOptions,
+  JSONSerializer,
   MigrationStyle,
   QueryResult,
   QueryResultRow,
@@ -17,10 +17,7 @@ import type {
 import { v7 as uuid } from 'uuid';
 import type { PongoCollectionSchemaComponent } from '../collection';
 import type { PongoDatabaseSchemaComponent } from '../database/pongoDatabaseSchemaComponent';
-import type {
-  AnyPongoDatabaseDriver,
-  ExtractPongoDatabaseDriverOptions,
-} from '../drivers';
+import type { AnyPongoDriver, ExtractPongoDriverOptions } from '../drivers';
 import { ConcurrencyError } from '../errors';
 import type { PongoClientSchema } from '../schema';
 
@@ -44,10 +41,10 @@ export interface PongoClient<
 }
 
 export type PongoClientOptions<
-  DatabaseDriver extends AnyPongoDatabaseDriver = AnyPongoDatabaseDriver,
+  DatabaseDriver extends AnyPongoDriver = AnyPongoDriver,
   TypedClientSchema extends PongoClientSchema = PongoClientSchema,
 > =
-  ExtractPongoDatabaseDriverOptions<DatabaseDriver> extends infer Options
+  ExtractPongoDriverOptions<DatabaseDriver> extends infer Options
     ? Options extends unknown
       ? {
           driver: DatabaseDriver;

--- a/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
@@ -12,7 +12,7 @@ import type { Db as MongoDb, ObjectId } from 'mongodb';
 import { MongoClient as OriginalMongoClient } from 'mongodb';
 import { after, before, describe, it } from 'node:test';
 import { v7 as uuid } from 'uuid';
-import { pgDriver, usePgDatabaseDriver } from '../../../pg';
+import { pgDriver, usePgPongoDriver } from '../../../pg';
 import { MongoClient, type Db } from '../../../shim';
 
 type History = { street: string };
@@ -44,7 +44,7 @@ void describe('MongoDB Compatibility Tests', () => {
   let mongoDb: MongoDb;
 
   before(async () => {
-    usePgDatabaseDriver();
+    usePgPongoDriver();
 
     postgres = await new PostgreSqlContainer('postgres:18.0').start();
     postgresConnectionString = PostgreSQLConnectionString(

--- a/src/packages/pongo/src/e2e/postgresql/pg/postgres.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/postgres.e2e.spec.ts
@@ -15,7 +15,7 @@ import {
   type PongoDb,
 } from '../../..';
 import { pongoSchema } from '../../../core';
-import { databaseDriver } from '../../../pg';
+import { pongoDriver } from '../../../pg';
 import { MongoClient, type Db } from '../../../shim';
 
 type History = { street: string };
@@ -52,7 +52,7 @@ void describe('MongoDB Compatibility Tests', () => {
       postgres.getConnectionUri(),
     );
     client = pongoClient({
-      driver: databaseDriver,
+      driver: pongoDriver,
       connectionString: postgresConnectionString,
     });
     shim = new MongoClient(postgresConnectionString);
@@ -1269,7 +1269,7 @@ void describe('MongoDB Compatibility Tests', () => {
 
     void it('should access typed collection and perform operation', async () => {
       const typedClient = pongoClient({
-        driver: databaseDriver,
+        driver: pongoDriver,
         connectionString: postgresConnectionString,
         schema: { definition: schema },
       });
@@ -1296,7 +1296,7 @@ void describe('MongoDB Compatibility Tests', () => {
 
     void it('should access collection by name and perform operation', async () => {
       const typedClient = pongoClient({
-        driver: databaseDriver,
+        driver: pongoDriver,
         connectionString: postgresConnectionString,
         schema: { definition: schema },
       });
@@ -1325,7 +1325,7 @@ void describe('MongoDB Compatibility Tests', () => {
   void describe('Serialization', () => {
     void it('should serialize and deserialize Date objects with custom serialization settings', async () => {
       const client = pongoClient({
-        driver: databaseDriver,
+        driver: pongoDriver,
         connectionString: postgresConnectionString,
         serialization: { options: { parseDates: true } },
       });
@@ -1380,7 +1380,7 @@ void describe('MongoDB Compatibility Tests', () => {
 
     void it('should serialize and deserialize bigint objects with custom serialization settings', async () => {
       const client = pongoClient({
-        driver: databaseDriver,
+        driver: pongoDriver,
         connectionString: postgresConnectionString,
         serialization: { options: { parseBigInts: true } },
       });

--- a/src/packages/pongo/src/e2e/postgresql/pg/postgres.optimistic-concurrency.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/postgres.optimistic-concurrency.spec.ts
@@ -14,7 +14,7 @@ import {
   type PongoCollection,
   type PongoDb,
 } from '../../../';
-import { databaseDriver } from '../../../pg';
+import { pongoDriver } from '../../../pg';
 
 type History = { street: string };
 type Address = {
@@ -52,7 +52,7 @@ void describe('MongoDB Compatibility Tests', () => {
     const dbName = postgres.getDatabase();
 
     client = pongoClient({
-      driver: databaseDriver,
+      driver: pongoDriver,
       connectionString: postgresConnectionString,
       schema: {
         autoMigration: 'CreateOrUpdate',

--- a/src/packages/pongo/src/index.ts
+++ b/src/packages/pongo/src/index.ts
@@ -1,1 +1,32 @@
+import type { AnyPongoDriver } from './core';
+
 export * from './core';
+
+pongoDriverRegistry.register(`PostgreSQL:pg`, () => loadPongoClient('pg'));
+pongoDriverRegistry.register(`SQLite:sqlite3`, () =>
+  loadPongoClient('sqlite3'),
+);
+pongoDriverRegistry.register(`SQLite:d1`, () => loadPongoClient('d1'));
+
+export const loadPongoClient = async (
+  path: 'pg' | 'sqlite3' | 'd1',
+): Promise<AnyPongoDriver> => {
+  let module;
+
+  if (path === 'pg') {
+    module = await import('./pg');
+  } else if (path === 'sqlite3') {
+    module = await import('./sqlite3');
+  } else if (path === 'd1') {
+    module = await import('./cloudflare');
+  } else {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    throw new Error(`Unknown path: ${path}`);
+  }
+
+  if (!module.pongoDriver) {
+    throw new Error(`Failed to load Pongo client for ${path}`);
+  }
+
+  return module.pongoDriver;
+};

--- a/src/packages/pongo/src/mongo/mongoClient.ts
+++ b/src/packages/pongo/src/mongo/mongoClient.ts
@@ -7,7 +7,7 @@ import type { ClientSession, WithSessionCallback } from 'mongodb';
 import {
   pongoClient,
   pongoSession,
-  type AnyPongoDatabaseDriver,
+  type AnyPongoDriver,
   type PongoClient,
   type PongoClientOptions,
   type PongoClientSchema,
@@ -15,7 +15,7 @@ import {
 import { Db } from './mongoDb';
 
 export class MongoClient<
-  DatabaseDriverType extends AnyPongoDatabaseDriver = AnyPongoDatabaseDriver,
+  DatabaseDriverType extends AnyPongoDriver = AnyPongoDriver,
   TypedClientSchema extends PongoClientSchema = PongoClientSchema,
 > {
   private pongoClient: PongoClient;
@@ -29,7 +29,7 @@ export class MongoClient<
       PongoClientOptions<DatabaseDriverType, TypedClientSchema>,
       'connectionString'
     > & {
-      driver?: AnyPongoDatabaseDriver;
+      driver?: AnyPongoDriver;
     },
   );
   constructor(
@@ -40,7 +40,7 @@ export class MongoClient<
       PongoClientOptions<DatabaseDriverType, TypedClientSchema>,
       'connectionString'
     > & {
-      driver?: AnyPongoDatabaseDriver;
+      driver?: AnyPongoDriver;
     },
   ) {
     if (typeof connectionStringOrOptions !== 'string') {
@@ -54,7 +54,7 @@ export class MongoClient<
 
     const driver =
       options?.driver ??
-      pongoDatabaseDriverRegistry.tryGet(
+      pongoDriverRegistry.tryGet(
         toDatabaseDriverType(databaseType, driverName),
       );
 

--- a/src/packages/pongo/src/pongoDriverResolution.spec.ts
+++ b/src/packages/pongo/src/pongoDriverResolution.spec.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { pongoDriverRegistry } from './';
+
+void describe('Pongo Driver Registry', () => {
+  void describe('Fails to get existing drivers when they were NOT resolved already', () => {
+    void it('fails to get pg', () => {
+      const resolved = pongoDriverRegistry.tryGet('PostgreSQL:pg');
+
+      assert.equal(
+        resolved,
+        null,
+        "Get shouldn't resolve PostgreSQL:pg driver before it was resolved",
+      );
+    });
+
+    void it('fails to get sqlite3', () => {
+      const resolved = pongoDriverRegistry.tryGet('SQLite:sqlite3');
+
+      assert.equal(
+        resolved,
+        null,
+        "Get shouldn't resolve SQLite:sqlite3 driver before it was resolved",
+      );
+    });
+
+    void it('fails to get d1', () => {
+      const resolved = pongoDriverRegistry.tryGet('SQLite:d1');
+
+      assert.equal(
+        resolved,
+        null,
+        "Get shouldn't resolve SQLite:d1 driver before it was resolved",
+      );
+    });
+  });
+
+  void describe('Resolves existing drivers', () => {
+    void it('resolves pg', async () => {
+      const resolved = await pongoDriverRegistry.tryResolve('PostgreSQL:pg');
+
+      assert.ok(resolved, 'Failed to resolve PostgreSQL:pg driver');
+    });
+
+    void it('resolves sqlite3', async () => {
+      const resolved = await pongoDriverRegistry.tryResolve('SQLite:sqlite3');
+
+      assert.ok(resolved, 'Failed to resolve SQLite:sqlite3 driver');
+    });
+
+    void it('resolves d1', async () => {
+      const resolved = await pongoDriverRegistry.tryResolve('SQLite:d1');
+
+      assert.ok(resolved, 'Failed to resolve SQLite:d1 driver');
+    });
+  });
+
+  void describe('Gets existing drivers when they were resolved already', () => {
+    void it('gets pg', () => {
+      const resolved = pongoDriverRegistry.tryGet('PostgreSQL:pg');
+
+      assert.ok(resolved, 'Failed to get PostgreSQL:pg driver');
+    });
+
+    void it('gets sqlite3', () => {
+      const resolved = pongoDriverRegistry.tryGet('SQLite:sqlite3');
+
+      assert.ok(resolved, 'Failed to get SQLite:sqlite3 driver');
+    });
+
+    void it('gets d1', () => {
+      const resolved = pongoDriverRegistry.tryGet('SQLite:d1');
+
+      assert.ok(resolved, 'Failed to get SQLite:d1 driver');
+    });
+  });
+});

--- a/src/packages/pongo/src/storage/postgresql/pg/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/pg/index.ts
@@ -9,12 +9,12 @@ import type pg from 'pg';
 import {
   PongoCollectionSchemaComponent,
   PongoDatabase,
-  pongoDatabaseDriverRegistry,
   PongoDatabaseSchemaComponent,
+  pongoDriverRegistry,
   pongoSchema,
-  type PongoDatabaseDriver,
-  type PongoDatabaseDriverOptions,
   type PongoDb,
+  type PongoDriver,
+  type PongoDriverOptions,
 } from '../../../core';
 import {
   pongoCollectionPostgreSQLMigrations,
@@ -54,13 +54,12 @@ export type NotPooledPongoOptions =
       pooled?: false;
     };
 
-type PgDatabaseDriverOptions =
-  PongoDatabaseDriverOptions<PgPongoClientOptions> & {
-    databaseName?: string | undefined;
-    connectionString: string;
-  };
+type PgDatabaseDriverOptions = PongoDriverOptions<PgPongoClientOptions> & {
+  databaseName?: string | undefined;
+  connectionString: string;
+};
 
-const pgDatabaseDriver: PongoDatabaseDriver<
+const pgPongoDriver: PongoDriver<
   PongoDb<PgDriverType>,
   PgDatabaseDriverOptions
 > = {
@@ -101,10 +100,10 @@ const pgDatabaseDriver: PongoDatabaseDriver<
   },
 };
 
-export const usePgDatabaseDriver = () => {
-  pongoDatabaseDriverRegistry.register(PgDriverType, pgDatabaseDriver);
+export const usePgPongoDriver = () => {
+  pongoDriverRegistry.register(PgDriverType, pgPongoDriver);
 };
 
-usePgDatabaseDriver();
+usePgPongoDriver();
 
-export { pgDatabaseDriver as databaseDriver, pgDatabaseDriver as pgDriver };
+export { pgPongoDriver as pgDriver, pgPongoDriver as pongoDriver };

--- a/src/packages/pongo/src/storage/postgresql/pg/migrations/migrations.int.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/pg/migrations/migrations.int.spec.ts
@@ -7,7 +7,7 @@ import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import assert from 'assert';
 import { after, before, beforeEach, describe, it } from 'node:test';
-import { databaseDriver } from '..';
+import { pongoDriver } from '..';
 import { pongoClient, pongoSchema, type PongoClient } from '../../../../core';
 
 void describe('Migration Integration Tests', () => {
@@ -28,7 +28,7 @@ void describe('Migration Integration Tests', () => {
     connectionString = PostgreSQLConnectionString(postgres.getConnectionUri());
     pool = dumbo({ connectionString });
     client = pongoClient({
-      driver: databaseDriver,
+      driver: pongoDriver,
       connectionString,
       schema: { autoMigration: 'CreateOrUpdate', definition: schema },
     });

--- a/src/packages/pongo/src/storage/sqlite/d1/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/d1/index.ts
@@ -4,21 +4,20 @@ import { D1DriverType, d1Pool } from '@event-driven-io/dumbo/cloudflare';
 import {
   PongoCollectionSchemaComponent,
   PongoDatabase,
-  pongoDatabaseDriverRegistry,
   PongoDatabaseSchemaComponent,
+  pongoDriverRegistry,
   pongoSchema,
-  type PongoDatabaseDriver,
-  type PongoDatabaseDriverOptions,
   type PongoDb,
+  type PongoDriver,
+  type PongoDriverOptions,
 } from '../../../core';
 import { pongoCollectionSQLiteMigrations, sqliteSQLBuilder } from '../core';
 
 export type SQLitePongoClientOptions = object;
 
-type D1DatabaseDriverOptions = PongoDatabaseDriverOptions<never> &
-  D1PoolOptions;
+type D1DatabaseDriverOptions = PongoDriverOptions<never> & D1PoolOptions;
 
-const d1DatabaseDriver: PongoDatabaseDriver<
+const d1PongoDriver: PongoDriver<
   PongoDb<D1DriverType>,
   D1DatabaseDriverOptions
 > = {
@@ -51,10 +50,10 @@ const d1DatabaseDriver: PongoDatabaseDriver<
   },
 };
 
-export const useSqlite3DatabaseDriver = () => {
-  pongoDatabaseDriverRegistry.register(D1DriverType, d1DatabaseDriver);
+export const useD1PongoDriver = () => {
+  pongoDriverRegistry.register(D1DriverType, d1PongoDriver);
 };
 
-useSqlite3DatabaseDriver();
+useD1PongoDriver();
 
-export { d1DatabaseDriver as d1Driver, d1DatabaseDriver as databaseDriver };
+export { d1PongoDriver as d1Driver, d1PongoDriver as pongoDriver };

--- a/src/packages/pongo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/sqlite3/index.ts
@@ -6,24 +6,24 @@ import {
 import {
   PongoCollectionSchemaComponent,
   PongoDatabase,
-  pongoDatabaseDriverRegistry,
   PongoDatabaseSchemaComponent,
+  pongoDriverRegistry,
   pongoSchema,
-  type PongoDatabaseDriver,
-  type PongoDatabaseDriverOptions,
   type PongoDb,
+  type PongoDriver,
+  type PongoDriverOptions,
 } from '../../../core';
 import { pongoCollectionSQLiteMigrations, sqliteSQLBuilder } from '../core';
 
 export type SQLitePongoClientOptions = object;
 
 type SQLiteDatabaseDriverOptions =
-  PongoDatabaseDriverOptions<SQLitePongoClientOptions> & {
+  PongoDriverOptions<SQLitePongoClientOptions> & {
     databaseName?: string | undefined;
     connectionString: string;
   };
 
-const sqlite3DatabaseDriver: PongoDatabaseDriver<
+const sqlite3PongoDriver: PongoDriver<
   PongoDb<SQLite3DriverType>,
   SQLiteDatabaseDriverOptions
 > = {
@@ -61,16 +61,13 @@ const sqlite3DatabaseDriver: PongoDatabaseDriver<
   },
 };
 
-export const useSqlite3DatabaseDriver = () => {
-  pongoDatabaseDriverRegistry.register(
-    SQLite3DriverType,
-    sqlite3DatabaseDriver,
-  );
+export const useSqlite3PongoDriver = () => {
+  pongoDriverRegistry.register(SQLite3DriverType, sqlite3PongoDriver);
 };
 
-useSqlite3DatabaseDriver();
+useSqlite3PongoDriver();
 
 export {
-  sqlite3DatabaseDriver as databaseDriver,
-  sqlite3DatabaseDriver as sqlite3Driver,
+  sqlite3PongoDriver as pongoDriver,
+  sqlite3PongoDriver as sqlite3Driver,
 };


### PR DESCRIPTION
Besides that, shortened the driver name to include Pongo instead of the database. Aligned exports accordingly.

Intentionally didn't expose resolving the whole PongoClient, as I don't want to make this too easy. The intention is to enable advanced users to do it, not all (e.g. Emmett projections). So yes, a little bit of intentional scarification.