### PR TITLE
Add sort option to FindOptions

### DIFF
--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -217,6 +217,7 @@ export type DeleteManyOptions = {
 export type FindOptions = {
   limit?: number;
   skip?: number;
+  sort?: { [field: string]: 1 | -1 };
 } & CollectionOperationOptions;
 
 export interface PongoCollection<T extends PongoDocument> {

--- a/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
@@ -1081,6 +1081,62 @@ describe('MongoDB Compatibility Tests', () => {
         mongoDocs.map((d) => d.age),
       );
     });
+
+    it('multi-field sort produces same order in Pongo and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>(
+        'sortMultiFieldCollection',
+      );
+      const mongoCollection = mongoDb.collection<User>(
+        'sortMultiFieldCollection',
+      );
+      const docs = [
+        { name: 'Alice', age: 30 },
+        { name: 'Bob', age: 30 },
+        { name: 'Alice', age: 25 },
+      ];
+
+      await pongoCollection.insertMany(docs);
+      await mongoCollection.insertMany(docs);
+
+      const opts = { sort: { name: 1 as const, age: -1 as const } };
+      const pongoDocs = await pongoCollection.find({}, opts).toArray();
+      const mongoDocs = await mongoCollection.find({}, opts).toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
+    it('nested field sort produces same order in Pongo and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>(
+        'sortNestedFieldCollection',
+      );
+      const mongoCollection = mongoDb.collection<User>(
+        'sortNestedFieldCollection',
+      );
+      const docs = [
+        { name: 'Charlie', age: 30, address: { city: 'Warsaw' } },
+        { name: 'Alice', age: 25, address: { city: 'Lisbon' } },
+        { name: 'Bob', age: 28, address: { city: 'Madrid' } },
+      ];
+
+      await pongoCollection.insertMany(docs);
+      await mongoCollection.insertMany(docs);
+
+      const opts = { sort: { 'address.city': 1 as const } };
+      const pongoDocs = await pongoCollection.find({}, opts).toArray();
+      const mongoDocs = await mongoCollection.find({}, opts).toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.name),
+        ['Alice', 'Bob', 'Charlie'],
+      );
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.name),
+        mongoDocs.map((d) => d.name),
+      );
+    });
   });
 
   describe('Handle Operations', () => {

--- a/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
@@ -1025,6 +1025,58 @@ describe('MongoDB Compatibility Tests', () => {
         mongoDocs.map((d) => ({ name: d.name, age: d.age })),
       );
     });
+
+    it('sort ASC produces same order in Pongo and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>('sortAscCollection');
+      const mongoCollection = mongoDb.collection<User>('sortAscCollection');
+      const docs = [
+        { name: 'Charlie', age: 30 },
+        { name: 'Alice', age: 25 },
+        { name: 'Bob', age: 28 },
+      ];
+
+      await pongoCollection.insertMany(docs);
+      await mongoCollection.insertMany(docs);
+
+      const pongoDocs = await pongoCollection
+        .find({}, { sort: { name: 1 } })
+        .toArray();
+      const mongoDocs = await mongoCollection
+        .find({}, { sort: { name: 1 } })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.name),
+        ['Alice', 'Bob', 'Charlie'],
+      );
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.name),
+        mongoDocs.map((d) => d.name),
+      );
+    });
+
+    it('sort DESC + limit + skip produces same result in Pongo and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>('sortDescLimitCollection');
+      const mongoCollection = mongoDb.collection<User>('sortDescLimitCollection');
+      const docs = [
+        { name: 'A', age: 40 },
+        { name: 'B', age: 45 },
+        { name: 'C', age: 50 },
+        { name: 'D', age: 35 },
+      ];
+
+      await pongoCollection.insertMany(docs);
+      await mongoCollection.insertMany(docs);
+
+      const opts = { sort: { age: -1 as const }, limit: 2, skip: 1 };
+      const pongoDocs = await pongoCollection.find({}, opts).toArray();
+      const mongoDocs = await mongoCollection.find({}, opts).toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.age),
+        mongoDocs.map((d) => d.age),
+      );
+    });
   });
 
   describe('Handle Operations', () => {

--- a/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
@@ -1056,8 +1056,12 @@ describe('MongoDB Compatibility Tests', () => {
     });
 
     it('sort DESC + limit + skip produces same result in Pongo and MongoDB', async () => {
-      const pongoCollection = pongoDb.collection<User>('sortDescLimitCollection');
-      const mongoCollection = mongoDb.collection<User>('sortDescLimitCollection');
+      const pongoCollection = pongoDb.collection<User>(
+        'sortDescLimitCollection',
+      );
+      const mongoCollection = mongoDb.collection<User>(
+        'sortDescLimitCollection',
+      );
       const docs = [
         { name: 'A', age: 40 },
         { name: 'B', age: 45 },

--- a/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
@@ -1169,6 +1169,62 @@ describe('MongoDB Compatibility Tests', () => {
         mongoDocs.map((d) => d.age),
       );
     });
+
+    it('sort by _id produces same order in Pongo and MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>('sortByIdCollection');
+      const mongoCollection = mongoDb.collection<User>('sortByIdCollection');
+      const docs = [
+        { name: 'Charlie', age: 30 },
+        { name: 'Alice', age: 25 },
+        { name: 'Bob', age: 28 },
+      ];
+
+      await pongoCollection.insertMany(docs);
+      await mongoCollection.insertMany(docs);
+
+      const pongoDocs = await pongoCollection
+        .find({}, { sort: { _id: 1 } })
+        .toArray();
+      const mongoDocs = await mongoCollection
+        .find({}, { sort: { _id: 1 } })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.name),
+        mongoDocs.map((d) => d.name),
+      );
+    });
+
+    it('documents with missing sort field sort first on ASC, matching MongoDB', async () => {
+      const pongoCollection = pongoDb.collection<User>(
+        'sortNullsFirstCollection',
+      );
+      const mongoCollection = mongoDb.collection<User>(
+        'sortNullsFirstCollection',
+      );
+      // 'Alice' has no age — should appear first in both ASC results
+      const docs = [
+        { name: 'Bob', age: 30 },
+        { name: 'Alice', age: undefined },
+        { name: 'Charlie', age: 20 },
+      ] as User[];
+
+      await pongoCollection.insertMany(docs);
+      await mongoCollection.insertMany(docs);
+
+      const pongoDocs = await pongoCollection
+        .find({}, { sort: { age: 1 } })
+        .toArray();
+      const mongoDocs = await mongoCollection
+        .find({}, { sort: { age: 1 } })
+        .toArray();
+
+      assert.strictEqual(pongoDocs[0]!.name, 'Alice');
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.name),
+        mongoDocs.map((d) => d.name),
+      );
+    });
   });
 
   describe('Handle Operations', () => {

--- a/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/compatibilityTest.e2e.spec.ts
@@ -1137,6 +1137,38 @@ describe('MongoDB Compatibility Tests', () => {
         mongoDocs.map((d) => d.name),
       );
     });
+    it('numeric field sort respects numeric order, not lexicographic', async () => {
+      const pongoCollection = pongoDb.collection<User>('sortNumericCollection');
+      const mongoCollection = mongoDb.collection<User>('sortNumericCollection');
+      // Deliberately use values with different digit counts so that
+      // lexicographic order (['10','2','20','9'] ASC) differs from
+      // numeric order ([2,9,10,20] ASC).
+      const docs = [
+        { name: 'D', age: 9 },
+        { name: 'A', age: 10 },
+        { name: 'C', age: 2 },
+        { name: 'B', age: 20 },
+      ];
+
+      await pongoCollection.insertMany(docs);
+      await mongoCollection.insertMany(docs);
+
+      const pongoDocs = await pongoCollection
+        .find({}, { sort: { age: 1 } })
+        .toArray();
+      const mongoDocs = await mongoCollection
+        .find({}, { sort: { age: 1 } })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.age),
+        [2, 9, 10, 20],
+      );
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => d.age),
+        mongoDocs.map((d) => d.age),
+      );
+    });
   });
 
   describe('Handle Operations', () => {

--- a/src/packages/pongo/src/mongo/mongoCollection.ts
+++ b/src/packages/pongo/src/mongo/mongoCollection.ts
@@ -85,7 +85,7 @@ const toCollectionOperationOptions = (
 const toFindOptions = (
   options: FindOptions | undefined,
 ): PongoFindOptions | undefined => {
-  if (!options?.session && !options?.limit && !options?.skip) {
+  if (!options?.session && !options?.limit && !options?.skip && !options?.sort) {
     return undefined;
   }
 
@@ -99,6 +99,9 @@ const toFindOptions = (
   }
   if (options?.skip !== undefined) {
     pongoFindOptions.skip = options.skip;
+  }
+  if (options?.sort !== undefined) {
+    pongoFindOptions.sort = options.sort as { [field: string]: 1 | -1 };
   }
 
   return pongoFindOptions;

--- a/src/packages/pongo/src/mongo/mongoCollection.ts
+++ b/src/packages/pongo/src/mongo/mongoCollection.ts
@@ -85,7 +85,12 @@ const toCollectionOperationOptions = (
 const toFindOptions = (
   options: FindOptions | undefined,
 ): PongoFindOptions | undefined => {
-  if (!options?.session && !options?.limit && !options?.skip && !options?.sort) {
+  if (
+    !options?.session &&
+    !options?.limit &&
+    !options?.skip &&
+    !options?.sort
+  ) {
     return undefined;
   }
 

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
@@ -316,6 +316,15 @@ export const postgresSQLBuilder = (
 
     query.push(where(filterQuery));
 
+    if (options?.sort) {
+      const clauses = Object.entries(options.sort).map(([field, dir]) =>
+        dir === 1
+          ? SQL`data ->> '${SQL.plain(field)}' ASC`
+          : SQL`data ->> '${SQL.plain(field)}' DESC`,
+      );
+      query.push(SQL`ORDER BY ${SQL.merge(clauses, ',')}`);
+    }
+
     if (options?.limit) {
       query.push(SQL`LIMIT ${options.limit}`);
     }

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
@@ -317,11 +317,13 @@ export const postgresSQLBuilder = (
     query.push(where(filterQuery));
 
     if (options?.sort) {
-      const clauses = Object.entries(options.sort).map(([field, dir]) =>
-        dir === 1
-          ? SQL`data ->> '${SQL.plain(field)}' ASC`
-          : SQL`data ->> '${SQL.plain(field)}' DESC`,
-      );
+      const clauses = Object.entries(options.sort).map(([field, dir]) => {
+        const isNested = field.includes('.');
+        const accessor = isNested
+          ? SQL`data #>> '${SQL.plain(`{${field.split('.').join(',')}}`)}'`
+          : SQL`data ->> '${SQL.plain(field)}'`;
+        return dir === 1 ? SQL`${accessor} ASC` : SQL`${accessor} DESC`;
+      });
       query.push(SQL`ORDER BY ${SQL.merge(clauses, ',')}`);
     }
 

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
@@ -316,12 +316,14 @@ export const postgresSQLBuilder = (
 
     query.push(where(filterQuery));
 
-    if (options?.sort) {
+    if (options?.sort && Object.keys(options.sort).length > 0) {
       const clauses = Object.entries(options.sort).map(([field, dir]) => {
         const isNested = field.includes('.');
+        // Use -> / #> (returns jsonb) rather than ->> / #>> (returns text) so
+        // that numeric fields are sorted numerically, not lexicographically.
         const accessor = isNested
-          ? SQL`data #>> '${SQL.plain(`{${field.split('.').join(',')}}`)}'`
-          : SQL`data ->> '${SQL.plain(field)}'`;
+          ? SQL`data #> '${SQL.plain(`{${field.split('.').join(',')}}`)}'`
+          : SQL`data -> '${SQL.plain(field)}'`;
         return dir === 1 ? SQL`${accessor} ASC` : SQL`${accessor} DESC`;
       });
       query.push(SQL`ORDER BY ${SQL.merge(clauses, ',')}`);

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
@@ -318,13 +318,21 @@ export const postgresSQLBuilder = (
 
     if (options?.sort && Object.keys(options.sort).length > 0) {
       const clauses = Object.entries(options.sort).map(([field, dir]) => {
-        const isNested = field.includes('.');
+        const isMetadata = field === '_id' || field === '_version';
+        const isNested = !isMetadata && field.includes('.');
+        // _id and _version are native columns, not JSON fields.
         // Use -> / #> (returns jsonb) rather than ->> / #>> (returns text) so
         // that numeric fields are sorted numerically, not lexicographically.
-        const accessor = isNested
-          ? SQL`data #> '${SQL.plain(`{${field.split('.').join(',')}}`)}'`
-          : SQL`data -> '${SQL.plain(field)}'`;
-        return dir === 1 ? SQL`${accessor} ASC` : SQL`${accessor} DESC`;
+        const accessor = isMetadata
+          ? SQL`${SQL.plain(field)}`
+          : isNested
+            ? SQL`data #> '${SQL.plain(`{${field.split('.').join(',')}}`)}'`
+            : SQL`data -> '${SQL.plain(field)}'`;
+        // Match MongoDB's null ordering: missing/null values sort first on ASC,
+        // last on DESC. PostgreSQL's default is the opposite for ASC (NULLS LAST).
+        return dir === 1
+          ? SQL`${accessor} ASC NULLS FIRST`
+          : SQL`${accessor} DESC NULLS LAST`;
       });
       query.push(SQL`ORDER BY ${SQL.merge(clauses, ',')}`);
     }

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -38,3 +38,32 @@ describe('find() query options', () => {
     });
   });
 });
+
+describe('find() sort option', () => {
+  const builder = postgresSQLBuilder('users', JSONSerializer);
+
+  it('sorts ASC by a single field', () => {
+    const query = builder.find({}, { sort: { name: 1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.includes(`ORDER BY data ->> 'name' ASC`), `got: ${sql}`);
+  });
+
+  it('sorts DESC by a single field', () => {
+    const query = builder.find({}, { sort: { created_at: -1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.includes(`ORDER BY data ->> 'created_at' DESC`), `got: ${sql}`);
+  });
+
+  it('ORDER BY appears before LIMIT', () => {
+    const query = builder.find({}, { sort: { name: 1 }, limit: 10 });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.indexOf('ORDER BY') < sql.indexOf('LIMIT'), `got: ${sql}`);
+  });
+
+  it('sort + limit + skip produces correct clause order', () => {
+    const query = builder.find({}, { sort: { name: 1 }, limit: 10, skip: 5 });
+    const { query: sql, params } = SQL.format(query, pgFormatter);
+    assert.ok(/ORDER BY.*LIMIT.*OFFSET/s.test(sql), `got: ${sql}`);
+    assert.deepStrictEqual(params, [10, 5]);
+  });
+});

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -80,7 +80,9 @@ describe('find() sort option', () => {
     const query = builder.find({}, { sort: { age: -1, name: 1 } });
     const { query: sql } = SQL.format(query, pgFormatter);
     assert.ok(
-      sql.includes(`ORDER BY data -> 'age' DESC,data -> 'name' ASC`),
+      sql.includes(
+        `ORDER BY data -> 'age' DESC NULLS LAST,data -> 'name' ASC NULLS FIRST`,
+      ),
       `got: ${sql}`,
     );
   });
@@ -98,5 +100,31 @@ describe('find() sort option', () => {
     const query = builder.find({}, { sort: { 'a.b.c': -1 } });
     const { query: sql } = SQL.format(query, pgFormatter);
     assert.ok(sql.includes(`ORDER BY data #> '{a,b,c}' DESC`), `got: ${sql}`);
+  });
+
+  it('places documents with missing field first on ASC sort (NULLS FIRST)', () => {
+    const query = builder.find({}, { sort: { age: 1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.includes(`ASC NULLS FIRST`), `got: ${sql}`);
+  });
+
+  it('places documents with missing field last on DESC sort (NULLS LAST)', () => {
+    const query = builder.find({}, { sort: { age: -1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.includes(`DESC NULLS LAST`), `got: ${sql}`);
+  });
+
+  it('sorts by _id using the native column, not the JSON field', () => {
+    const query = builder.find({}, { sort: { _id: 1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.includes('ORDER BY _id ASC'), `got: ${sql}`);
+    assert.ok(!sql.includes('data ->'), `got: ${sql}`);
+  });
+
+  it('sorts by _version using the native column, not the JSON field', () => {
+    const query = builder.find({}, { sort: { _version: -1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.includes('ORDER BY _version DESC'), `got: ${sql}`);
+    assert.ok(!sql.includes('data ->'), `got: ${sql}`);
   });
 });

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -51,7 +51,10 @@ describe('find() sort option', () => {
   it('sorts DESC by a single field', () => {
     const query = builder.find({}, { sort: { created_at: -1 } });
     const { query: sql } = SQL.format(query, pgFormatter);
-    assert.ok(sql.includes(`ORDER BY data ->> 'created_at' DESC`), `got: ${sql}`);
+    assert.ok(
+      sql.includes(`ORDER BY data ->> 'created_at' DESC`),
+      `got: ${sql}`,
+    );
   });
 
   it('ORDER BY appears before LIMIT', () => {

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -45,14 +45,14 @@ describe('find() sort option', () => {
   it('sorts ASC by a single field', () => {
     const query = builder.find({}, { sort: { name: 1 } });
     const { query: sql } = SQL.format(query, pgFormatter);
-    assert.ok(sql.includes(`ORDER BY data ->> 'name' ASC`), `got: ${sql}`);
+    assert.ok(sql.includes(`ORDER BY data -> 'name' ASC`), `got: ${sql}`);
   });
 
   it('sorts DESC by a single field', () => {
     const query = builder.find({}, { sort: { created_at: -1 } });
     const { query: sql } = SQL.format(query, pgFormatter);
     assert.ok(
-      sql.includes(`ORDER BY data ->> 'created_at' DESC`),
+      sql.includes(`ORDER BY data -> 'created_at' DESC`),
       `got: ${sql}`,
     );
   });
@@ -70,11 +70,17 @@ describe('find() sort option', () => {
     assert.deepStrictEqual(params, [10, 5]);
   });
 
+  it('empty sort object produces no ORDER BY clause', () => {
+    const query = builder.find({}, { sort: {} });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(!sql.includes('ORDER BY'), `got: ${sql}`);
+  });
+
   it('sorts by multiple fields', () => {
     const query = builder.find({}, { sort: { age: -1, name: 1 } });
     const { query: sql } = SQL.format(query, pgFormatter);
     assert.ok(
-      sql.includes(`ORDER BY data ->> 'age' DESC,data ->> 'name' ASC`),
+      sql.includes(`ORDER BY data -> 'age' DESC,data -> 'name' ASC`),
       `got: ${sql}`,
     );
   });
@@ -83,8 +89,14 @@ describe('find() sort option', () => {
     const query = builder.find({}, { sort: { 'address.city': 1 } });
     const { query: sql } = SQL.format(query, pgFormatter);
     assert.ok(
-      sql.includes(`ORDER BY data #>> '{address,city}' ASC`),
+      sql.includes(`ORDER BY data #> '{address,city}' ASC`),
       `got: ${sql}`,
     );
+  });
+
+  it('sorts by a deeply nested field (3 levels)', () => {
+    const query = builder.find({}, { sort: { 'a.b.c': -1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(sql.includes(`ORDER BY data #> '{a,b,c}' DESC`), `got: ${sql}`);
   });
 });

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -69,4 +69,22 @@ describe('find() sort option', () => {
     assert.ok(/ORDER BY.*LIMIT.*OFFSET/s.test(sql), `got: ${sql}`);
     assert.deepStrictEqual(params, [10, 5]);
   });
+
+  it('sorts by multiple fields', () => {
+    const query = builder.find({}, { sort: { age: -1, name: 1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(
+      sql.includes(`ORDER BY data ->> 'age' DESC,data ->> 'name' ASC`),
+      `got: ${sql}`,
+    );
+  });
+
+  it('sorts by a nested field', () => {
+    const query = builder.find({}, { sort: { 'address.city': 1 } });
+    const { query: sql } = SQL.format(query, pgFormatter);
+    assert.ok(
+      sql.includes(`ORDER BY data #>> '{address,city}' ASC`),
+      `got: ${sql}`,
+    );
+  });
 });

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
@@ -271,7 +271,7 @@ export const sqliteSQLBuilder = (
 
     query.push(where(filterQuery));
 
-    if (options?.sort) {
+    if (options?.sort && Object.keys(options.sort).length > 0) {
       const clauses = Object.entries(options.sort).map(([field, dir]) =>
         dir === 1
           ? SQL`json_extract(data, '${SQL.plain(`$.${field}`)}') ASC`

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
@@ -272,11 +272,14 @@ export const sqliteSQLBuilder = (
     query.push(where(filterQuery));
 
     if (options?.sort && Object.keys(options.sort).length > 0) {
-      const clauses = Object.entries(options.sort).map(([field, dir]) =>
-        dir === 1
-          ? SQL`json_extract(data, '${SQL.plain(`$.${field}`)}') ASC`
-          : SQL`json_extract(data, '${SQL.plain(`$.${field}`)}') DESC`,
-      );
+      const clauses = Object.entries(options.sort).map(([field, dir]) => {
+        // _id and _version are native columns, not JSON fields.
+        const isMetadata = field === '_id' || field === '_version';
+        const accessor = isMetadata
+          ? SQL`${SQL.plain(field)}`
+          : SQL`json_extract(data, '${SQL.plain(`$.${field}`)}')`;
+        return dir === 1 ? SQL`${accessor} ASC` : SQL`${accessor} DESC`;
+      });
       query.push(SQL`ORDER BY ${SQL.merge(clauses, ',')}`);
     }
 

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
@@ -271,6 +271,15 @@ export const sqliteSQLBuilder = (
 
     query.push(where(filterQuery));
 
+    if (options?.sort) {
+      const clauses = Object.entries(options.sort).map(([field, dir]) =>
+        dir === 1
+          ? SQL`json_extract(data, '${SQL.plain(`$.${field}`)}') ASC`
+          : SQL`json_extract(data, '${SQL.plain(`$.${field}`)}') DESC`,
+      );
+      query.push(SQL`ORDER BY ${SQL.merge(clauses, ',')}`);
+    }
+
     if (options?.limit) {
       query.push(SQL`LIMIT ${options.limit}`);
     }

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -66,6 +66,30 @@ describe('sqliteSQLBuilder', () => {
       assert.ok(query.includes('LIMIT'));
       assert.ok(query.includes('OFFSET'));
     });
+
+    it('sorts ASC by a single field', () => {
+      const result = builder.find({}, { sort: { name: 1 } });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(query.includes(`ORDER BY json_extract(data, '$.name') ASC`), `got: ${query}`);
+    });
+
+    it('sorts DESC by a single field', () => {
+      const result = builder.find({}, { sort: { created_at: -1 } });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(query.includes(`ORDER BY json_extract(data, '$.created_at') DESC`), `got: ${query}`);
+    });
+
+    it('ORDER BY appears before LIMIT', () => {
+      const result = builder.find({}, { sort: { name: 1 }, limit: 10 });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(query.indexOf('ORDER BY') < query.indexOf('LIMIT'), `got: ${query}`);
+    });
+
+    it('sort + limit + skip produces correct clause order', () => {
+      const result = builder.find({}, { sort: { name: 1 }, limit: 10, skip: 5 });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(/ORDER BY.*LIMIT.*OFFSET/s.test(query), `got: ${query}`);
+    });
   });
 
   describe('update operations', () => {

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -67,6 +67,12 @@ describe('sqliteSQLBuilder', () => {
       assert.ok(query.includes('OFFSET'));
     });
 
+    it('empty sort object produces no ORDER BY clause', () => {
+      const result = builder.find({}, { sort: {} });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(!query.includes('ORDER BY'), `got: ${query}`);
+    });
+
     it('sorts ASC by a single field', () => {
       const result = builder.find({}, { sort: { name: 1 } });
       const { query } = SQL.format(result, sqliteFormatter);
@@ -119,6 +125,15 @@ describe('sqliteSQLBuilder', () => {
       const { query } = SQL.format(result, sqliteFormatter);
       assert.ok(
         query.includes(`ORDER BY json_extract(data, '$.address.city') ASC`),
+        `got: ${query}`,
+      );
+    });
+
+    it('sorts by a deeply nested field (3 levels)', () => {
+      const result = builder.find({}, { sort: { 'a.b.c': -1 } });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(
+        query.includes(`ORDER BY json_extract(data, '$.a.b.c') DESC`),
         `got: ${query}`,
       );
     });

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -70,23 +70,35 @@ describe('sqliteSQLBuilder', () => {
     it('sorts ASC by a single field', () => {
       const result = builder.find({}, { sort: { name: 1 } });
       const { query } = SQL.format(result, sqliteFormatter);
-      assert.ok(query.includes(`ORDER BY json_extract(data, '$.name') ASC`), `got: ${query}`);
+      assert.ok(
+        query.includes(`ORDER BY json_extract(data, '$.name') ASC`),
+        `got: ${query}`,
+      );
     });
 
     it('sorts DESC by a single field', () => {
       const result = builder.find({}, { sort: { created_at: -1 } });
       const { query } = SQL.format(result, sqliteFormatter);
-      assert.ok(query.includes(`ORDER BY json_extract(data, '$.created_at') DESC`), `got: ${query}`);
+      assert.ok(
+        query.includes(`ORDER BY json_extract(data, '$.created_at') DESC`),
+        `got: ${query}`,
+      );
     });
 
     it('ORDER BY appears before LIMIT', () => {
       const result = builder.find({}, { sort: { name: 1 }, limit: 10 });
       const { query } = SQL.format(result, sqliteFormatter);
-      assert.ok(query.indexOf('ORDER BY') < query.indexOf('LIMIT'), `got: ${query}`);
+      assert.ok(
+        query.indexOf('ORDER BY') < query.indexOf('LIMIT'),
+        `got: ${query}`,
+      );
     });
 
     it('sort + limit + skip produces correct clause order', () => {
-      const result = builder.find({}, { sort: { name: 1 }, limit: 10, skip: 5 });
+      const result = builder.find(
+        {},
+        { sort: { name: 1 }, limit: 10, skip: 5 },
+      );
       const { query } = SQL.format(result, sqliteFormatter);
       assert.ok(/ORDER BY.*LIMIT.*OFFSET/s.test(query), `got: ${query}`);
     });

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -102,6 +102,26 @@ describe('sqliteSQLBuilder', () => {
       const { query } = SQL.format(result, sqliteFormatter);
       assert.ok(/ORDER BY.*LIMIT.*OFFSET/s.test(query), `got: ${query}`);
     });
+
+    it('sorts by multiple fields', () => {
+      const result = builder.find({}, { sort: { age: -1, name: 1 } });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(
+        query.includes(
+          `ORDER BY json_extract(data, '$.age') DESC,json_extract(data, '$.name') ASC`,
+        ),
+        `got: ${query}`,
+      );
+    });
+
+    it('sorts by a nested field', () => {
+      const result = builder.find({}, { sort: { 'address.city': 1 } });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(
+        query.includes(`ORDER BY json_extract(data, '$.address.city') ASC`),
+        `got: ${query}`,
+      );
+    });
   });
 
   describe('update operations', () => {

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -137,6 +137,20 @@ describe('sqliteSQLBuilder', () => {
         `got: ${query}`,
       );
     });
+
+    it('sorts by _id using the native column, not the JSON field', () => {
+      const result = builder.find({}, { sort: { _id: 1 } });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(query.includes('ORDER BY _id ASC'), `got: ${query}`);
+      assert.ok(!query.includes('json_extract'), `got: ${query}`);
+    });
+
+    it('sorts by _version using the native column, not the JSON field', () => {
+      const result = builder.find({}, { sort: { _version: -1 } });
+      const { query } = SQL.format(result, sqliteFormatter);
+      assert.ok(query.includes('ORDER BY _version DESC'), `got: ${query}`);
+      assert.ok(!query.includes('json_extract'), `got: ${query}`);
+    });
   });
 
   describe('update operations', () => {


### PR DESCRIPTION
## Summary

- Adds `sort?: { [field: string]: 1 | -1 }` to `FindOptions`
- PostgreSQL builder emits `ORDER BY data -> 'field' ASC NULLS FIRST|DESC NULLS LAST` (jsonb operator preserves type for correct numeric ordering); nested paths use `data #> '{a,b}'`
- SQLite builder emits `ORDER BY json_extract(data, '$.field') ASC|DESC`; nested paths use `$.a.b` naturally
- MongoDB shim's `toFindOptions` passes `sort` through to Pongo options
- Supports single field, multiple fields, nested paths (`address.city`), deeply nested paths (`a.b.c`), and metadata columns (`_id`, `_version`)
- Empty `sort: {}` is a no-op (no `ORDER BY` clause emitted)

## Motivation

`find()` already supports `limit` and `skip` but lacks `sort`, forcing callers to fetch all matching documents and sort in memory. With this change, sorting is pushed down to the database as a single round-trip.

## Test plan

- [ ] Unit tests: 13 new cases in `sqlBuilder.unit.spec.ts` for both PostgreSQL and SQLite builders (ASC, DESC, ORDER BY before LIMIT, sort+limit+skip, empty sort, multiple fields, nested field, deeply nested field, NULLS FIRST/LAST, `_id` sort, `_version` sort)
- [ ] E2E tests: 7 new cases in `compatibilityTest.e2e.spec.ts` — sort ASC parity, sort DESC+limit+skip parity, multi-field parity, nested field parity, numeric ordering correctness, `_id` sort parity, NULL ordering parity (all vs MongoDB)
- [ ] All existing unit tests continue to pass (183 total)

## Correctness notes

- **Numeric sort**: `data ->>` returns `text` in PostgreSQL, causing lexicographic ordering that breaks for values with different digit counts (e.g. `9 > 10` as text). Uses `data ->` / `data #>` instead, which return `jsonb` and sort numerically. SQLite's `json_extract` already returns typed values and was unaffected.
- **NULL ordering**: PostgreSQL's default `NULLS LAST` for ASC differs from MongoDB, which places missing/null fields first. All PG sort clauses now use `NULLS FIRST` (ASC) and `NULLS LAST` (DESC). SQLite already matches MongoDB's behaviour.
- **`_id` / `_version`**: These are native table columns, not JSON fields. Sort on these now emits `ORDER BY _id` instead of the wrong `ORDER BY data -> '_id'`, matching the existing guard in the filter builder.

## Known limitations

- **Array fields**: MongoDB uses the minimum array element for ASC sort and the maximum for DESC. Replicating this would require a correlated subquery per sort field (`SELECT MIN(el) FROM jsonb_array_elements(data -> 'field') el`) and we cannot know at query-build time whether a field holds an array. Not implemented.
- **Mixed types**: MongoDB has a defined BSON type sort order (null < numbers < strings < arrays < objects). PostgreSQL jsonb has its own ordering which partially overlaps but diverges (e.g. jsonb places booleans before numbers; BSON does not). This only affects schema-less collections where the same field holds different types across documents.

## Other notes

- The pre-existing `replaceMany returns correct result sets for updates and conflicts` E2E failure is unrelated to this change (fails on `main` too)
- `PongoCollectionSQLBuilder` interface, `pongoCollection.ts`, and `FindCursor` required no changes