### PR TITLE
Enabled safe concurrent SQLite client initialisation

### DIFF
--- a/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
@@ -1,4 +1,5 @@
 import {
+  mapSqliteError,
   SQLiteConnectionString,
   sqliteSQLExecutor,
   type SQLiteDriverType,
@@ -261,8 +262,13 @@ export const sqliteClientConnection = <
 
     client = sqliteClientFactory(connectionOptions as ClientOptions);
 
-    if (client && 'connect' in client && typeof client.connect === 'function')
-      await client.connect();
+    if (client && 'connect' in client && typeof client.connect === 'function') {
+      try {
+        await client.connect();
+      } catch (error) {
+        throw mapSqliteError(error);
+      }
+    }
 
     return client;
   };
@@ -316,7 +322,11 @@ export const sqlitePoolClientConnection = <
 
     client = sqliteClientFactory(connectionOptions as ClientOptions);
 
-    await client.connect();
+    try {
+      await client.connect();
+    } catch (error) {
+      throw mapSqliteError(error);
+    }
 
     return client;
   };
@@ -380,6 +390,7 @@ export const DEFAULT_SQLITE_PRAGMA_OPTIONS: SQLitePragmaOptions = {
 export type SQLiteClientOptions = {
   pragmaOptions?: Partial<SQLitePragmaOptions>;
   defaultTransactionMode?: SQLiteTransactionMode;
+  skipDatabasePragmas?: boolean;
 };
 
 export * from './connectionString';

--- a/src/packages/dumbo/src/storage/sqlite/core/connections/pragmas.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/connections/pragmas.ts
@@ -18,15 +18,19 @@ export const mergePragmaOptions = (
   };
 };
 
-export const buildPragmaStatements = (
+export const buildConnectionPragmaStatements = (
   pragmas: SQLitePragmaOptions,
-): Array<{ pragma: string; value: string | number }> => {
-  return [
-    { pragma: 'journal_mode', value: pragmas.journal_mode! },
-    { pragma: 'synchronous', value: pragmas.synchronous! },
-    { pragma: 'cache_size', value: pragmas.cache_size! },
-    { pragma: 'foreign_keys', value: pragmas.foreign_keys ? 'ON' : 'OFF' },
-    { pragma: 'temp_store', value: pragmas.temp_store! },
-    { pragma: 'busy_timeout', value: pragmas.busy_timeout! },
-  ];
-};
+): Array<{ pragma: string; value: string | number }> => [
+  // busy_timeout FIRST - enables waiting on locks for subsequent operations
+  { pragma: 'busy_timeout', value: pragmas.busy_timeout! },
+  { pragma: 'synchronous', value: pragmas.synchronous! },
+  { pragma: 'cache_size', value: pragmas.cache_size! },
+  { pragma: 'foreign_keys', value: pragmas.foreign_keys ? 'ON' : 'OFF' },
+  { pragma: 'temp_store', value: pragmas.temp_store! },
+];
+
+export const buildDatabasePragmaStatements = (
+  pragmas: SQLitePragmaOptions,
+): Array<{ pragma: string; value: string | number }> => [
+  { pragma: 'journal_mode', value: pragmas.journal_mode! },
+];


### PR DESCRIPTION
Setting WAL mode for SQLite is a must for concurrency and performance, but it requires write mode, and it's redundant to set it always;s it's only needed once. To fix that:

1. Split PRAGMAs into database-level and connection-level.
2. Made an idempotent check if WAL mode is enabled.
3. Enabled skipping database pragmas setup for the or connection.
4. Extended dual database pool to do the pragmas setup only on the first connection; the rest will skip it.
5. Wrapped connection errors with DumboError mapping to unify error handling. It should already have been there, but I missed this piece when I was SQL-dining the g it to the SQL executor.

A follow-up, applying SQLite single writer connection pool from: 
- https://github.com/event-driven-io/Pongo/pull/163
- https://github.com/event-driven-io/Pongo/pull/164

@SamHatoum @davecosec FYI.