### PR TITLE
Add for support top-level logical operators in SQL builders

### DIFF
--- a/src/packages/pongo/src/core/collection/filters/filters.ts
+++ b/src/packages/pongo/src/core/collection/filters/filters.ts
@@ -10,7 +10,7 @@ const asPlainObjectWithSingleKey = <T>(
   !Array.isArray(filter) &&
   Object.keys(filter).length === 1 &&
   key in filter
-    ? filter
+    ? { [key]: (filter as Record<string, unknown>)[key] }
     : undefined;
 
 export const idFromFilter = <T>(

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -411,16 +411,21 @@ export declare type AlternativeType<T> =
 export declare type Condition<T> =
   AlternativeType<T> | PongoFilterOperator<AlternativeType<T>>;
 
-export declare type PongoFilter<TSchema> =
-  | {
-      [P in keyof WithId<TSchema>]?: Condition<WithId<TSchema>[P]>;
-    }
-  | HasId; // TODO: & RootFilterOperators<WithId<TSchema>>;
-
-export declare interface RootFilterOperators<TSchema> extends Document {
+export declare interface LogicalRootFilterOperators<TSchema> extends Document {
   $and?: PongoFilter<TSchema>[];
   $nor?: PongoFilter<TSchema>[];
   $or?: PongoFilter<TSchema>[];
+}
+
+export declare type PongoFilter<TSchema> =
+  | ({
+      [P in keyof WithId<TSchema>]?: Condition<WithId<TSchema>[P]>;
+    } & LogicalRootFilterOperators<WithId<TSchema>>)
+  | (HasId & LogicalRootFilterOperators<WithId<TSchema>>);
+
+export declare interface RootFilterOperators<
+  TSchema,
+> extends LogicalRootFilterOperators<TSchema> {
   $text?: {
     $search: string;
     $language?: string;

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -411,21 +411,10 @@ export declare type AlternativeType<T> =
 export declare type Condition<T> =
   AlternativeType<T> | PongoFilterOperator<AlternativeType<T>>;
 
-export declare interface LogicalRootFilterOperators<TSchema> {
+export declare interface RootFilterOperators<TSchema> extends Document {
   $and?: PongoFilter<TSchema>[];
   $nor?: PongoFilter<TSchema>[];
   $or?: PongoFilter<TSchema>[];
-}
-
-export declare type PongoFilter<TSchema> =
-  | ({
-      [P in keyof WithId<TSchema>]?: Condition<WithId<TSchema>[P]>;
-    } & LogicalRootFilterOperators<WithId<TSchema>>)
-  | (HasId & LogicalRootFilterOperators<WithId<TSchema>>);
-
-export declare interface RootFilterOperators<
-  TSchema,
-> extends LogicalRootFilterOperators<TSchema> {
   $text?: {
     $search: string;
     $language?: string;
@@ -435,6 +424,13 @@ export declare interface RootFilterOperators<
   $where?: string | ((this: TSchema) => boolean);
   $comment?: string | Document;
 }
+
+export declare type PongoFilter<TSchema> =
+  | ({
+      [P in keyof WithId<TSchema>]?: Condition<WithId<TSchema>[P]>;
+    } & Pick<RootFilterOperators<WithId<TSchema>>, '$and' | '$nor' | '$or'>)
+  | (HasId &
+      Pick<RootFilterOperators<WithId<TSchema>>, '$and' | '$nor' | '$or'>);
 
 export declare interface PongoFilterOperator<
   TValue,

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -411,7 +411,7 @@ export declare type AlternativeType<T> =
 export declare type Condition<T> =
   AlternativeType<T> | PongoFilterOperator<AlternativeType<T>>;
 
-export declare interface LogicalRootFilterOperators<TSchema> extends Document {
+export declare interface LogicalRootFilterOperators<TSchema> {
   $and?: PongoFilter<TSchema>[];
   $nor?: PongoFilter<TSchema>[];
   $or?: PongoFilter<TSchema>[];

--- a/src/packages/pongo/src/e2e/postgresql/pg/postgres.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/postgresql/pg/postgres.e2e.spec.ts
@@ -716,6 +716,110 @@ describe('MongoDB Compatibility Tests', () => {
       );
     });
 
+    it('should find documents with a top-level $or filter', async () => {
+      const pongoCollection = pongoDb.collection<User>('findWithTopLevelOr');
+      const mongoCollection = mongoDb.collection<User>(
+        'shimfindWithTopLevelOr',
+      );
+      const docs = [
+        { name: 'David', age: 40 },
+        { name: 'Eve', age: 45 },
+        { name: 'Frank', age: 50 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({
+        $or: [{ age: 40 }, { age: 50 }],
+      });
+      const mongoDocs = await mongoCollection
+        .find({
+          $or: [{ age: 40 }, { age: 50 }],
+        })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
+    it('should find documents with nested $and and $or filters', async () => {
+      const pongoCollection = pongoDb.collection<User>(
+        'findWithNestedLogicalOperators',
+      );
+      const mongoCollection = mongoDb.collection<User>(
+        'shimfindWithNestedLogicalOperators',
+      );
+      const docs = [
+        { name: 'Anita', age: 25 },
+        { name: 'Roger', age: 30 },
+        { name: 'Cruella', age: 35 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({
+        $and: [{ age: { $gte: 30 } }, { $or: [{ name: 'Roger' }] }],
+      });
+      const mongoDocs = await mongoCollection
+        .find({
+          $and: [{ age: { $gte: 30 } }, { $or: [{ name: 'Roger' }] }],
+        })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
+    it('should find documents with a top-level $nor filter', async () => {
+      const pongoCollection = pongoDb.collection<User>('findWithTopLevelNor');
+      const mongoCollection = mongoDb.collection<User>(
+        'shimfindWithTopLevelNor',
+      );
+      const docs = [
+        { name: 'Anita', age: 25 },
+        { name: 'Roger', age: 30 },
+        { name: 'Cruella', age: 35 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({
+        $nor: [{ age: 25 }, { age: 35 }],
+      });
+      const mongoDocs = await mongoCollection
+        .find({
+          $nor: [{ age: 25 }, { age: 35 }],
+        })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
     it('should find one document with a filter', async () => {
       const pongoCollection = pongoDb.collection<User>('testCollection');
       const mongoCollection = mongoDb.collection<User>('shimtestCollection');

--- a/src/packages/pongo/src/e2e/sqlite/sqlite3/sqlite3.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/sqlite/sqlite3/sqlite3.e2e.spec.ts
@@ -720,6 +720,110 @@ describe('SQLite MongoDB Compatibility Tests', () => {
       );
     });
 
+    it('should find documents with a top-level $or filter', async () => {
+      const pongoCollection = pongoDb.collection<User>('findWithTopLevelOr');
+      const mongoCollection = mongoDb.collection<User>(
+        'shimfindWithTopLevelOr',
+      );
+      const docs = [
+        { name: 'David', age: 40 },
+        { name: 'Eve', age: 45 },
+        { name: 'Frank', age: 50 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({
+        $or: [{ age: 40 }, { age: 50 }],
+      });
+      const mongoDocs = await mongoCollection
+        .find({
+          $or: [{ age: 40 }, { age: 50 }],
+        })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
+    it('should find documents with nested $and and $or filters', async () => {
+      const pongoCollection = pongoDb.collection<User>(
+        'findWithNestedLogicalOperators',
+      );
+      const mongoCollection = mongoDb.collection<User>(
+        'shimfindWithNestedLogicalOperators',
+      );
+      const docs = [
+        { name: 'Anita', age: 25 },
+        { name: 'Roger', age: 30 },
+        { name: 'Cruella', age: 35 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({
+        $and: [{ age: { $gte: 30 } }, { $or: [{ name: 'Roger' }] }],
+      });
+      const mongoDocs = await mongoCollection
+        .find({
+          $and: [{ age: { $gte: 30 } }, { $or: [{ name: 'Roger' }] }],
+        })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
+    it('should find documents with a top-level $nor filter', async () => {
+      const pongoCollection = pongoDb.collection<User>('findWithTopLevelNor');
+      const mongoCollection = mongoDb.collection<User>(
+        'shimfindWithTopLevelNor',
+      );
+      const docs = [
+        { name: 'Anita', age: 25 },
+        { name: 'Roger', age: 30 },
+        { name: 'Cruella', age: 35 },
+      ];
+
+      await pongoCollection.insertOne(docs[0]!);
+      await pongoCollection.insertOne(docs[1]!);
+      await pongoCollection.insertOne(docs[2]!);
+
+      await mongoCollection.insertOne(docs[0]!);
+      await mongoCollection.insertOne(docs[1]!);
+      await mongoCollection.insertOne(docs[2]!);
+
+      const pongoDocs = await pongoCollection.find({
+        $nor: [{ age: 25 }, { age: 35 }],
+      });
+      const mongoDocs = await mongoCollection
+        .find({
+          $nor: [{ age: 25 }, { age: 35 }],
+        })
+        .toArray();
+
+      assert.deepStrictEqual(
+        pongoDocs.map((d) => ({ name: d.name, age: d.age })),
+        mongoDocs.map((d) => ({ name: d.name, age: d.age })),
+      );
+    });
+
     it('should find one document with a filter', async () => {
       const pongoCollection = pongoDb.collection<User>('testCollection');
       const mongoCollection = mongoDb.collection<User>('shimtestCollection');

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
@@ -4,7 +4,7 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
-  type LogicalRootFilterOperators,
+  type RootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -23,7 +23,7 @@ export const constructFilterQuery = <T>(
   ensureSupportedRootOperators(filter as Record<string, unknown>);
 
   const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
-    LogicalRootFilterOperators<T>;
+    Pick<RootFilterOperators<T>, '$and' | '$nor' | '$or'>;
   const parts: SQL[] = [];
 
   const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
@@ -4,6 +4,7 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
+  type RootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -11,19 +12,87 @@ import { handleOperator } from './queryOperators';
 export * from './queryOperators';
 
 const AND = 'AND';
+const OR = 'OR';
+
+const unsupportedRootOperators = ['$text', '$where', '$comment'] as const;
 
 export const constructFilterQuery = <T>(
   filter: PongoFilter<T>,
+  serializer: JSONSerializer,
+): SQL => {
+  ensureSupportedRootOperators(filter as Record<string, unknown>);
+
+  const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
+    RootFilterOperators<T>;
+  const parts: SQL[] = [];
+
+  const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);
+  if (!SQL.check.isEmpty(fieldFilterQuery)) {
+    parts.push(fieldFilterQuery);
+  }
+
+  const orFilterQuery = constructLogicalFilterQuery($or, OR, serializer);
+  if (!SQL.check.isEmpty(orFilterQuery)) {
+    parts.push(orFilterQuery);
+  }
+
+  const andFilterQuery = constructLogicalFilterQuery($and, AND, serializer);
+  if (!SQL.check.isEmpty(andFilterQuery)) {
+    parts.push(andFilterQuery);
+  }
+
+  const norFilterQuery = constructNorFilterQuery($nor, serializer);
+  if (!SQL.check.isEmpty(norFilterQuery)) {
+    parts.push(norFilterQuery);
+  }
+
+  return SQL.merge(parts, ` ${AND} `);
+};
+
+const constructFieldFilterQuery = (
+  filter: Record<string, unknown>,
   serializer: JSONSerializer,
 ): SQL =>
   SQL.merge(
     Object.entries(filter).map(([key, value]) =>
       isRecord(value)
         ? constructComplexFilterQuery(key, value, serializer)
-        : handleOperator(key, '$eq', value, serializer),
+        : handleOperator(key, QueryOperators.$eq, value, serializer),
     ),
     ` ${AND} `,
   );
+
+const constructLogicalFilterQuery = <T>(
+  filters: PongoFilter<T>[] | undefined,
+  joinOperator: typeof AND | typeof OR,
+  serializer: JSONSerializer,
+): SQL => {
+  if (!filters) {
+    return SQL.EMPTY;
+  }
+
+  if (filters.length === 0) {
+    return joinOperator === OR ? SQL`1 = 0` : SQL.EMPTY;
+  }
+
+  return SQL`(${SQL.merge(
+    filters.map((filter) =>
+      wrapFilterQuery(constructFilterQuery(filter, serializer)),
+    ),
+    ` ${joinOperator} `,
+  )})`;
+};
+
+const constructNorFilterQuery = <T>(
+  filters: PongoFilter<T>[] | undefined,
+  serializer: JSONSerializer,
+): SQL => {
+  if (!filters || filters.length === 0) {
+    return SQL.EMPTY;
+  }
+
+  return SQL`NOT ${constructLogicalFilterQuery(filters, OR, serializer)}`;
+};
 
 const constructComplexFilterQuery = (
   key: string,
@@ -45,6 +114,19 @@ const constructComplexFilterQuery = (
     ),
     ` ${AND} `,
   );
+};
+
+const wrapFilterQuery = (filterQuery: SQL): SQL =>
+  SQL.check.isEmpty(filterQuery) ? SQL`(1 = 1)` : SQL`(${filterQuery})`;
+
+const ensureSupportedRootOperators = (
+  filter: Record<string, unknown>,
+): void => {
+  for (const operator of unsupportedRootOperators) {
+    if (operator in filter) {
+      throw new Error(`Unsupported root operator: ${operator}`);
+    }
+  }
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
@@ -4,7 +4,7 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
-  type RootFilterOperators,
+  type LogicalRootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -23,7 +23,7 @@ export const constructFilterQuery = <T>(
   ensureSupportedRootOperators(filter as Record<string, unknown>);
 
   const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
-    RootFilterOperators<T>;
+    LogicalRootFilterOperators<T>;
   const parts: SQL[] = [];
 
   const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts
@@ -4,7 +4,6 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
-  type RootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -20,28 +19,29 @@ export const constructFilterQuery = <T>(
   filter: PongoFilter<T>,
   serializer: JSONSerializer,
 ): SQL => {
-  ensureSupportedRootOperators(filter as Record<string, unknown>);
-
-  const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
-    Pick<RootFilterOperators<T>, '$and' | '$nor' | '$or'>;
+  ensureSupportedRootOperators(filter);
   const parts: SQL[] = [];
 
-  const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);
+  const fieldFilterQuery = constructFieldFilterQuery(filter, serializer);
   if (!SQL.check.isEmpty(fieldFilterQuery)) {
     parts.push(fieldFilterQuery);
   }
 
-  const orFilterQuery = constructLogicalFilterQuery($or, OR, serializer);
+  const orFilterQuery = constructLogicalFilterQuery(filter.$or, OR, serializer);
   if (!SQL.check.isEmpty(orFilterQuery)) {
     parts.push(orFilterQuery);
   }
 
-  const andFilterQuery = constructLogicalFilterQuery($and, AND, serializer);
+  const andFilterQuery = constructLogicalFilterQuery(
+    filter.$and,
+    AND,
+    serializer,
+  );
   if (!SQL.check.isEmpty(andFilterQuery)) {
     parts.push(andFilterQuery);
   }
 
-  const norFilterQuery = constructNorFilterQuery($nor, serializer);
+  const norFilterQuery = constructNorFilterQuery(filter.$nor, serializer);
   if (!SQL.check.isEmpty(norFilterQuery)) {
     parts.push(norFilterQuery);
   }
@@ -49,15 +49,19 @@ export const constructFilterQuery = <T>(
   return SQL.merge(parts, ` ${AND} `);
 };
 
-const constructFieldFilterQuery = (
-  filter: Record<string, unknown>,
+const constructFieldFilterQuery = <T>(
+  filter: PongoFilter<T>,
   serializer: JSONSerializer,
 ): SQL =>
   SQL.merge(
-    Object.entries(filter).map(([key, value]) =>
-      isRecord(value)
-        ? constructComplexFilterQuery(key, value, serializer)
-        : handleOperator(key, QueryOperators.$eq, value, serializer),
+    objectEntries(filter).flatMap(([key, value]) =>
+      isLogicalRootOperator(key)
+        ? []
+        : [
+            isRecord(value)
+              ? constructComplexFilterQuery(key, value, serializer)
+              : handleOperator(key, QueryOperators.$eq, value, serializer),
+          ],
     ),
     ` ${AND} `,
   );
@@ -67,31 +71,46 @@ const constructLogicalFilterQuery = <T>(
   joinOperator: typeof AND | typeof OR,
   serializer: JSONSerializer,
 ): SQL => {
-  if (!filters) {
+  if (!filters?.length) {
     return SQL.EMPTY;
   }
 
-  if (filters.length === 0) {
-    return joinOperator === OR ? SQL`1 = 0` : SQL.EMPTY;
+  const subFilterQueries = filters.reduce<SQL[]>((queries, filter) => {
+    const query = constructFilterQuery(filter, serializer);
+    if (!SQL.check.isEmpty(query)) {
+      queries.push(query);
+    }
+
+    return queries;
+  }, []);
+
+  if (subFilterQueries.length === 0) {
+    return SQL.EMPTY;
   }
 
-  return SQL`(${SQL.merge(
-    filters.map((filter) =>
-      wrapFilterQuery(constructFilterQuery(filter, serializer)),
-    ),
-    ` ${joinOperator} `,
-  )})`;
+  if (subFilterQueries.length === 1) {
+    return wrapFilterQuery(subFilterQueries[0]!);
+  }
+
+  return SQL`(${SQL.merge(subFilterQueries.map(wrapFilterQuery), ` ${joinOperator} `)})`;
 };
 
 const constructNorFilterQuery = <T>(
   filters: PongoFilter<T>[] | undefined,
   serializer: JSONSerializer,
 ): SQL => {
-  if (!filters || filters.length === 0) {
+  if (!filters?.length) {
     return SQL.EMPTY;
   }
 
-  return SQL`NOT ${constructLogicalFilterQuery(filters, OR, serializer)}`;
+  const logicalFilterQuery = constructLogicalFilterQuery(
+    filters,
+    OR,
+    serializer,
+  );
+  return SQL.check.isEmpty(logicalFilterQuery)
+    ? SQL.EMPTY
+    : SQL`NOT ${logicalFilterQuery}`;
 };
 
 const constructComplexFilterQuery = (
@@ -116,18 +135,18 @@ const constructComplexFilterQuery = (
   );
 };
 
-const wrapFilterQuery = (filterQuery: SQL): SQL =>
-  SQL.check.isEmpty(filterQuery) ? SQL`(1 = 1)` : SQL`(${filterQuery})`;
+const wrapFilterQuery = (filterQuery: SQL): SQL => SQL`(${filterQuery})`;
 
-const ensureSupportedRootOperators = (
-  filter: Record<string, unknown>,
-): void => {
+const ensureSupportedRootOperators = (filter: object): void => {
   for (const operator of unsupportedRootOperators) {
     if (operator in filter) {
       throw new Error(`Unsupported root operator: ${operator}`);
     }
   }
 };
+
+const isLogicalRootOperator = (key: string): key is '$and' | '$nor' | '$or' =>
+  key === '$and' || key === '$nor' || key === '$or';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -201,6 +201,8 @@ describe('find() logical operators', () => {
 
     assert.ok(sql.includes(' OR '), `got: ${sql}`);
     assert.ok(!sql.includes('$.$or'), `got: ${sql}`);
+    assert.ok(!sql.includes('1 = 0'), `got: ${sql}`);
+    assert.ok(!sql.includes('1 = 1'), `got: ${sql}`);
   });
 
   it('ANDs normal fields with $or blocks', () => {
@@ -222,24 +224,17 @@ describe('find() logical operators', () => {
 
     assert.ok(sql.includes(' AND '), `got: ${sql}`);
     assert.ok(sql.includes(' OR '), `got: ${sql}`);
-  });
-
-  it('treats empty $or as match-nothing', () => {
-    const query = builder.find<{ flag: boolean }>({
-      $or: [],
-    });
-    const { query: sql } = SQL.format(query, pgFormatter);
-
-    assert.ok(/WHERE\s+1 = 0/.test(sql), `got: ${sql}`);
+    assert.ok(!sql.includes('1 = 0'), `got: ${sql}`);
+    assert.ok(!sql.includes('1 = 1'), `got: ${sql}`);
   });
 
   it('throws for unsupported root operators instead of treating them as fields', () => {
+    const unsupportedFilter = {
+      $text: { $search: 'active' },
+    } as unknown as Parameters<typeof builder.find>[0];
+
     assert.throws(
-      () =>
-        builder.find({
-          $text: { $search: 'active' },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any),
+      () => builder.find(unsupportedFilter),
       /Unsupported root operator: \$text/,
     );
   });

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -2,8 +2,8 @@ import { JSONSerializer, SQL } from '@event-driven-io/dumbo';
 import { pgFormatter } from '@event-driven-io/dumbo/pg';
 import assert from 'assert';
 import { describe, it } from 'vitest';
-import type { ExpectedDocumentVersion } from '../../../../core';
 import { postgresSQLBuilder } from '.';
+import type { ExpectedDocumentVersion } from '../../../../core';
 
 describe('insertOrReplace()', () => {
   const builder = postgresSQLBuilder('users', JSONSerializer);
@@ -187,5 +187,60 @@ describe('expected version markers', () => {
     const pinned = queryFor(2n);
     assert.ok(pinned.includes('_version'), `got: ${pinned}`);
     assert.notEqual(pinned, queryFor('NO_CONCURRENCY_CHECK'));
+  });
+});
+
+describe('find() logical operators', () => {
+  const builder = postgresSQLBuilder('users', JSONSerializer);
+
+  it('supports top-level $or', () => {
+    const query = builder.find<{ flag: boolean }>({
+      $or: [{ flag: true }, { flag: false }],
+    });
+    const { query: sql } = SQL.format(query, pgFormatter);
+
+    assert.ok(sql.includes(' OR '), `got: ${sql}`);
+    assert.ok(!sql.includes('$.$or'), `got: ${sql}`);
+  });
+
+  it('ANDs normal fields with $or blocks', () => {
+    const query = builder.find<{ flag: boolean; status: string }>({
+      status: 'active',
+      $or: [{ flag: true }, { flag: false }],
+    });
+    const { query: sql } = SQL.format(query, pgFormatter);
+
+    assert.ok(sql.includes(' AND '), `got: ${sql}`);
+    assert.ok(sql.includes(' OR '), `got: ${sql}`);
+  });
+
+  it('supports nested logical operators', () => {
+    const query = builder.find<{ flag: boolean; status: string }>({
+      $and: [{ status: 'active' }, { $or: [{ flag: true }, { flag: false }] }],
+    });
+    const { query: sql } = SQL.format(query, pgFormatter);
+
+    assert.ok(sql.includes(' AND '), `got: ${sql}`);
+    assert.ok(sql.includes(' OR '), `got: ${sql}`);
+  });
+
+  it('treats empty $or as match-nothing', () => {
+    const query = builder.find<{ flag: boolean }>({
+      $or: [],
+    });
+    const { query: sql } = SQL.format(query, pgFormatter);
+
+    assert.ok(/WHERE\s+1 = 0/.test(sql), `got: ${sql}`);
+  });
+
+  it('throws for unsupported root operators instead of treating them as fields', () => {
+    assert.throws(
+      () =>
+        builder.find({
+          $text: { $search: 'active' },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any),
+      /Unsupported root operator: \$text/,
+    );
   });
 });

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
@@ -4,7 +4,7 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
-  type LogicalRootFilterOperators,
+  type RootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -23,7 +23,7 @@ export const constructFilterQuery = <T>(
   ensureSupportedRootOperators(filter as Record<string, unknown>);
 
   const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
-    LogicalRootFilterOperators<T>;
+    Pick<RootFilterOperators<T>, '$and' | '$nor' | '$or'>;
   const parts: SQL[] = [];
 
   const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
@@ -4,6 +4,7 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
+  type RootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -11,19 +12,87 @@ import { handleOperator } from './queryOperators';
 export * from './queryOperators';
 
 const AND = 'AND';
+const OR = 'OR';
+
+const unsupportedRootOperators = ['$text', '$where', '$comment'] as const;
 
 export const constructFilterQuery = <T>(
   filter: PongoFilter<T>,
+  serializer: JSONSerializer,
+): SQL => {
+  ensureSupportedRootOperators(filter as Record<string, unknown>);
+
+  const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
+    RootFilterOperators<T>;
+  const parts: SQL[] = [];
+
+  const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);
+  if (!SQL.check.isEmpty(fieldFilterQuery)) {
+    parts.push(fieldFilterQuery);
+  }
+
+  const orFilterQuery = constructLogicalFilterQuery($or, OR, serializer);
+  if (!SQL.check.isEmpty(orFilterQuery)) {
+    parts.push(orFilterQuery);
+  }
+
+  const andFilterQuery = constructLogicalFilterQuery($and, AND, serializer);
+  if (!SQL.check.isEmpty(andFilterQuery)) {
+    parts.push(andFilterQuery);
+  }
+
+  const norFilterQuery = constructNorFilterQuery($nor, serializer);
+  if (!SQL.check.isEmpty(norFilterQuery)) {
+    parts.push(norFilterQuery);
+  }
+
+  return SQL.merge(parts, ` ${AND} `);
+};
+
+const constructFieldFilterQuery = (
+  filter: Record<string, unknown>,
   serializer: JSONSerializer,
 ): SQL =>
   SQL.merge(
     Object.entries(filter).map(([key, value]) =>
       isRecord(value)
         ? constructComplexFilterQuery(key, value, serializer)
-        : handleOperator(key, '$eq', value, serializer),
+        : handleOperator(key, QueryOperators.$eq, value, serializer),
     ),
     ` ${AND} `,
   );
+
+const constructLogicalFilterQuery = <T>(
+  filters: PongoFilter<T>[] | undefined,
+  joinOperator: typeof AND | typeof OR,
+  serializer: JSONSerializer,
+): SQL => {
+  if (!filters) {
+    return SQL.EMPTY;
+  }
+
+  if (filters.length === 0) {
+    return joinOperator === OR ? SQL`1 = 0` : SQL.EMPTY;
+  }
+
+  return SQL`(${SQL.merge(
+    filters.map((filter) =>
+      wrapFilterQuery(constructFilterQuery(filter, serializer)),
+    ),
+    ` ${joinOperator} `,
+  )})`;
+};
+
+const constructNorFilterQuery = <T>(
+  filters: PongoFilter<T>[] | undefined,
+  serializer: JSONSerializer,
+): SQL => {
+  if (!filters || filters.length === 0) {
+    return SQL.EMPTY;
+  }
+
+  return SQL`NOT ${constructLogicalFilterQuery(filters, OR, serializer)}`;
+};
 
 const constructComplexFilterQuery = (
   key: string,
@@ -45,6 +114,19 @@ const constructComplexFilterQuery = (
     ),
     ` ${AND} `,
   );
+};
+
+const wrapFilterQuery = (filterQuery: SQL): SQL =>
+  SQL.check.isEmpty(filterQuery) ? SQL`(1 = 1)` : SQL`(${filterQuery})`;
+
+const ensureSupportedRootOperators = (
+  filter: Record<string, unknown>,
+): void => {
+  for (const operator of unsupportedRootOperators) {
+    if (operator in filter) {
+      throw new Error(`Unsupported root operator: ${operator}`);
+    }
+  }
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
@@ -4,7 +4,7 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
-  type RootFilterOperators,
+  type LogicalRootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -23,7 +23,7 @@ export const constructFilterQuery = <T>(
   ensureSupportedRootOperators(filter as Record<string, unknown>);
 
   const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
-    RootFilterOperators<T>;
+    LogicalRootFilterOperators<T>;
   const parts: SQL[] = [];
 
   const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts
@@ -4,7 +4,6 @@ import {
   hasOperators,
   objectEntries,
   QueryOperators,
-  type RootFilterOperators,
   type PongoFilter,
 } from '../../../../../core';
 import { handleOperator } from './queryOperators';
@@ -20,28 +19,29 @@ export const constructFilterQuery = <T>(
   filter: PongoFilter<T>,
   serializer: JSONSerializer,
 ): SQL => {
-  ensureSupportedRootOperators(filter as Record<string, unknown>);
-
-  const { $or, $and, $nor, ...rest } = filter as PongoFilter<T> &
-    Pick<RootFilterOperators<T>, '$and' | '$nor' | '$or'>;
+  ensureSupportedRootOperators(filter);
   const parts: SQL[] = [];
 
-  const fieldFilterQuery = constructFieldFilterQuery(rest, serializer);
+  const fieldFilterQuery = constructFieldFilterQuery(filter, serializer);
   if (!SQL.check.isEmpty(fieldFilterQuery)) {
     parts.push(fieldFilterQuery);
   }
 
-  const orFilterQuery = constructLogicalFilterQuery($or, OR, serializer);
+  const orFilterQuery = constructLogicalFilterQuery(filter.$or, OR, serializer);
   if (!SQL.check.isEmpty(orFilterQuery)) {
     parts.push(orFilterQuery);
   }
 
-  const andFilterQuery = constructLogicalFilterQuery($and, AND, serializer);
+  const andFilterQuery = constructLogicalFilterQuery(
+    filter.$and,
+    AND,
+    serializer,
+  );
   if (!SQL.check.isEmpty(andFilterQuery)) {
     parts.push(andFilterQuery);
   }
 
-  const norFilterQuery = constructNorFilterQuery($nor, serializer);
+  const norFilterQuery = constructNorFilterQuery(filter.$nor, serializer);
   if (!SQL.check.isEmpty(norFilterQuery)) {
     parts.push(norFilterQuery);
   }
@@ -49,15 +49,19 @@ export const constructFilterQuery = <T>(
   return SQL.merge(parts, ` ${AND} `);
 };
 
-const constructFieldFilterQuery = (
-  filter: Record<string, unknown>,
+const constructFieldFilterQuery = <T>(
+  filter: PongoFilter<T>,
   serializer: JSONSerializer,
 ): SQL =>
   SQL.merge(
-    Object.entries(filter).map(([key, value]) =>
-      isRecord(value)
-        ? constructComplexFilterQuery(key, value, serializer)
-        : handleOperator(key, QueryOperators.$eq, value, serializer),
+    objectEntries(filter).flatMap(([key, value]) =>
+      isLogicalRootOperator(key)
+        ? []
+        : [
+            isRecord(value)
+              ? constructComplexFilterQuery(key, value, serializer)
+              : handleOperator(key, QueryOperators.$eq, value, serializer),
+          ],
     ),
     ` ${AND} `,
   );
@@ -67,31 +71,46 @@ const constructLogicalFilterQuery = <T>(
   joinOperator: typeof AND | typeof OR,
   serializer: JSONSerializer,
 ): SQL => {
-  if (!filters) {
+  if (!filters?.length) {
     return SQL.EMPTY;
   }
 
-  if (filters.length === 0) {
-    return joinOperator === OR ? SQL`1 = 0` : SQL.EMPTY;
+  const subFilterQueries = filters.reduce<SQL[]>((queries, filter) => {
+    const query = constructFilterQuery(filter, serializer);
+    if (!SQL.check.isEmpty(query)) {
+      queries.push(query);
+    }
+
+    return queries;
+  }, []);
+
+  if (subFilterQueries.length === 0) {
+    return SQL.EMPTY;
   }
 
-  return SQL`(${SQL.merge(
-    filters.map((filter) =>
-      wrapFilterQuery(constructFilterQuery(filter, serializer)),
-    ),
-    ` ${joinOperator} `,
-  )})`;
+  if (subFilterQueries.length === 1) {
+    return wrapFilterQuery(subFilterQueries[0]!);
+  }
+
+  return SQL`(${SQL.merge(subFilterQueries.map(wrapFilterQuery), ` ${joinOperator} `)})`;
 };
 
 const constructNorFilterQuery = <T>(
   filters: PongoFilter<T>[] | undefined,
   serializer: JSONSerializer,
 ): SQL => {
-  if (!filters || filters.length === 0) {
+  if (!filters?.length) {
     return SQL.EMPTY;
   }
 
-  return SQL`NOT ${constructLogicalFilterQuery(filters, OR, serializer)}`;
+  const logicalFilterQuery = constructLogicalFilterQuery(
+    filters,
+    OR,
+    serializer,
+  );
+  return SQL.check.isEmpty(logicalFilterQuery)
+    ? SQL.EMPTY
+    : SQL`NOT ${logicalFilterQuery}`;
 };
 
 const constructComplexFilterQuery = (
@@ -116,18 +135,18 @@ const constructComplexFilterQuery = (
   );
 };
 
-const wrapFilterQuery = (filterQuery: SQL): SQL =>
-  SQL.check.isEmpty(filterQuery) ? SQL`(1 = 1)` : SQL`(${filterQuery})`;
+const wrapFilterQuery = (filterQuery: SQL): SQL => SQL`(${filterQuery})`;
 
-const ensureSupportedRootOperators = (
-  filter: Record<string, unknown>,
-): void => {
+const ensureSupportedRootOperators = (filter: object): void => {
   for (const operator of unsupportedRootOperators) {
     if (operator in filter) {
       throw new Error(`Unsupported root operator: ${operator}`);
     }
   }
 };
+
+const isLogicalRootOperator = (key: string): key is '$and' | '$nor' | '$or' =>
+  key === '$and' || key === '$nor' || key === '$or';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -1,5 +1,5 @@
 import { JSONSerializer, SQL } from '@event-driven-io/dumbo';
-import { sqliteFormatter } from '@event-driven-io/dumbo/sqlite3';
+import { sqliteFormatter } from '@event-driven-io/dumbo/sqlite';
 import { randomUUID } from 'crypto';
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
@@ -278,6 +278,62 @@ describe('sqliteSQLBuilder', () => {
 
       assert.ok(query.includes('SELECT COUNT(1) as count'));
       assert.ok(query.includes('WHERE'));
+    });
+  });
+
+  describe('logical operators', () => {
+    it('supports top-level $or', () => {
+      const result = builder.find<{ flag: boolean }>({
+        $or: [{ flag: true }, { flag: false }],
+      });
+      const { query } = SQL.format(result, sqliteFormatter);
+
+      assert.ok(query.includes(' OR '), `got: ${query}`);
+      assert.ok(!query.includes('$.$or'), `got: ${query}`);
+    });
+
+    it('ANDs normal fields with $or blocks', () => {
+      const result = builder.find<{ flag: boolean; status: string }>({
+        status: 'active',
+        $or: [{ flag: true }, { flag: false }],
+      });
+      const { query } = SQL.format(result, sqliteFormatter);
+
+      assert.ok(query.includes(' AND '), `got: ${query}`);
+      assert.ok(query.includes(' OR '), `got: ${query}`);
+    });
+
+    it('supports nested logical operators', () => {
+      const result = builder.find<{ flag: boolean; status: string }>({
+        $and: [
+          { status: 'active' },
+          { $or: [{ flag: true }, { flag: false }] },
+        ],
+      });
+      const { query } = SQL.format(result, sqliteFormatter);
+
+      assert.ok(query.includes(' AND '), `got: ${query}`);
+      assert.ok(query.includes(' OR '), `got: ${query}`);
+    });
+
+    it('treats empty $or as match-nothing', () => {
+      const result = builder.find<{ flag: boolean }>({
+        $or: [],
+      });
+      const { query } = SQL.format(result, sqliteFormatter);
+
+      assert.ok(/WHERE\s+1 = 0/.test(query), `got: ${query}`);
+    });
+
+    it('throws for unsupported root operators instead of treating them as fields', () => {
+      assert.throws(
+        () =>
+          builder.find({
+            $text: { $search: 'active' },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any),
+        /Unsupported root operator: \$text/,
+      );
     });
   });
 });

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -290,6 +290,8 @@ describe('sqliteSQLBuilder', () => {
 
       assert.ok(query.includes(' OR '), `got: ${query}`);
       assert.ok(!query.includes('$.$or'), `got: ${query}`);
+      assert.ok(!query.includes('1 = 0'), `got: ${query}`);
+      assert.ok(!query.includes('1 = 1'), `got: ${query}`);
     });
 
     it('ANDs normal fields with $or blocks', () => {
@@ -314,24 +316,17 @@ describe('sqliteSQLBuilder', () => {
 
       assert.ok(query.includes(' AND '), `got: ${query}`);
       assert.ok(query.includes(' OR '), `got: ${query}`);
-    });
-
-    it('treats empty $or as match-nothing', () => {
-      const result = builder.find<{ flag: boolean }>({
-        $or: [],
-      });
-      const { query } = SQL.format(result, sqliteFormatter);
-
-      assert.ok(/WHERE\s+1 = 0/.test(query), `got: ${query}`);
+      assert.ok(!query.includes('1 = 0'), `got: ${query}`);
+      assert.ok(!query.includes('1 = 1'), `got: ${query}`);
     });
 
     it('throws for unsupported root operators instead of treating them as fields', () => {
+      const unsupportedFilter = {
+        $text: { $search: 'active' },
+      } as unknown as Parameters<typeof builder.find>[0];
+
       assert.throws(
-        () =>
-          builder.find({
-            $text: { $search: 'active' },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } as any),
+        () => builder.find(unsupportedFilter),
         /Unsupported root operator: \$text/,
       );
     });


### PR DESCRIPTION
Refs #180

## Summary

This patch wires top-level logical operators into the current SQL filter builders and reconnects `PongoFilter<TSchema>` to the supported logical subset.

### What changed

- implement top-level `$or`, `$and`, `$nor` handling in:
  - `src/packages/pongo/src/storage/postgresql/core/sqlBuilder/filter/index.ts`
  - `src/packages/pongo/src/storage/sqlite/core/sqlBuilder/filter/index.ts`
- reconnect `PongoFilter<TSchema>` to the supported logical subset using:
  - `Pick<RootFilterOperators<WithId<TSchema>>, '$and' | '$nor' | '$or'>`
- explicitly reject unsupported root operators (`$text`, `$where`, `$comment`) in the SQL builders instead of letting them fall through as field names
- add unit coverage for logical operators in both SQL builder test suites

### Notes

- this keeps the existing PG / SQLite builder split instead of introducing a new shared abstraction
- this keeps unsupported root operators out of the public `PongoFilter` surface for now

## Verification

```sh
npm run build
npx vitest run packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
```
