### PR TITLE
Added sequential processing for SQLite database initialisation

### DIFF
--- a/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/pool/pool.ts
@@ -185,6 +185,13 @@ export const toSqlitePoolOptions = <
   const { singleton, ...rest } = options;
   const isInMemory = isInMemoryDatabase(options);
 
+  if ('client' in options && options.client) {
+    return { ...rest, singleton: true } as SQLitePoolOptions<
+      SQLiteConnectionType,
+      ConnectionOptions
+    >;
+  }
+
   if (isInMemory) {
     return { ...rest, singleton: true } as SQLitePoolOptions<
       SQLiteConnectionType,
@@ -212,9 +219,6 @@ export function sqlitePool<
   options: SQLitePoolOptions<SQLiteConnectionType, ConnectionOptions>,
 ): SQLitePool<SQLiteConnectionType> {
   const { driverType } = options;
-
-  // TODO: Handle dates and bigints
-  // setSQLiteTypeParser(serializer ?? JSONSerializer);
 
   if (
     (

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.int.spec.ts
@@ -191,26 +191,30 @@ void describe('Node SQLite3 pool', () => {
         }
       });
 
-      void it('connects using ambient client', withDeadline, async () => {
-        const existingClient = sqlite3Client({
-          fileName,
-          serializer: JSONSerializer,
-        });
-        await existingClient.connect();
+      void it(
+        `connects using ambient client ${testName}`,
+        withDeadline,
+        async () => {
+          const existingClient = sqlite3Client({
+            fileName,
+            serializer: JSONSerializer,
+          });
+          await existingClient.connect();
 
-        const pool = sqlite3Pool({
-          client: existingClient,
-        });
-        const connection = await pool.connection();
+          const pool = sqlite3Pool({
+            client: existingClient,
+          });
+          const connection = await pool.connection();
 
-        try {
-          await connection.execute.query(SQL`SELECT 1`);
-        } finally {
-          await connection.close();
-          await pool.close();
-          await existingClient.close();
-        }
-      });
+          try {
+            await connection.execute.query(SQL`SELECT 1`);
+          } finally {
+            await connection.close();
+            await pool.close();
+            await existingClient.close();
+          }
+        },
+      );
 
       void it(
         'connects using connected ambient connected connection from pool',


### PR DESCRIPTION
A follow-up, applying SQLite single writer connection pool from: 
- https://github.com/event-driven-io/Pongo/pull/163
- https://github.com/event-driven-io/Pongo/pull/164
- https://github.com/event-driven-io/Pongo/pull/165
- https://github.com/event-driven-io/Pongo/pull/166
- https://github.com/event-driven-io/Pongo/pull/167
- https://github.com/event-driven-io/Pongo/pull/168

@SamHatoum @davecosec FYI.