### PR TITLE
Ensured that all SQLite errors are mapped

### DIFF
--- a/src/packages/dumbo/src/storage/sqlite/core/pool/dualPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/pool/dualPool.ts
@@ -9,6 +9,7 @@ import type {
   SQLiteConnectionFactory,
   SQLiteConnectionOptions,
 } from '../connections';
+import { mapSqliteError } from '../errors';
 import type { SQLitePool } from './pool';
 
 export type SQLiteDualPoolOptions<
@@ -79,7 +80,7 @@ export const sqliteDualConnectionPool = <
           if (retryCount < 3) {
             return ensureDatabaseInitialized(connectionOptions, retryCount + 1);
           }
-          throw error;
+          throw mapSqliteError(error);
         }
       },
       { taskGroupId: 'db-init' },


### PR DESCRIPTION
A follow-up, applying SQLite single writer connection pool from: 
- https://github.com/event-driven-io/Pongo/pull/163
- https://github.com/event-driven-io/Pongo/pull/164
- https://github.com/event-driven-io/Pongo/pull/165
- https://github.com/event-driven-io/Pongo/pull/166
- https://github.com/event-driven-io/Pongo/pull/167
- https://github.com/event-driven-io/Pongo/pull/168
- https://github.com/event-driven-io/Pongo/pull/169
- https://github.com/event-driven-io/Pongo/pull/170