### PR TITLE
Improved the race condition on database setup

### DIFF
--- a/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
@@ -391,6 +391,7 @@ export type SQLiteClientOptions = {
   pragmaOptions?: Partial<SQLitePragmaOptions>;
   defaultTransactionMode?: SQLiteTransactionMode;
   skipDatabasePragmas?: boolean;
+  readonly?: boolean;
 };
 
 export * from './connectionString';

--- a/src/packages/dumbo/src/storage/sqlite/core/pool/dualPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/pool/dualPool.ts
@@ -38,11 +38,16 @@ export const sqliteDualConnectionPool = <
 
   let databaseInitPromise: Promise<void> | null = null;
 
-  const getConnectionOptions = (): ConnectionOptions => {
+  const getConnectionOptions = ({
+    readonly,
+  }: {
+    readonly: boolean;
+  }): ConnectionOptions => {
     if (databaseInitPromise !== null) {
       return {
         ...connectionOptions,
         skipDatabasePragmas: true,
+        readonly: readonly,
       } as ConnectionOptions;
     }
     return connectionOptions as ConnectionOptions;
@@ -74,12 +79,14 @@ export const sqliteDualConnectionPool = <
 
   const writerPool = createSingletonConnectionPool({
     driverType: options.driverType,
-    getConnection: () => wrappedConnectionFactory(getConnectionOptions()),
+    getConnection: () =>
+      wrappedConnectionFactory(getConnectionOptions({ readonly: false })),
   });
 
   const readerPool = createBoundedConnectionPool({
     driverType: options.driverType,
-    getConnection: () => wrappedConnectionFactory(getConnectionOptions()),
+    getConnection: () =>
+      wrappedConnectionFactory(getConnectionOptions({ readonly: true })),
     maxConnections: readerPoolSize,
   });
 


### PR DESCRIPTION
Ensured that apply params happens after we opened the connection, also that we're setting the busy timeout through the built-in configure method.

A follow-up, applying SQLite single writer connection pool from: 
- https://github.com/event-driven-io/Pongo/pull/163
- https://github.com/event-driven-io/Pongo/pull/164
- https://github.com/event-driven-io/Pongo/pull/165
- https://github.com/event-driven-io/Pongo/pull/166

@SamHatoum @davecosec FYI.