### PR TITLE
Ensured that TaskProcessor used in connection pools clears pending tasks

### DIFF
--- a/src/packages/dumbo/src/core/connections/connection.ts
+++ b/src/packages/dumbo/src/core/connections/connection.ts
@@ -6,7 +6,7 @@ import {
   type WithSQLExecutor,
 } from '../execute';
 import type { JSONSerializer } from '../serializer';
-import type { OperationContext } from '../taskProcessing';
+import type { AbortOptions, OperationContext } from '../taskProcessing';
 import {
   transactionFactoryWithDbClient,
   type AnyDatabaseTransaction,
@@ -66,7 +66,7 @@ export type ConnectionFactory<
   ConnectionType extends AnyConnection = AnyConnection,
 > = (options: ConnectionOptions<ConnectionType>) => ConnectionType;
 
-export type WithConnectionOptions = {
+export type WithConnectionOptions = AbortOptions & {
   readonly?: boolean;
 };
 

--- a/src/packages/dumbo/src/core/connections/connection.ts
+++ b/src/packages/dumbo/src/core/connections/connection.ts
@@ -69,13 +69,20 @@ export type WithConnectionOptions = {
   readonly?: boolean;
 };
 
+export type ConnectionContext = {
+  signal: AbortSignal;
+};
+
 export interface WithConnectionFactory<
   ConnectionType extends AnyConnection = AnyConnection,
 > {
   connection: (options?: WithConnectionOptions) => Promise<ConnectionType>;
 
   withConnection: <Result = unknown>(
-    handle: (connection: ConnectionType) => Promise<Result>,
+    handle: (
+      connection: ConnectionType,
+      ctx: ConnectionContext,
+    ) => Promise<Result>,
     options?: WithConnectionOptions,
   ) => Promise<Result>;
 }

--- a/src/packages/dumbo/src/core/connections/connection.ts
+++ b/src/packages/dumbo/src/core/connections/connection.ts
@@ -6,6 +6,7 @@ import {
   type WithSQLExecutor,
 } from '../execute';
 import type { JSONSerializer } from '../serializer';
+import type { OperationContext } from '../taskProcessing';
 import {
   transactionFactoryWithDbClient,
   type AnyDatabaseTransaction,
@@ -69,10 +70,6 @@ export type WithConnectionOptions = {
   readonly?: boolean;
 };
 
-export type ConnectionContext = {
-  signal: AbortSignal;
-};
-
 export interface WithConnectionFactory<
   ConnectionType extends AnyConnection = AnyConnection,
 > {
@@ -81,7 +78,7 @@ export interface WithConnectionFactory<
   withConnection: <Result = unknown>(
     handle: (
       connection: ConnectionType,
-      ctx: ConnectionContext,
+      ctx: OperationContext,
     ) => Promise<Result>,
     options?: WithConnectionOptions,
   ) => Promise<Result>;

--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -6,7 +6,7 @@ import {
   sqlExecutorInNewConnection,
   type WithSQLExecutor,
 } from '../execute';
-import { guardBoundedAccess } from '../taskProcessing';
+import { guardBoundedAccess, type OperationContext } from '../taskProcessing';
 import type {
   AnyConnection,
   InferDbClientFromConnection,
@@ -95,7 +95,11 @@ export const createSingletonConnectionPool = <
   const { driverType, getConnection } = options;
 
   let connectionPromise: Promise<ConnectionType> | null = null;
-  const lifecycle = openCloseLifecycle('Singleton connection pool');
+  const closeController = new AbortController();
+  const lifecycle = openCloseLifecycle(
+    'Singleton connection pool',
+    closeController,
+  );
 
   const getExistingOrNewConnection = () => {
     if (!connectionPromise) {
@@ -136,13 +140,13 @@ export const createSingletonConnectionPool = <
     withConnection: <Result>(
       handle: (
         connection: ConnectionType,
-        ctx: { signal: AbortSignal },
+        ctx: OperationContext,
       ) => Promise<Result>,
       _options?: WithConnectionOptions,
     ) =>
       lifecycle.runTracked(() =>
         executeInAmbientConnection<ConnectionType, Result>(
-          (conn) => handle(conn, { signal: lifecycle.signal }),
+          (conn) => handle(conn, { signal: closeController.signal }),
           { connection: getExistingOrNewConnection },
         ),
       ),
@@ -153,7 +157,7 @@ export const createSingletonConnectionPool = <
     withTransaction: (handle, transactionOptions) =>
       lifecycle.runTracked(() =>
         innerTransaction.withTransaction(
-          (tx) => handle(tx, { signal: lifecycle.signal }),
+          (tx) => handle(tx, { signal: closeController.signal }),
           transactionOptions,
         ),
       ),
@@ -189,7 +193,6 @@ const resolveCloseOptions = (
 };
 
 type OpenCloseLifecycle = {
-  signal: AbortSignal;
   assertOpen: () => void;
   runTracked: <T>(op: () => Promise<T>) => Promise<T>;
   close: (
@@ -198,10 +201,12 @@ type OpenCloseLifecycle = {
   ) => Promise<void>;
 };
 
-const openCloseLifecycle = (resourceName: string): OpenCloseLifecycle => {
+const openCloseLifecycle = (
+  resourceName: string,
+  abortController: AbortController = new AbortController(),
+): OpenCloseLifecycle => {
   let closed = false;
   const inFlight = new Set<Promise<unknown>>();
-  const abortController = new AbortController();
 
   const closedError = () => new DumboError(`${resourceName} has been closed`);
 
@@ -234,9 +239,6 @@ const openCloseLifecycle = (resourceName: string): OpenCloseLifecycle => {
   };
 
   return {
-    get signal() {
-      return abortController.signal;
-    },
     assertOpen,
     runTracked,
     close,
@@ -284,23 +286,22 @@ export const createBoundedConnectionPool = <
 ): ConnectionPool<ConnectionType> => {
   const { driverType, maxConnections } = options;
 
+  const closeController = new AbortController();
   const guardMaxConnections = guardBoundedAccess(options.getConnection, {
     maxResources: maxConnections,
     reuseResources: true,
     closeResource: (conn) => conn.close(),
+    abortController: closeController,
   });
 
   let closed = false;
 
   const executeWithPooling = async <Result>(
-    operation: (
-      conn: ConnectionType,
-      ctx: { signal: AbortSignal },
-    ) => Promise<Result>,
+    operation: (conn: ConnectionType, ctx: OperationContext) => Promise<Result>,
   ): Promise<Result> => {
     const conn = await guardMaxConnections.acquire();
     try {
-      return await operation(conn, { signal: guardMaxConnections.signal });
+      return await operation(conn, { signal: closeController.signal });
     } finally {
       guardMaxConnections.release(conn);
     }
@@ -334,7 +335,7 @@ export const createBoundedConnectionPool = <
     transaction: innerTransactionFactory.transaction,
     withTransaction: (handle, transactionOptions) =>
       innerTransactionFactory.withTransaction(
-        (tx) => handle(tx, { signal: guardMaxConnections.signal }),
+        (tx) => handle(tx, { signal: closeController.signal }),
         transactionOptions,
       ),
     close: async (closeOptions) => {
@@ -426,7 +427,7 @@ export const createConnectionPool = <ConnectionType extends AnyConnection>(
       : <Result>(
           handle: (
             connection: ConnectionType,
-            ctx: { signal: AbortSignal },
+            ctx: OperationContext,
           ) => Promise<Result>,
           _options?: WithConnectionOptions,
         ) =>

--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -67,7 +67,8 @@ export const createAmbientConnectionPool = <
       connection.transaction(
         options,
       ) as InferTransactionFromConnection<ConnectionType>,
-    withConnection: (handle, _options?) => handle(connection),
+    withConnection: (handle, _options?) =>
+      handle(connection, { signal: ambientNeverAbortSignal }),
     withTransaction: (handle, options) => {
       const withTx =
         connection.withTransaction as WithDatabaseTransactionFactory<ConnectionType>['withTransaction'];
@@ -133,13 +134,17 @@ export const createSingletonConnectionPool = <
         lifecycle.runTracked(() => ambientExecutor.batchCommand(sqls, opts)),
     },
     withConnection: <Result>(
-      handle: (connection: ConnectionType) => Promise<Result>,
+      handle: (
+        connection: ConnectionType,
+        ctx: { signal: AbortSignal },
+      ) => Promise<Result>,
       _options?: WithConnectionOptions,
     ) =>
       lifecycle.runTracked(() =>
-        executeInAmbientConnection<ConnectionType, Result>(handle, {
-          connection: getExistingOrNewConnection,
-        }),
+        executeInAmbientConnection<ConnectionType, Result>(
+          (conn) => handle(conn, { signal: lifecycle.signal }),
+          { connection: getExistingOrNewConnection },
+        ),
       ),
     transaction: (transactionOptions) => {
       lifecycle.assertOpen();
@@ -147,7 +152,10 @@ export const createSingletonConnectionPool = <
     },
     withTransaction: (handle, transactionOptions) =>
       lifecycle.runTracked(() =>
-        innerTransaction.withTransaction(handle, transactionOptions),
+        innerTransaction.withTransaction(
+          (tx) => handle(tx, { signal: lifecycle.signal }),
+          transactionOptions,
+        ),
       ),
     close: (closeOptions) =>
       lifecycle.close(
@@ -181,6 +189,7 @@ const resolveCloseOptions = (
 };
 
 type OpenCloseLifecycle = {
+  signal: AbortSignal;
   assertOpen: () => void;
   runTracked: <T>(op: () => Promise<T>) => Promise<T>;
   close: (
@@ -192,6 +201,7 @@ type OpenCloseLifecycle = {
 const openCloseLifecycle = (resourceName: string): OpenCloseLifecycle => {
   let closed = false;
   const inFlight = new Set<Promise<unknown>>();
+  const abortController = new AbortController();
 
   const closedError = () => new DumboError(`${resourceName} has been closed`);
 
@@ -216,13 +226,21 @@ const openCloseLifecycle = (resourceName: string): OpenCloseLifecycle => {
   ): Promise<void> => {
     if (closed) return;
     closed = true;
+    abortController.abort(closedError());
     if (!options?.force) {
       await drainInFlight(inFlight, options?.closeDeadline);
     }
     await teardown();
   };
 
-  return { assertOpen, runTracked, close };
+  return {
+    get signal() {
+      return abortController.signal;
+    },
+    assertOpen,
+    runTracked,
+    close,
+  };
 };
 
 const drainInFlight = async (
@@ -243,6 +261,12 @@ const delay = (ms: number): Promise<void> =>
     const handle = setTimeout(resolve, ms);
     handle.unref();
   });
+
+// Signal used by pool variants that have no shutdown semantics of their own
+// (ambient/caller-managed connections, generic createConnectionPool). User
+// handles still receive a real AbortSignal that simply never aborts.
+export const ambientNeverAbortSignal: AbortSignal = new AbortController()
+  .signal;
 
 export type CreateBoundedConnectionPoolOptions<
   ConnectionType extends AnyConnection,
@@ -269,15 +293,24 @@ export const createBoundedConnectionPool = <
   let closed = false;
 
   const executeWithPooling = async <Result>(
-    operation: (conn: ConnectionType) => Promise<Result>,
+    operation: (
+      conn: ConnectionType,
+      ctx: { signal: AbortSignal },
+    ) => Promise<Result>,
   ): Promise<Result> => {
     const conn = await guardMaxConnections.acquire();
     try {
-      return await operation(conn);
+      return await operation(conn, { signal: guardMaxConnections.signal });
     } finally {
       guardMaxConnections.release(conn);
     }
   };
+
+  const innerTransactionFactory = transactionFactoryWithAsyncAmbientConnection(
+    driverType,
+    guardMaxConnections.acquire,
+    guardMaxConnections.release,
+  );
 
   return {
     driverType,
@@ -298,11 +331,12 @@ export const createBoundedConnectionPool = <
         executeWithPooling((c) => c.execute.batchCommand(sqls, opts)),
     },
     withConnection: executeWithPooling,
-    ...transactionFactoryWithAsyncAmbientConnection(
-      driverType,
-      guardMaxConnections.acquire,
-      guardMaxConnections.release,
-    ),
+    transaction: innerTransactionFactory.transaction,
+    withTransaction: (handle, transactionOptions) =>
+      innerTransactionFactory.withTransaction(
+        (tx) => handle(tx, { signal: guardMaxConnections.signal }),
+        transactionOptions,
+      ),
     close: async (closeOptions) => {
       if (closed) return;
       closed = true;
@@ -390,12 +424,16 @@ export const createConnectionPool = <ConnectionType extends AnyConnection>(
     'withConnection' in pool
       ? pool.withConnection
       : <Result>(
-          handle: (connection: ConnectionType) => Promise<Result>,
+          handle: (
+            connection: ConnectionType,
+            ctx: { signal: AbortSignal },
+          ) => Promise<Result>,
           _options?: WithConnectionOptions,
         ) =>
-          executeInNewConnection<ConnectionType, Result>(handle, {
-            connection,
-          });
+          executeInNewConnection<ConnectionType, Result>(
+            (conn) => handle(conn, { signal: ambientNeverAbortSignal }),
+            { connection },
+          );
 
   const close = 'close' in pool ? pool.close : () => Promise.resolve();
 

--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -6,7 +6,12 @@ import {
   sqlExecutorInNewConnection,
   type WithSQLExecutor,
 } from '../execute';
-import { guardBoundedAccess, type OperationContext } from '../taskProcessing';
+import {
+  Guard,
+  TaskProcessor,
+  type AbortOptions,
+  type OperationContext,
+} from '../taskProcessing';
 import type {
   AnyConnection,
   InferDbClientFromConnection,
@@ -84,6 +89,7 @@ export type SingletonConnectionPoolOptions<
   getConnection: () => ConnectionType | Promise<ConnectionType>;
   closeConnection?: (connection: ConnectionType) => void | Promise<void>;
   closeDeadline?: number;
+  signal?: AbortSignal;
   connectionOptions?: never;
 };
 
@@ -95,11 +101,28 @@ export const createSingletonConnectionPool = <
   const { driverType, getConnection } = options;
 
   let connectionPromise: Promise<ConnectionType> | null = null;
-  const closeController = new AbortController();
-  const lifecycle = openCloseLifecycle(
-    'Singleton connection pool',
-    closeController,
-  );
+
+  const closedError = () =>
+    new DumboError('Singleton connection pool has been closed');
+
+  const processor = new TaskProcessor({
+    maxActiveTasks: Number.MAX_SAFE_INTEGER,
+    maxQueueSize: Number.MAX_SAFE_INTEGER,
+    signal: options.signal,
+    stoppedError: closedError,
+  });
+
+  const run = <Result>(
+    op: (ctx: OperationContext) => Promise<Result>,
+    opts?: AbortOptions,
+  ): Promise<Result> =>
+    processor.enqueue(async ({ ack, signal }) => {
+      try {
+        return await op({ signal });
+      } finally {
+        ack();
+      }
+    }, opts);
 
   const getExistingOrNewConnection = () => {
     if (!connectionPromise) {
@@ -121,55 +144,62 @@ export const createSingletonConnectionPool = <
 
   const result: ConnectionPool<ConnectionType> = {
     driverType,
-    connection: () =>
-      lifecycle.runTracked(() =>
-        getExistingOrNewConnection().then((conn) =>
-          wrapPooledConnection(conn, () => Promise.resolve()),
-        ),
+    connection: (connectionOptions) =>
+      run(
+        (_ctx) =>
+          getExistingOrNewConnection().then((conn) =>
+            wrapPooledConnection(conn, () => Promise.resolve()),
+          ),
+        connectionOptions,
       ),
     execute: {
       query: (sql, opts) =>
-        lifecycle.runTracked(() => ambientExecutor.query(sql, opts)),
+        run((_ctx) => ambientExecutor.query(sql, opts), opts),
       batchQuery: (sqls, opts) =>
-        lifecycle.runTracked(() => ambientExecutor.batchQuery(sqls, opts)),
+        run((_ctx) => ambientExecutor.batchQuery(sqls, opts), opts),
       command: (sql, opts) =>
-        lifecycle.runTracked(() => ambientExecutor.command(sql, opts)),
+        run((_ctx) => ambientExecutor.command(sql, opts), opts),
       batchCommand: (sqls, opts) =>
-        lifecycle.runTracked(() => ambientExecutor.batchCommand(sqls, opts)),
+        run((_ctx) => ambientExecutor.batchCommand(sqls, opts), opts),
     },
     withConnection: <Result>(
       handle: (
         connection: ConnectionType,
         ctx: OperationContext,
       ) => Promise<Result>,
-      _options?: WithConnectionOptions,
+      withConnectionOpts?: WithConnectionOptions,
     ) =>
-      lifecycle.runTracked(() =>
-        executeInAmbientConnection<ConnectionType, Result>(
-          (conn) => handle(conn, { signal: closeController.signal }),
-          { connection: getExistingOrNewConnection },
-        ),
+      run(
+        (ctx) =>
+          executeInAmbientConnection<ConnectionType, Result>(
+            (conn) => handle(conn, ctx),
+            { connection: getExistingOrNewConnection },
+          ),
+        withConnectionOpts,
       ),
     transaction: (transactionOptions) => {
-      lifecycle.assertOpen();
+      if (processor.stopped) throw closedError();
       return innerTransaction.transaction(transactionOptions);
     },
     withTransaction: (handle, transactionOptions) =>
-      lifecycle.runTracked(() =>
-        innerTransaction.withTransaction(
-          (tx) => handle(tx, { signal: closeController.signal }),
-          transactionOptions,
-        ),
+      run(
+        (ctx) =>
+          innerTransaction.withTransaction(
+            (tx) => handle(tx, ctx),
+            transactionOptions,
+          ),
+        transactionOptions,
       ),
-    close: (closeOptions) =>
-      lifecycle.close(
-        async () => {
-          if (!connectionPromise) return;
-          const connection = await connectionPromise;
-          await connection.close();
-        },
+    close: async (closeOptions) => {
+      if (processor.stopped) return;
+      await processor.stop(
         resolveCloseOptions(closeOptions, options.closeDeadline),
-      ),
+      );
+      if (!connectionPromise) return;
+      const connection = await connectionPromise;
+      connectionPromise = null;
+      await connection.close();
+    },
   };
 
   return result;
@@ -192,78 +222,6 @@ const resolveCloseOptions = (
   };
 };
 
-type OpenCloseLifecycle = {
-  assertOpen: () => void;
-  runTracked: <T>(op: () => Promise<T>) => Promise<T>;
-  close: (
-    teardown: () => Promise<void>,
-    options?: PoolCloseOptions,
-  ) => Promise<void>;
-};
-
-const openCloseLifecycle = (
-  resourceName: string,
-  abortController: AbortController = new AbortController(),
-): OpenCloseLifecycle => {
-  let closed = false;
-  const inFlight = new Set<Promise<unknown>>();
-
-  const closedError = () => new DumboError(`${resourceName} has been closed`);
-
-  const assertOpen = () => {
-    if (closed) throw closedError();
-  };
-
-  const runTracked = <T>(op: () => Promise<T>): Promise<T> => {
-    if (closed) return Promise.reject(closedError());
-    const tracked = op();
-    inFlight.add(tracked);
-    const cleanup = () => {
-      inFlight.delete(tracked);
-    };
-    tracked.then(cleanup, cleanup);
-    return tracked;
-  };
-
-  const close = async (
-    teardown: () => Promise<void>,
-    options?: PoolCloseOptions,
-  ): Promise<void> => {
-    if (closed) return;
-    closed = true;
-    abortController.abort(closedError());
-    if (!options?.force) {
-      await drainInFlight(inFlight, options?.closeDeadline);
-    }
-    await teardown();
-  };
-
-  return {
-    assertOpen,
-    runTracked,
-    close,
-  };
-};
-
-const drainInFlight = async (
-  inFlight: Set<Promise<unknown>>,
-  closeDeadline: number | undefined,
-): Promise<void> => {
-  if (inFlight.size === 0) return;
-  const drained = Promise.allSettled([...inFlight]);
-  if (closeDeadline === undefined) {
-    await drained;
-    return;
-  }
-  await Promise.race([drained, delay(closeDeadline)]);
-};
-
-const delay = (ms: number): Promise<void> =>
-  new Promise((resolve) => {
-    const handle = setTimeout(resolve, ms);
-    handle.unref();
-  });
-
 // Signal used by pool variants that have no shutdown semantics of their own
 // (ambient/caller-managed connections, generic createConnectionPool). User
 // handles still receive a real AbortSignal that simply never aborts.
@@ -277,6 +235,7 @@ export type CreateBoundedConnectionPoolOptions<
   getConnection: () => ConnectionType | Promise<ConnectionType>;
   maxConnections: number;
   closeDeadline?: number;
+  signal?: AbortSignal | undefined;
 };
 
 export const createBoundedConnectionPool = <
@@ -286,26 +245,19 @@ export const createBoundedConnectionPool = <
 ): ConnectionPool<ConnectionType> => {
   const { driverType, maxConnections } = options;
 
-  const closeController = new AbortController();
-  const guardMaxConnections = guardBoundedAccess(options.getConnection, {
-    maxResources: maxConnections,
-    reuseResources: true,
-    closeResource: (conn) => conn.close(),
-    abortController: closeController,
-  });
+  const closedError = () =>
+    new DumboError('Bounded connection pool has been closed');
 
-  let closed = false;
-
-  const executeWithPooling = async <Result>(
-    operation: (conn: ConnectionType, ctx: OperationContext) => Promise<Result>,
-  ): Promise<Result> => {
-    const conn = await guardMaxConnections.acquire();
-    try {
-      return await operation(conn, { signal: closeController.signal });
-    } finally {
-      guardMaxConnections.release(conn);
-    }
-  };
+  const guardMaxConnections = Guard.boundedAccess<ConnectionType>(
+    options.getConnection,
+    {
+      maxResources: maxConnections,
+      reuseResources: true,
+      closeResource: (conn) => conn.close(),
+      signal: options.signal,
+      stoppedError: closedError,
+    },
+  );
 
   const innerTransactionFactory = transactionFactoryWithAsyncAmbientConnection(
     driverType,
@@ -323,29 +275,39 @@ export const createBoundedConnectionPool = <
     },
     execute: {
       query: (sql, opts) =>
-        executeWithPooling((c) => c.execute.query(sql, opts)),
+        guardMaxConnections.execute((c) => c.execute.query(sql, opts), opts),
       batchQuery: (sqls, opts) =>
-        executeWithPooling((c) => c.execute.batchQuery(sqls, opts)),
+        guardMaxConnections.execute(
+          (c) => c.execute.batchQuery(sqls, opts),
+          opts,
+        ),
       command: (sql, opts) =>
-        executeWithPooling((c) => c.execute.command(sql, opts)),
+        guardMaxConnections.execute((c) => c.execute.command(sql, opts), opts),
       batchCommand: (sqls, opts) =>
-        executeWithPooling((c) => c.execute.batchCommand(sqls, opts)),
+        guardMaxConnections.execute(
+          (c) => c.execute.batchCommand(sqls, opts),
+          opts,
+        ),
     },
-    withConnection: executeWithPooling,
-    transaction: innerTransactionFactory.transaction,
-    withTransaction: (handle, transactionOptions) =>
-      innerTransactionFactory.withTransaction(
-        (tx) => handle(tx, { signal: closeController.signal }),
-        transactionOptions,
+    withConnection: (handle, withConnectionOpts) =>
+      guardMaxConnections.execute(
+        (conn, ctx) => handle(conn, ctx),
+        withConnectionOpts,
       ),
-    close: async (closeOptions) => {
-      if (closed) return;
-      closed = true;
-
-      await guardMaxConnections.stop(
-        resolveCloseOptions(closeOptions, options.closeDeadline),
-      );
+    transaction: (transactionOptions) => {
+      if (guardMaxConnections.stopped) throw closedError();
+      return innerTransactionFactory.transaction(transactionOptions);
     },
+    withTransaction: (handle, transactionOptions) =>
+      guardMaxConnections.execute((conn, ctx) => {
+        const withTx =
+          conn.withTransaction as WithDatabaseTransactionFactory<ConnectionType>['withTransaction'];
+        return withTx((tx) => handle(tx, ctx), transactionOptions);
+      }, transactionOptions),
+    close: (closeOptions) =>
+      guardMaxConnections.stop(
+        resolveCloseOptions(closeOptions, options.closeDeadline),
+      ),
   };
 };
 

--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -1,3 +1,4 @@
+import { DumboError } from '../errors';
 import {
   executeInAmbientConnection,
   executeInNewConnection,
@@ -19,6 +20,11 @@ import {
   type WithDatabaseTransactionFactory,
 } from './transaction';
 
+export type PoolCloseOptions = {
+  force?: boolean;
+  closeDeadline?: number;
+};
+
 export interface ConnectionPool<
   ConnectionType extends AnyConnection = AnyConnection,
 >
@@ -27,7 +33,7 @@ export interface ConnectionPool<
     WithConnectionFactory<ConnectionType>,
     WithDatabaseTransactionFactory<ConnectionType> {
   driverType: ConnectionType['driverType'];
-  close: () => Promise<void>;
+  close: (options?: PoolCloseOptions) => Promise<void>;
 }
 
 const wrapPooledConnection = <ConnectionType extends AnyConnection>(
@@ -76,6 +82,7 @@ export type SingletonConnectionPoolOptions<
   driverType: ConnectionType['driverType'];
   getConnection: () => ConnectionType | Promise<ConnectionType>;
   closeConnection?: (connection: ConnectionType) => void | Promise<void>;
+  closeDeadline?: number;
   connectionOptions?: never;
 };
 
@@ -87,6 +94,7 @@ export const createSingletonConnectionPool = <
   const { driverType, getConnection } = options;
 
   let connectionPromise: Promise<ConnectionType> | null = null;
+  const lifecycle = openCloseLifecycle('Singleton connection pool');
 
   const getExistingOrNewConnection = () => {
     if (!connectionPromise) {
@@ -95,37 +103,146 @@ export const createSingletonConnectionPool = <
     return connectionPromise;
   };
 
+  const ambientExecutor = sqlExecutorInAmbientConnection({
+    driverType,
+    connection: getExistingOrNewConnection,
+  });
+
+  const innerTransaction = transactionFactoryWithAsyncAmbientConnection(
+    options.driverType,
+    getExistingOrNewConnection,
+    options.closeConnection,
+  );
+
   const result: ConnectionPool<ConnectionType> = {
     driverType,
     connection: () =>
-      getExistingOrNewConnection().then((conn) =>
-        wrapPooledConnection(conn, () => Promise.resolve()),
+      lifecycle.runTracked(() =>
+        getExistingOrNewConnection().then((conn) =>
+          wrapPooledConnection(conn, () => Promise.resolve()),
+        ),
       ),
-    execute: sqlExecutorInAmbientConnection({
-      driverType,
-      connection: getExistingOrNewConnection,
-    }),
+    execute: {
+      query: (sql, opts) =>
+        lifecycle.runTracked(() => ambientExecutor.query(sql, opts)),
+      batchQuery: (sqls, opts) =>
+        lifecycle.runTracked(() => ambientExecutor.batchQuery(sqls, opts)),
+      command: (sql, opts) =>
+        lifecycle.runTracked(() => ambientExecutor.command(sql, opts)),
+      batchCommand: (sqls, opts) =>
+        lifecycle.runTracked(() => ambientExecutor.batchCommand(sqls, opts)),
+    },
     withConnection: <Result>(
       handle: (connection: ConnectionType) => Promise<Result>,
       _options?: WithConnectionOptions,
     ) =>
-      executeInAmbientConnection<ConnectionType, Result>(handle, {
-        connection: getExistingOrNewConnection,
-      }),
-    ...transactionFactoryWithAsyncAmbientConnection(
-      options.driverType,
-      getExistingOrNewConnection,
-      options.closeConnection,
-    ),
-    close: async () => {
-      if (!connectionPromise) return;
-      const connection = await connectionPromise;
-      await connection.close();
+      lifecycle.runTracked(() =>
+        executeInAmbientConnection<ConnectionType, Result>(handle, {
+          connection: getExistingOrNewConnection,
+        }),
+      ),
+    transaction: (transactionOptions) => {
+      lifecycle.assertOpen();
+      return innerTransaction.transaction(transactionOptions);
     },
+    withTransaction: (handle, transactionOptions) =>
+      lifecycle.runTracked(() =>
+        innerTransaction.withTransaction(handle, transactionOptions),
+      ),
+    close: (closeOptions) =>
+      lifecycle.close(
+        async () => {
+          if (!connectionPromise) return;
+          const connection = await connectionPromise;
+          await connection.close();
+        },
+        resolveCloseOptions(closeOptions, options.closeDeadline),
+      ),
   };
 
   return result;
 };
+
+const resolveCloseOptions = (
+  perCall: PoolCloseOptions | undefined,
+  configuredDeadline: number | undefined,
+): { force?: boolean; closeDeadline?: number } | undefined => {
+  const force = perCall?.force;
+  const closeDeadline =
+    perCall?.closeDeadline !== undefined
+      ? perCall.closeDeadline
+      : configuredDeadline;
+
+  if (force === undefined && closeDeadline === undefined) return undefined;
+  return {
+    ...(force !== undefined ? { force } : {}),
+    ...(closeDeadline !== undefined ? { closeDeadline } : {}),
+  };
+};
+
+type OpenCloseLifecycle = {
+  assertOpen: () => void;
+  runTracked: <T>(op: () => Promise<T>) => Promise<T>;
+  close: (
+    teardown: () => Promise<void>,
+    options?: PoolCloseOptions,
+  ) => Promise<void>;
+};
+
+const openCloseLifecycle = (resourceName: string): OpenCloseLifecycle => {
+  let closed = false;
+  const inFlight = new Set<Promise<unknown>>();
+
+  const closedError = () => new DumboError(`${resourceName} has been closed`);
+
+  const assertOpen = () => {
+    if (closed) throw closedError();
+  };
+
+  const runTracked = <T>(op: () => Promise<T>): Promise<T> => {
+    if (closed) return Promise.reject(closedError());
+    const tracked = op();
+    inFlight.add(tracked);
+    const cleanup = () => {
+      inFlight.delete(tracked);
+    };
+    tracked.then(cleanup, cleanup);
+    return tracked;
+  };
+
+  const close = async (
+    teardown: () => Promise<void>,
+    options?: PoolCloseOptions,
+  ): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    if (!options?.force) {
+      await drainInFlight(inFlight, options?.closeDeadline);
+    }
+    await teardown();
+  };
+
+  return { assertOpen, runTracked, close };
+};
+
+const drainInFlight = async (
+  inFlight: Set<Promise<unknown>>,
+  closeDeadline: number | undefined,
+): Promise<void> => {
+  if (inFlight.size === 0) return;
+  const drained = Promise.allSettled([...inFlight]);
+  if (closeDeadline === undefined) {
+    await drained;
+    return;
+  }
+  await Promise.race([drained, delay(closeDeadline)]);
+};
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const handle = setTimeout(resolve, ms);
+    handle.unref();
+  });
 
 export type CreateBoundedConnectionPoolOptions<
   ConnectionType extends AnyConnection,
@@ -133,6 +250,7 @@ export type CreateBoundedConnectionPoolOptions<
   driverType: ConnectionType['driverType'];
   getConnection: () => ConnectionType | Promise<ConnectionType>;
   maxConnections: number;
+  closeDeadline?: number;
 };
 
 export const createBoundedConnectionPool = <
@@ -145,6 +263,7 @@ export const createBoundedConnectionPool = <
   const guardMaxConnections = guardBoundedAccess(options.getConnection, {
     maxResources: maxConnections,
     reuseResources: true,
+    closeResource: (conn) => conn.close(),
   });
 
   let closed = false;
@@ -184,11 +303,13 @@ export const createBoundedConnectionPool = <
       guardMaxConnections.acquire,
       guardMaxConnections.release,
     ),
-    close: async () => {
+    close: async (closeOptions) => {
       if (closed) return;
       closed = true;
 
-      await guardMaxConnections.stop({ force: true });
+      await guardMaxConnections.stop(
+        resolveCloseOptions(closeOptions, options.closeDeadline),
+      );
     },
   };
 };

--- a/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
+++ b/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert';
+import { describe, it } from 'vitest';
+import type { AnyConnection } from './connection';
+import {
+  createBoundedConnectionPool,
+  createSingletonConnectionPool,
+} from './pool';
+
+type FakeConnection = AnyConnection & { id: number; closed: boolean };
+
+const fakeDriverType = 'fake-driver' as unknown as AnyConnection['driverType'];
+
+const makeFakeConnection = (id: number): FakeConnection => {
+  const conn: {
+    id: number;
+    closed: boolean;
+    driverType: AnyConnection['driverType'];
+    open: () => Promise<unknown>;
+    close: () => Promise<void>;
+  } = {
+    id,
+    closed: false,
+    driverType: fakeDriverType,
+    open: () => Promise.resolve(undefined),
+    close: () => {
+      conn.closed = true;
+      return Promise.resolve();
+    },
+  };
+  return conn as unknown as FakeConnection;
+};
+
+describe('createBoundedConnectionPool', () => {
+  it('closes acquired connections when the pool is closed', async () => {
+    const created: FakeConnection[] = [];
+
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 2,
+      getConnection: () => {
+        const conn = makeFakeConnection(created.length + 1);
+        created.push(conn);
+        return conn;
+      },
+    });
+
+    await Promise.all([
+      pool.withConnection(() => Promise.resolve(1)),
+      pool.withConnection(() => Promise.resolve(2)),
+    ]);
+
+    await pool.close();
+
+    assert.strictEqual(
+      created.length,
+      2,
+      'pool should have used 2 connections',
+    );
+    assert.ok(
+      created.every((c) => c.closed),
+      'every acquired connection should be closed after pool.close()',
+    );
+  });
+
+  it('waits for in-flight operations before closing', async () => {
+    const created: FakeConnection[] = [];
+
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => {
+        const conn = makeFakeConnection(created.length + 1);
+        created.push(conn);
+        return conn;
+      },
+    });
+
+    let inFlightStillRunning = false;
+    let inFlightFinished = false;
+
+    const inFlight = pool.withConnection(async (conn) => {
+      inFlightStillRunning = true;
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      assert.strictEqual(
+        conn.closed,
+        false,
+        'underlying connection must stay open until the in-flight op finishes',
+      );
+      inFlightFinished = true;
+    });
+
+    // Let the in-flight op start
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(inFlightStillRunning, true);
+
+    await pool.close();
+
+    assert.strictEqual(
+      inFlightFinished,
+      true,
+      'pool.close() should not resolve before the in-flight op finished',
+    );
+    await inFlight;
+  });
+});
+
+describe('createBoundedConnectionPool', () => {
+  it('falls back to force when closeDeadline elapses', async () => {
+    const hangSignal = Promise.withResolvers<void>();
+    const created: FakeConnection[] = [];
+
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      closeDeadline: 30,
+      getConnection: () => {
+        const conn = makeFakeConnection(created.length + 1);
+        created.push(conn);
+        return conn;
+      },
+    });
+
+    const hung = pool.withConnection(() => hangSignal.promise);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const start = Date.now();
+    await pool.close();
+    const elapsed = Date.now() - start;
+
+    assert.ok(
+      elapsed < 200,
+      `pool.close() should return within closeDeadline window, took ${elapsed}ms`,
+    );
+
+    hangSignal.resolve();
+    await hung.catch(() => undefined);
+  });
+});
+
+describe('createSingletonConnectionPool', () => {
+  it('drains in-flight withConnection callbacks before closing the underlying connection', async () => {
+    const conn = makeFakeConnection(1);
+
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    let observedClosedDuringCall = false;
+
+    const inFlight = pool.withConnection(async (c) => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      if (c.closed) observedClosedDuringCall = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await pool.close();
+
+    assert.strictEqual(
+      observedClosedDuringCall,
+      false,
+      'underlying connection must not be closed while withConnection callback is running',
+    );
+    assert.strictEqual(
+      conn.closed,
+      true,
+      'underlying connection should be closed after pool.close() returns',
+    );
+    await inFlight;
+  });
+
+  it('falls back to force when closeDeadline elapses', async () => {
+    const hangSignal = Promise.withResolvers<void>();
+    const conn = makeFakeConnection(1);
+
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+      closeDeadline: 30,
+    });
+
+    const hung = pool.withConnection(() => hangSignal.promise);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const start = Date.now();
+    await pool.close();
+    const elapsed = Date.now() - start;
+
+    assert.ok(
+      elapsed < 200,
+      `pool.close() should return within closeDeadline window, took ${elapsed}ms`,
+    );
+    assert.strictEqual(
+      conn.closed,
+      true,
+      'underlying connection should be torn down after close deadline',
+    );
+
+    hangSignal.resolve();
+    await hung.catch(() => undefined);
+  });
+
+  it('rejects new operations attempted after close', async () => {
+    const conn = makeFakeConnection(1);
+
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    await pool.close();
+
+    await assert.rejects(
+      () => pool.withConnection(() => Promise.resolve(1)),
+      /closed/i,
+    );
+  });
+});

--- a/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
+++ b/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
@@ -11,13 +11,7 @@ type FakeConnection = AnyConnection & { id: number; closed: boolean };
 const fakeDriverType = 'fake-driver' as unknown as AnyConnection['driverType'];
 
 const makeFakeConnection = (id: number): FakeConnection => {
-  const conn: {
-    id: number;
-    closed: boolean;
-    driverType: AnyConnection['driverType'];
-    open: () => Promise<unknown>;
-    close: () => Promise<void>;
-  } = {
+  const conn = {
     id,
     closed: false,
     driverType: fakeDriverType,
@@ -25,6 +19,23 @@ const makeFakeConnection = (id: number): FakeConnection => {
     close: () => {
       conn.closed = true;
       return Promise.resolve();
+    },
+    withTransaction: async <Result>(
+      handle: (
+        tx: unknown,
+      ) => Promise<Result | { success: boolean; result: Result }>,
+    ): Promise<Result> => {
+      const fakeTx = { id: `tx-${id}` };
+      const outcome = await handle(fakeTx);
+      if (
+        outcome !== null &&
+        typeof outcome === 'object' &&
+        'success' in outcome &&
+        'result' in outcome
+      ) {
+        return (outcome as { result: Result }).result;
+      }
+      return outcome;
     },
   };
   return conn as unknown as FakeConnection;
@@ -147,17 +158,24 @@ describe('createSingletonConnectionPool', () => {
       getConnection: () => conn,
     });
 
+    let callbackFinished = false;
     let observedClosedDuringCall = false;
 
     const inFlight = pool.withConnection(async (c) => {
       await new Promise((resolve) => setTimeout(resolve, 30));
       if (c.closed) observedClosedDuringCall = true;
+      callbackFinished = true;
     });
 
     await new Promise((resolve) => setImmediate(resolve));
 
     await pool.close();
 
+    assert.strictEqual(
+      callbackFinished,
+      true,
+      'pool.close() must wait for in-flight withConnection callback before returning',
+    );
     assert.strictEqual(
       observedClosedDuringCall,
       false,
@@ -270,5 +288,536 @@ describe('createBoundedConnectionPool AbortSignal', () => {
     const aborted = await sawAbort.promise;
     assert.strictEqual(aborted, true);
     await inFlight;
+  });
+});
+
+describe('Pool per-call cancellation', () => {
+  it('singleton: per-call signal aborts ctx.signal without closing the pool', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const perCall = new AbortController();
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withConnection(
+      async (_c, { signal }) => {
+        signal.addEventListener('abort', () => sawAbort.resolve(true));
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+      { signal: perCall.signal },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    perCall.abort(new Error('user cancelled'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    assert.strictEqual(
+      conn.closed,
+      false,
+      'pool must not close on per-call abort',
+    );
+    await pool.close();
+  });
+
+  it('singleton: per-call timeoutMs aborts ctx.signal even if pool stays open', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const reason = await pool.withConnection(
+      async (_c, { signal }) => {
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return signal.reason instanceof Error ? signal.reason.message : null;
+      },
+      { timeoutMs: 15 },
+    );
+
+    assert.match(String(reason), /timed out/i);
+    await pool.close();
+  });
+
+  it('bounded: per-call signal aborts ctx.signal without closing the pool', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+    });
+
+    const perCall = new AbortController();
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withConnection(
+      async (_c, { signal }) => {
+        signal.addEventListener('abort', () => sawAbort.resolve(true));
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+      { signal: perCall.signal },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    perCall.abort(new Error('user cancelled'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    await pool.close();
+  });
+
+  it('bounded: per-call timeoutMs aborts ctx.signal delivered to withConnection handler', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+    });
+
+    const reason = await pool.withConnection(
+      async (_c, { signal }) => {
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return signal.reason instanceof Error ? signal.reason.message : null;
+      },
+      { timeoutMs: 15 },
+    );
+
+    assert.match(String(reason), /timed out/i);
+    await pool.close();
+  });
+
+  it('singleton: pool close still aborts ctx.signal even when a per-call signal is wired up but stays open', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const perCall = new AbortController();
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withConnection(
+      async (_c, { signal }) => {
+        signal.addEventListener('abort', () => sawAbort.resolve(true));
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+      { signal: perCall.signal },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await pool.close();
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    assert.strictEqual(perCall.signal.aborted, false);
+  });
+});
+
+describe('Pool concurrency', () => {
+  it('singleton: withConnection does not serialize concurrent calls — runTracked is bookkeeping, not a mutex', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    let inFlight = 0;
+    let peak = 0;
+    const work = () =>
+      pool.withConnection(async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight--;
+      });
+
+    await Promise.all([work(), work(), work(), work(), work()]);
+
+    assert.strictEqual(peak, 5);
+    await pool.close();
+  });
+
+  it('bounded: withConnection respects maxConnections cap', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 2,
+      getConnection: () => makeFakeConnection(Math.random()),
+    });
+
+    let inFlight = 0;
+    let peak = 0;
+    const work = () =>
+      pool.withConnection(async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight--;
+      });
+
+    await Promise.all([work(), work(), work(), work(), work()]);
+
+    assert.strictEqual(peak, 2);
+    await pool.close();
+  });
+
+  it('singleton: withTransaction does not serialize concurrent calls', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    let inFlight = 0;
+    let peak = 0;
+    const work = () =>
+      pool.withTransaction(async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight--;
+        return undefined;
+      });
+
+    await Promise.all([work(), work(), work(), work(), work()]);
+
+    assert.strictEqual(peak, 5);
+    await pool.close();
+  });
+
+  it('bounded: withTransaction respects maxConnections cap', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 2,
+      getConnection: () => makeFakeConnection(Math.random()),
+    });
+
+    let inFlight = 0;
+    let peak = 0;
+    const work = () =>
+      pool.withTransaction(async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight--;
+        return undefined;
+      });
+
+    await Promise.all([work(), work(), work(), work(), work()]);
+
+    assert.strictEqual(peak, 2);
+    await pool.close();
+  });
+});
+
+describe('Pool withTransaction abort threading', () => {
+  it('singleton: per-call signal aborts ctx.signal delivered to withTransaction handler', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const perCall = new AbortController();
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withTransaction(
+      async (_tx, { signal }) => {
+        signal.addEventListener('abort', () => sawAbort.resolve(true));
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return undefined;
+      },
+      { signal: perCall.signal },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    perCall.abort(new Error('user cancelled'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    await pool.close();
+  });
+
+  it('singleton: pool close aborts ctx.signal delivered to withTransaction handler', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withTransaction(async (_tx, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return undefined;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await pool.close();
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+  });
+
+  it('singleton: per-call timeoutMs aborts ctx.signal delivered to withTransaction handler', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const reason = await pool.withTransaction(
+      async (_tx, { signal }) => {
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return signal.reason instanceof Error
+          ? signal.reason.message
+          : 'no-reason';
+      },
+      { timeoutMs: 15 },
+    );
+
+    assert.match(String(reason), /timed out/i);
+    await pool.close();
+  });
+
+  it('bounded: per-call signal aborts ctx.signal delivered to withTransaction handler', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+    });
+
+    const perCall = new AbortController();
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withTransaction(
+      async (_tx, { signal }) => {
+        signal.addEventListener('abort', () => sawAbort.resolve(true));
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return undefined;
+      },
+      { signal: perCall.signal },
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    perCall.abort(new Error('user cancelled'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    await pool.close();
+  });
+
+  it('bounded: pool close aborts ctx.signal delivered to withTransaction handler', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withTransaction(async (_tx, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return undefined;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await pool.close();
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+  });
+
+  it('bounded: per-call timeoutMs aborts ctx.signal delivered to withTransaction handler', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+    });
+
+    const reason = await pool.withTransaction(
+      async (_tx, { signal }) => {
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return signal.reason instanceof Error
+          ? signal.reason.message
+          : 'no-reason';
+      },
+      { timeoutMs: 15 },
+    );
+
+    assert.match(String(reason), /timed out/i);
+    await pool.close();
+  });
+});
+
+describe('Pool lifecycle signal (outer parent)', () => {
+  it('singleton: aborting the outer signal fires ctx.signal on in-flight withConnection without calling close()', async () => {
+    const outer = new AbortController();
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+      signal: outer.signal,
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withConnection(async (_c, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    outer.abort(new Error('outer fired'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    assert.strictEqual(
+      conn.closed,
+      false,
+      'outer abort must signal in-flight work, NOT tear the pool down',
+    );
+    await pool.close();
+  });
+
+  it('bounded: aborting the outer signal fires ctx.signal on in-flight withConnection', async () => {
+    const outer = new AbortController();
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+      signal: outer.signal,
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withConnection(async (_c, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    outer.abort(new Error('outer fired'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    await pool.close();
+  });
+
+  it('singleton: outer signal aborting before any operation rejects subsequent enqueues fast', async () => {
+    const outer = new AbortController();
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+      signal: outer.signal,
+    });
+
+    outer.abort(new Error('outer fired pre-op'));
+
+    await assert.rejects(() => pool.execute.query({} as never));
+    await pool.close();
+  });
+
+  it('singleton: aborting the outer signal fires ctx.signal on in-flight withTransaction without calling close()', async () => {
+    const outer = new AbortController();
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+      signal: outer.signal,
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withTransaction(async (_tx, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return undefined;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    outer.abort(new Error('outer fired'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    assert.strictEqual(
+      conn.closed,
+      false,
+      'outer abort must signal in-flight work, NOT tear the pool down',
+    );
+    await pool.close();
+  });
+
+  it('bounded: aborting the outer signal fires ctx.signal on in-flight withTransaction', async () => {
+    const outer = new AbortController();
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+      signal: outer.signal,
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withTransaction(async (_tx, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return undefined;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    outer.abort(new Error('outer fired'));
+
+    assert.strictEqual(await sawAbort.promise, true);
+    await inFlight;
+    await pool.close();
   });
 });

--- a/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
+++ b/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
@@ -218,4 +218,57 @@ describe('createSingletonConnectionPool', () => {
       /closed/i,
     );
   });
+
+  it('exposes an abort signal that fires when close() is called', async () => {
+    const conn = makeFakeConnection(1);
+
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withConnection(async (_c, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await pool.close();
+
+    const aborted = await sawAbort.promise;
+    assert.strictEqual(aborted, true);
+    await inFlight;
+  });
+});
+
+describe('createBoundedConnectionPool AbortSignal', () => {
+  it('exposes an abort signal that fires when close() is called', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+    });
+
+    const sawAbort = Promise.withResolvers<boolean>();
+
+    const inFlight = pool.withConnection(async (_c, { signal }) => {
+      signal.addEventListener('abort', () => sawAbort.resolve(true));
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await pool.close();
+
+    const aborted = await sawAbort.promise;
+    assert.strictEqual(aborted, true);
+    await inFlight;
+  });
 });

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -1,4 +1,5 @@
 import type { WithSQLExecutor } from '../execute';
+import type { OperationContext } from '../taskProcessing';
 import type {
   AnyConnection,
   InferDbClientFromConnection,
@@ -43,7 +44,7 @@ export interface WithDatabaseTransactionFactory<
   withTransaction: <Result = never>(
     handle: (
       transaction: InferTransactionFromConnection<ConnectionType>,
-      ctx: { signal: AbortSignal },
+      ctx: OperationContext,
     ) => Promise<TransactionResult<Result> | Result>,
     options?: InferTransactionOptionsFromConnection<ConnectionType>,
   ) => Promise<Result>;

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -43,6 +43,7 @@ export interface WithDatabaseTransactionFactory<
   withTransaction: <Result = never>(
     handle: (
       transaction: InferTransactionFromConnection<ConnectionType>,
+      ctx: { signal: AbortSignal },
     ) => Promise<TransactionResult<Result> | Result>,
     options?: InferTransactionOptionsFromConnection<ConnectionType>,
   ) => Promise<Result>;
@@ -119,9 +120,13 @@ export const transactionFactoryWithDbClient = <
   return {
     transaction: getOrInitCurrentTransaction,
     withTransaction: (handle, options) =>
-      executeInTransaction(getOrInitCurrentTransaction(options), handle),
+      executeInTransaction(getOrInitCurrentTransaction(options), (tx) =>
+        handle(tx, { signal: neverAbortSignal }),
+      ),
   };
 };
+
+const neverAbortSignal: AbortSignal = new AbortController().signal;
 
 const wrapInConnectionClosure = async <
   ConnectionType extends AnyConnection = AnyConnection,
@@ -160,7 +165,9 @@ export const transactionFactoryWithNewConnection = <
     const connection = connect();
     const withTx =
       connection.withTransaction as WithDatabaseTransactionFactory<ConnectionType>['withTransaction'];
-    return wrapInConnectionClosure(connection, () => withTx(handle, options));
+    return wrapInConnectionClosure(connection, () =>
+      withTx((tx, ctx) => handle(tx, ctx), options),
+    );
   },
 });
 

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -1,5 +1,5 @@
 import type { WithSQLExecutor } from '../execute';
-import type { OperationContext } from '../taskProcessing';
+import type { AbortOptions, OperationContext } from '../taskProcessing';
 import type {
   AnyConnection,
   InferDbClientFromConnection,
@@ -23,7 +23,7 @@ export interface DatabaseTransaction<
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyDatabaseTransaction = DatabaseTransaction<any, any>;
 
-export type DatabaseTransactionOptions = {
+export type DatabaseTransactionOptions = AbortOptions & {
   allowNestedTransactions?: boolean;
   readonly?: boolean;
 };

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -1,3 +1,4 @@
+import { InvalidOperationError } from '../errors';
 import type { WithSQLExecutor } from '../execute';
 import type { AbortOptions, OperationContext } from '../taskProcessing';
 import type {
@@ -26,6 +27,106 @@ export type AnyDatabaseTransaction = DatabaseTransaction<any, any>;
 export type DatabaseTransactionOptions = AbortOptions & {
   allowNestedTransactions?: boolean;
   readonly?: boolean;
+};
+
+export type TransactionNestingCounter = {
+  increment: () => void;
+  decrement: () => void;
+  reset: () => void;
+  level: number;
+};
+
+export const transactionNestingCounter = (): TransactionNestingCounter => {
+  let transactionLevel = 0;
+
+  return {
+    reset: () => {
+      transactionLevel = 0;
+    },
+    increment: () => {
+      transactionLevel++;
+    },
+    decrement: () => {
+      transactionLevel--;
+
+      if (transactionLevel < 0) {
+        throw new Error('Transaction level is out of bounds');
+      }
+    },
+    get level() {
+      return transactionLevel;
+    },
+  };
+};
+
+/**
+ * Composes a backend-specific transaction (BEGIN/COMMIT/ROLLBACK + optional
+ * savepoint SQL) with the framework's nested-transaction state machine:
+ * hasBegun guard, nesting counter, the actionable error when nesting isn't
+ * permitted, and SAVEPOINT routing when opted in.
+ *
+ * Drivers (pgTransaction, sqliteTransaction, ...) provide the raw begin /
+ * commit / rollback and the optional savepoint trio; this returns the same
+ * three lifecycle methods wrapped with the shared semantics.
+ */
+export const databaseTransaction = (
+  backend: Pick<DatabaseTransaction, 'begin' | 'commit' | 'rollback'> & {
+    savepoint?: ((level: number) => Promise<void>) | undefined;
+    releaseSavepoint?: ((level: number) => Promise<void>) | undefined;
+    rollbackToSavepoint?: ((level: number) => Promise<void>) | undefined;
+  },
+  options?: {
+    allowNestedTransactions?: boolean | undefined;
+    useSavepoints?: boolean | undefined;
+  },
+): Pick<DatabaseTransaction, 'begin' | 'commit' | 'rollback'> => {
+  const allowNestedTransactions = options?.allowNestedTransactions ?? false;
+  const useSavepoints = options?.useSavepoints ?? false;
+  const counter = transactionNestingCounter();
+  let hasBegun = false;
+
+  return {
+    begin: async () => {
+      if (allowNestedTransactions) {
+        if (counter.level >= 1) {
+          counter.increment();
+          if (useSavepoints && backend.savepoint)
+            await backend.savepoint(counter.level);
+          return;
+        }
+        counter.increment();
+      } else if (hasBegun) {
+        throw new InvalidOperationError(
+          'Cannot start a nested transaction: allowNestedTransactions is false. ' +
+            'Set transactionOptions: { allowNestedTransactions: true } on your pool or connection.',
+        );
+      }
+      hasBegun = true;
+      await backend.begin();
+    },
+    commit: async () => {
+      if (allowNestedTransactions && counter.level > 1) {
+        if (useSavepoints && backend.releaseSavepoint)
+          await backend.releaseSavepoint(counter.level);
+        counter.decrement();
+        return;
+      }
+      if (allowNestedTransactions) counter.reset();
+      hasBegun = false;
+      await backend.commit();
+    },
+    rollback: async (error?: unknown) => {
+      if (allowNestedTransactions && counter.level > 1) {
+        if (useSavepoints && backend.rollbackToSavepoint)
+          await backend.rollbackToSavepoint(counter.level);
+        counter.decrement();
+        return;
+      }
+      if (allowNestedTransactions) counter.reset();
+      hasBegun = false;
+      await backend.rollback(error);
+    },
+  };
 };
 
 export type InferTransactionOptionsFromTransaction<

--- a/src/packages/dumbo/src/core/connections/transaction.unit.spec.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.unit.spec.ts
@@ -1,0 +1,238 @@
+import assert from 'node:assert';
+import { describe, it } from 'vitest';
+import { InvalidOperationError } from '../errors';
+import { databaseTransaction, transactionNestingCounter } from './transaction';
+
+describe('transactionNestingCounter', () => {
+  it('starts at level 0', () => {
+    const counter = transactionNestingCounter();
+    assert.strictEqual(counter.level, 0);
+  });
+
+  it('increments / decrements / resets', () => {
+    const counter = transactionNestingCounter();
+    counter.increment();
+    counter.increment();
+    assert.strictEqual(counter.level, 2);
+    counter.decrement();
+    assert.strictEqual(counter.level, 1);
+    counter.reset();
+    assert.strictEqual(counter.level, 0);
+  });
+
+  it('throws when decremented below zero', () => {
+    const counter = transactionNestingCounter();
+    assert.throws(() => counter.decrement(), /out of bounds/i);
+  });
+});
+
+const makeBackend = () => {
+  const calls: string[] = [];
+  return {
+    calls,
+    backend: {
+      begin: () => {
+        calls.push('begin');
+        return Promise.resolve();
+      },
+      commit: () => {
+        calls.push('commit');
+        return Promise.resolve();
+      },
+      rollback: (_err?: unknown) => {
+        calls.push('rollback');
+        return Promise.resolve();
+      },
+      savepoint: (level: number) => {
+        calls.push(`savepoint:${level}`);
+        return Promise.resolve();
+      },
+      releaseSavepoint: (level: number) => {
+        calls.push(`release:${level}`);
+        return Promise.resolve();
+      },
+      rollbackToSavepoint: (level: number) => {
+        calls.push(`rollbackTo:${level}`);
+        return Promise.resolve();
+      },
+    },
+  };
+};
+
+describe('databaseTransaction', () => {
+  describe('allowNestedTransactions: false (default)', () => {
+    it('first begin runs backend.begin, commit runs backend.commit', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend);
+
+      await tx.begin();
+      await tx.commit();
+
+      assert.deepStrictEqual(calls, ['begin', 'commit']);
+    });
+
+    it('second begin throws InvalidOperationError mentioning the flag', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend);
+
+      await tx.begin();
+      await assert.rejects(
+        () => tx.begin(),
+        (err) =>
+          err instanceof InvalidOperationError &&
+          /allowNestedTransactions/.test(err.message),
+      );
+      assert.deepStrictEqual(calls, ['begin']);
+    });
+
+    it('rollback after begin runs backend.rollback', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend);
+
+      await tx.begin();
+      await tx.rollback();
+
+      assert.deepStrictEqual(calls, ['begin', 'rollback']);
+    });
+  });
+
+  describe('allowNestedTransactions: true, useSavepoints: false', () => {
+    it('nested begin/commit/rollback are no-ops at the backend layer', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend, {
+        allowNestedTransactions: true,
+      });
+
+      await tx.begin(); // outer
+      await tx.begin(); // nested
+      await tx.commit(); // nested commit — no-op
+      await tx.commit(); // outer commit
+
+      assert.deepStrictEqual(calls, ['begin', 'commit']);
+    });
+
+    it('outer rollback runs backend.rollback; nested rollback is a no-op', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend, {
+        allowNestedTransactions: true,
+      });
+
+      await tx.begin();
+      await tx.begin();
+      await tx.rollback();
+      await tx.rollback();
+
+      assert.deepStrictEqual(calls, ['begin', 'rollback']);
+    });
+
+    it('outer can begin again after committing (counter resets)', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend, {
+        allowNestedTransactions: true,
+      });
+
+      await tx.begin();
+      await tx.commit();
+      await tx.begin();
+      await tx.commit();
+
+      assert.deepStrictEqual(calls, ['begin', 'commit', 'begin', 'commit']);
+    });
+  });
+
+  describe('allowNestedTransactions: true, useSavepoints: true', () => {
+    it('nested begin runs savepoint, nested commit runs releaseSavepoint', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend, {
+        allowNestedTransactions: true,
+        useSavepoints: true,
+      });
+
+      await tx.begin(); // outer: backend.begin
+      await tx.begin(); // nested: savepoint:2
+      await tx.commit(); // nested: release:2
+      await tx.commit(); // outer: backend.commit
+
+      assert.deepStrictEqual(calls, [
+        'begin',
+        'savepoint:2',
+        'release:2',
+        'commit',
+      ]);
+    });
+
+    it('nested rollback runs rollbackToSavepoint', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend, {
+        allowNestedTransactions: true,
+        useSavepoints: true,
+      });
+
+      await tx.begin();
+      await tx.begin();
+      await tx.rollback();
+      await tx.commit();
+
+      assert.deepStrictEqual(calls, [
+        'begin',
+        'savepoint:2',
+        'rollbackTo:2',
+        'commit',
+      ]);
+    });
+
+    it('savepoint level reflects current nesting depth', async () => {
+      const { backend, calls } = makeBackend();
+      const tx = databaseTransaction(backend, {
+        allowNestedTransactions: true,
+        useSavepoints: true,
+      });
+
+      await tx.begin(); // level 1
+      await tx.begin(); // level 2
+      await tx.begin(); // level 3
+      await tx.commit(); // level 3 → release:3
+      await tx.commit(); // level 2 → release:2
+      await tx.commit(); // level 1 → backend.commit
+
+      assert.deepStrictEqual(calls, [
+        'begin',
+        'savepoint:2',
+        'savepoint:3',
+        'release:3',
+        'release:2',
+        'commit',
+      ]);
+    });
+  });
+
+  describe('savepoint hooks are optional', () => {
+    it('skips savepoint when useSavepoints is true but backend has no savepoint hook', async () => {
+      const calls: string[] = [];
+      const tx = databaseTransaction(
+        {
+          begin: () => {
+            calls.push('begin');
+            return Promise.resolve();
+          },
+          commit: () => {
+            calls.push('commit');
+            return Promise.resolve();
+          },
+          rollback: () => {
+            calls.push('rollback');
+            return Promise.resolve();
+          },
+        },
+        { allowNestedTransactions: true, useSavepoints: true },
+      );
+
+      await tx.begin();
+      await tx.begin();
+      await tx.commit();
+      await tx.commit();
+
+      assert.deepStrictEqual(calls, ['begin', 'commit']);
+    });
+  });
+});

--- a/src/packages/dumbo/src/core/execute/execute.ts
+++ b/src/packages/dumbo/src/core/execute/execute.ts
@@ -4,6 +4,7 @@ import { DumboError } from '../errors';
 import type { QueryResult, QueryResultRow } from '../query';
 import type { JSONDeserializeOptions, JSONSerializer } from '../serializer';
 import type { SQL, SQLFormatter } from '../sql';
+import type { AbortOptions } from '../taskProcessing';
 
 export const mapColumnToJSON = (
   column: string,
@@ -66,13 +67,11 @@ export type SQLQueryResultColumnMapping = {
   [column: string]: (value: unknown) => unknown;
 };
 
-export type SQLQueryOptions = {
-  timeoutMs?: number | undefined;
+export type SQLQueryOptions = AbortOptions & {
   mapping?: SQLQueryResultColumnMapping;
 };
 
-export type SQLCommandOptions = {
-  timeoutMs?: number | undefined;
+export type SQLCommandOptions = AbortOptions & {
   mapping?: SQLQueryResultColumnMapping;
 };
 

--- a/src/packages/dumbo/src/core/taskProcessing/abort.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/abort.ts
@@ -1,0 +1,65 @@
+import { DumboError, TransientDatabaseError } from '../errors';
+
+export type AbortOptions = {
+  signal?: AbortSignal | undefined;
+  timeoutMs?: number | undefined;
+};
+
+const link = (...signals: (AbortSignal | undefined | null)[]): AbortSignal => {
+  const real = signals.filter((p): p is AbortSignal => p != null);
+  if (real.length === 0) return new AbortController().signal;
+  if (real.length === 1) return real[0]!;
+  return AbortSignal.any(real);
+};
+
+const source = (
+  ...parents: (AbortSignal | undefined | null)[]
+): AbortController => {
+  const controller = new AbortController();
+  for (const parent of parents) {
+    if (!parent) continue;
+    if (parent.aborted) {
+      controller.abort(parent.reason);
+      return controller;
+    }
+    parent.addEventListener('abort', () => controller.abort(parent.reason), {
+      once: true,
+    });
+  }
+  return controller;
+};
+
+const after = (
+  timeoutMs: number,
+  ...parents: (AbortSignal | undefined | null)[]
+): AbortSignal => {
+  const controller = source(...parents);
+  if (controller.signal.aborted) return controller.signal;
+  const timer = setTimeout(
+    () =>
+      controller.abort(
+        new TransientDatabaseError(`Operation timed out after ${timeoutMs}ms`),
+      ),
+    timeoutMs,
+  );
+  timer.unref();
+  controller.signal.addEventListener('abort', () => clearTimeout(timer), {
+    once: true,
+  });
+  return controller.signal;
+};
+
+const reason = (signal: AbortSignal): Error => {
+  const value: unknown = signal.reason;
+  if (value instanceof Error) return value;
+  return new DumboError(
+    typeof value === 'string' ? value : 'Operation aborted',
+  );
+};
+
+export const Abort = {
+  link,
+  source,
+  after,
+  reason,
+} as const;

--- a/src/packages/dumbo/src/core/taskProcessing/abort.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/abort.unit.spec.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert';
+import { describe, it } from 'vitest';
+import { TransientDatabaseError } from '../errors';
+import { Abort } from './abort';
+
+describe('Abort.link', () => {
+  it('returns a never-aborting signal when no parents provided', () => {
+    const signal = Abort.link();
+    assert.strictEqual(signal.aborted, false);
+  });
+
+  it('returns the parent verbatim when only one is provided', () => {
+    const controller = new AbortController();
+    const signal = Abort.link(controller.signal);
+    assert.strictEqual(signal, controller.signal);
+  });
+
+  it('ignores undefined and null parents', () => {
+    const controller = new AbortController();
+    const signal = Abort.link(undefined, controller.signal, null);
+    assert.strictEqual(signal, controller.signal);
+  });
+
+  it('aborts when any parent aborts', () => {
+    const a = new AbortController();
+    const b = new AbortController();
+    const signal = Abort.link(a.signal, b.signal);
+
+    assert.strictEqual(signal.aborted, false);
+    a.abort(new Error('a fired'));
+    assert.strictEqual(signal.aborted, true);
+  });
+
+  it('returns an already-aborted signal if any parent is already aborted', () => {
+    const a = new AbortController();
+    a.abort(new Error('pre-aborted'));
+    const b = new AbortController();
+    const signal = Abort.link(a.signal, b.signal);
+    assert.strictEqual(signal.aborted, true);
+  });
+});
+
+describe('Abort.source', () => {
+  it('returns a native AbortController', () => {
+    const controller = Abort.source();
+    assert.ok(controller instanceof AbortController);
+  });
+
+  it('signal fires when the controller is aborted manually', () => {
+    const controller = Abort.source();
+    const reason = new Error('manual');
+    controller.abort(reason);
+    assert.strictEqual(controller.signal.aborted, true);
+    assert.strictEqual(controller.signal.reason, reason);
+  });
+
+  it('signal fires when any parent aborts', () => {
+    const a = new AbortController();
+    const controller = Abort.source(a.signal);
+    assert.strictEqual(controller.signal.aborted, false);
+    a.abort(new Error('parent'));
+    assert.strictEqual(controller.signal.aborted, true);
+  });
+
+  it('signal is pre-aborted when any parent is already aborted', () => {
+    const a = new AbortController();
+    a.abort(new Error('pre'));
+    const controller = Abort.source(a.signal);
+    assert.strictEqual(controller.signal.aborted, true);
+  });
+});
+
+describe('Abort.after', () => {
+  it('aborts when the timeout elapses', async () => {
+    const signal = Abort.after(10);
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) return resolve();
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+    assert.strictEqual(signal.aborted, true);
+    assert.ok(signal.reason instanceof TransientDatabaseError);
+  });
+
+  it('aborts with the parent reason when a parent fires before the timeout', () => {
+    const controller = new AbortController();
+    const parentReason = new Error('parent fired');
+    const signal = Abort.after(60_000, controller.signal);
+
+    assert.strictEqual(signal.aborted, false);
+    controller.abort(parentReason);
+    assert.strictEqual(signal.aborted, true);
+    assert.strictEqual(signal.reason, parentReason);
+  });
+
+  it('does not change the reason after the timeout window when already aborted by a parent', async () => {
+    const controller = new AbortController();
+    const parentReason = new Error('parent fired');
+    const signal = Abort.after(20, controller.signal);
+    controller.abort(parentReason);
+
+    const reasonBefore: unknown = signal.reason;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    assert.strictEqual(signal.reason, reasonBefore);
+  });
+});
+
+describe('Abort.reason', () => {
+  it('returns the signal reason verbatim when it is an Error', () => {
+    const controller = new AbortController();
+    const reason = new Error('boom');
+    controller.abort(reason);
+    assert.strictEqual(Abort.reason(controller.signal), reason);
+  });
+
+  it('wraps non-Error string reasons in a DumboError', () => {
+    const controller = new AbortController();
+    controller.abort('something');
+    const result = Abort.reason(controller.signal);
+    assert.ok(result instanceof Error);
+    assert.strictEqual(result.message, 'something');
+  });
+
+  it('falls back to a generic DumboError when the reason is not stringable', () => {
+    const controller = new AbortController();
+    controller.abort({ unusual: 'value' });
+    const result = Abort.reason(controller.signal);
+    assert.ok(result instanceof Error);
+    assert.strictEqual(result.message, 'Operation aborted');
+  });
+});

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
@@ -2,6 +2,7 @@ import { v7 as uuid } from 'uuid';
 import { TaskProcessor } from './taskProcessor';
 
 export type ExclusiveAccessGuard = {
+  signal: AbortSignal;
   execute: <Result>(operation: () => Promise<Result>) => Promise<Result>;
   waitForIdle: () => Promise<void>;
   stop: (options?: {
@@ -19,6 +20,9 @@ export const guardExclusiveAccess = (options?: {
   });
 
   return {
+    get signal() {
+      return taskProcessor.signal;
+    },
     execute: <Result>(operation: () => Promise<Result>): Promise<Result> =>
       taskProcessor.enqueue(async ({ ack }) => {
         try {
@@ -33,6 +37,7 @@ export const guardExclusiveAccess = (options?: {
 };
 
 export type BoundedAccessGuard<Resource> = {
+  signal: AbortSignal;
   acquire: () => Promise<Resource>;
   release: (resource: Resource) => void;
   execute: <Result>(
@@ -109,6 +114,9 @@ export const guardBoundedAccess = <Resource>(
   };
 
   return {
+    get signal() {
+      return taskProcessor.signal;
+    },
     acquire,
     release,
     execute,
@@ -134,6 +142,7 @@ export const guardBoundedAccess = <Resource>(
 };
 
 export type InitializedOnceGuard<T> = {
+  signal: AbortSignal;
   ensureInitialized: () => Promise<T>;
   reset: () => void;
   stop: (options?: {
@@ -189,6 +198,9 @@ export const guardInitializedOnce = <T>(
   };
 
   return {
+    get signal() {
+      return taskProcessor.signal;
+    },
     ensureInitialized,
     reset: () => {
       initPromise = null;

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
@@ -4,7 +4,10 @@ import { TaskProcessor } from './taskProcessor';
 export type ExclusiveAccessGuard = {
   execute: <Result>(operation: () => Promise<Result>) => Promise<Result>;
   waitForIdle: () => Promise<void>;
-  stop: (options?: { force?: boolean }) => Promise<void>;
+  stop: (options?: {
+    force?: boolean;
+    closeDeadline?: number;
+  }) => Promise<void>;
 };
 
 export const guardExclusiveAccess = (options?: {
@@ -36,7 +39,10 @@ export type BoundedAccessGuard<Resource> = {
     operation: (resource: Resource) => Promise<Result>,
   ) => Promise<Result>;
   waitForIdle: () => Promise<void>;
-  stop: (options?: { force?: boolean }) => Promise<void>;
+  stop: (options?: {
+    force?: boolean;
+    closeDeadline?: number;
+  }) => Promise<void>;
 };
 
 export const guardBoundedAccess = <Resource>(
@@ -110,6 +116,9 @@ export const guardBoundedAccess = <Resource>(
     stop: async (stopOptions) => {
       if (isStopped) return;
       isStopped = true;
+
+      await taskProcessor.stop(stopOptions);
+
       if (options?.closeResource) {
         const resources = [...allResources];
         allResources.clear();
@@ -120,8 +129,6 @@ export const guardBoundedAccess = <Resource>(
           ),
         );
       }
-
-      await taskProcessor.stop(stopOptions);
     },
   };
 };
@@ -129,7 +136,10 @@ export const guardBoundedAccess = <Resource>(
 export type InitializedOnceGuard<T> = {
   ensureInitialized: () => Promise<T>;
   reset: () => void;
-  stop: (options?: { force?: boolean }) => Promise<void>;
+  stop: (options?: {
+    force?: boolean;
+    closeDeadline?: number;
+  }) => Promise<void>;
 };
 
 export const guardInitializedOnce = <T>(

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
@@ -1,51 +1,14 @@
-import { DumboError } from '../errors';
 import { v7 as uuid } from 'uuid';
+import type { AbortOptions } from './abort';
+import { ResourcePool } from './resourcePool';
+import type { OperationContext } from './taskProcessor';
 import { TaskProcessor } from './taskProcessor';
 
 export type ExclusiveAccessGuard = {
-  execute: <Result>(operation: () => Promise<Result>) => Promise<Result>;
-  waitForIdle: () => Promise<void>;
-  stop: (options?: {
-    force?: boolean;
-    closeDeadline?: number;
-  }) => Promise<void>;
-};
-
-export const guardExclusiveAccess = (options?: {
-  maxQueueSize?: number;
-  abortController?: AbortController;
-}): ExclusiveAccessGuard => {
-  const abortController = options?.abortController ?? new AbortController();
-  const taskProcessor = new TaskProcessor({
-    maxActiveTasks: 1,
-    maxQueueSize: options?.maxQueueSize ?? 1000,
-    abortController,
-  });
-
-  return {
-    execute: <Result>(operation: () => Promise<Result>): Promise<Result> =>
-      taskProcessor.enqueue(async ({ ack }) => {
-        try {
-          return await operation();
-        } finally {
-          ack();
-        }
-      }),
-    waitForIdle: () => taskProcessor.waitForEndOfProcessing(),
-    stop: async (stopOptions) => {
-      abortController.abort(
-        new DumboError('Exclusive access guard has been stopped'),
-      );
-      await taskProcessor.stop(stopOptions);
-    },
-  };
-};
-
-export type BoundedAccessGuard<Resource> = {
-  acquire: () => Promise<Resource>;
-  release: (resource: Resource) => void;
+  readonly stopped: boolean;
   execute: <Result>(
-    operation: (resource: Resource) => Promise<Result>,
+    operation: (ctx: OperationContext) => Promise<Result>,
+    options?: AbortOptions,
   ) => Promise<Result>;
   waitForIdle: () => Promise<void>;
   stop: (options?: {
@@ -54,42 +17,82 @@ export type BoundedAccessGuard<Resource> = {
   }) => Promise<void>;
 };
 
-export const guardBoundedAccess = <Resource>(
+const exclusiveAccess = (options?: {
+  maxQueueSize?: number;
+  signal?: AbortSignal | undefined;
+  stoppedError?: (() => Error) | undefined;
+}): ExclusiveAccessGuard => {
+  const taskProcessor = new TaskProcessor({
+    maxActiveTasks: 1,
+    maxQueueSize: options?.maxQueueSize ?? 1000,
+    signal: options?.signal,
+    stoppedError: options?.stoppedError,
+  });
+
+  return {
+    get stopped() {
+      return taskProcessor.stopped;
+    },
+    execute: <Result>(
+      operation: (ctx: OperationContext) => Promise<Result>,
+      operationOptions?: AbortOptions,
+    ): Promise<Result> =>
+      taskProcessor.enqueue(async ({ ack, signal }) => {
+        try {
+          return await operation({ signal });
+        } finally {
+          ack();
+        }
+      }, operationOptions),
+    waitForIdle: () => taskProcessor.waitForEndOfProcessing(),
+    stop: (stopOptions) => taskProcessor.stop(stopOptions),
+  };
+};
+
+export type BoundedAccessGuard<Resource> = {
+  readonly stopped: boolean;
+  acquire: () => Promise<Resource>;
+  release: (resource: Resource) => void;
+  execute: <Result>(
+    operation: (resource: Resource, ctx: OperationContext) => Promise<Result>,
+    options?: AbortOptions,
+  ) => Promise<Result>;
+  waitForIdle: () => Promise<void>;
+  stop: (options?: {
+    force?: boolean;
+    closeDeadline?: number;
+  }) => Promise<void>;
+};
+
+const boundedAccess = <Resource>(
   getResource: () => Resource | Promise<Resource>,
   options: {
     maxResources: number;
     maxQueueSize?: number;
     reuseResources?: boolean;
     closeResource?: (resource: Resource) => void | Promise<void>;
-    abortController?: AbortController;
+    signal?: AbortSignal | undefined;
+    stoppedError?: (() => Error) | undefined;
   },
 ): BoundedAccessGuard<Resource> => {
-  let isStopped = false;
-  const abortController = options.abortController ?? new AbortController();
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: options.maxResources,
     maxQueueSize: options.maxQueueSize ?? 1000,
-    abortController,
+    signal: options.signal,
+    stoppedError: options.stoppedError,
   });
 
-  const resourcePool: Resource[] = [];
-  const allResources = new Set<Resource>();
+  const resourcePool = ResourcePool.create<Resource>(getResource, {
+    reuseResources: options.reuseResources,
+    closeResource: options.closeResource,
+  });
+
   const ackCallbacks = new Map<Resource, () => void>();
 
   const acquire = async (): Promise<Resource> =>
     taskProcessor.enqueue(async ({ ack }) => {
       try {
-        let resource: Resource | undefined;
-
-        if (options.reuseResources) {
-          resource = resourcePool.pop();
-        }
-
-        if (!resource) {
-          resource = await getResource();
-          allResources.add(resource);
-        }
-
+        const resource = await resourcePool.acquire();
         ackCallbacks.set(resource, ack);
         return resource;
       } catch (e) {
@@ -102,53 +105,44 @@ export const guardBoundedAccess = <Resource>(
     const ack = ackCallbacks.get(resource);
     if (ack) {
       ackCallbacks.delete(resource);
-      if (options.reuseResources) {
-        resourcePool.push(resource);
-      }
+      resourcePool.release(resource);
       ack();
     }
   };
 
-  const execute = async <Result>(
-    operation: (resource: Resource) => Promise<Result>,
-  ): Promise<Result> => {
-    const resource = await acquire();
-    try {
-      return await operation(resource);
-    } finally {
-      release(resource);
-    }
-  };
+  const execute = <Result>(
+    operation: (resource: Resource, ctx: OperationContext) => Promise<Result>,
+    operationOptions?: AbortOptions,
+  ): Promise<Result> =>
+    taskProcessor.enqueue(async ({ ack, signal }) => {
+      let resource: Resource | undefined;
+      try {
+        resource = await resourcePool.acquire();
+        return await operation(resource, { signal });
+      } finally {
+        if (resource) resourcePool.release(resource);
+        ack();
+      }
+    }, operationOptions);
 
   return {
+    get stopped() {
+      return taskProcessor.stopped;
+    },
     acquire,
     release,
     execute,
     waitForIdle: () => taskProcessor.waitForEndOfProcessing(),
     stop: async (stopOptions) => {
-      if (isStopped) return;
-      isStopped = true;
-
-      abortController.abort(
-        new DumboError('Bounded access guard has been stopped'),
-      );
+      if (taskProcessor.stopped) return;
       await taskProcessor.stop(stopOptions);
-
-      if (options?.closeResource) {
-        const resources = [...allResources];
-        allResources.clear();
-        resourcePool.length = 0;
-        await Promise.all(
-          resources.map(
-            async (resource) => await options.closeResource!(resource),
-          ),
-        );
-      }
+      await resourcePool.close();
     },
   };
 };
 
 export type InitializedOnceGuard<T> = {
+  readonly stopped: boolean;
   ensureInitialized: () => Promise<T>;
   reset: () => void;
   stop: (options?: {
@@ -157,21 +151,22 @@ export type InitializedOnceGuard<T> = {
   }) => Promise<void>;
 };
 
-export const guardInitializedOnce = <T>(
+const initializedOnce = <T>(
   initialize: () => Promise<T>,
   options?: {
     maxQueueSize?: number;
     maxRetries?: number;
-    abortController?: AbortController;
+    signal?: AbortSignal | undefined;
+    stoppedError?: (() => Error) | undefined;
   },
 ): InitializedOnceGuard<T> => {
   let initPromise: Promise<T> | null = null;
-  const abortController = options?.abortController ?? new AbortController();
 
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: 1,
     maxQueueSize: options?.maxQueueSize ?? 1000,
-    abortController,
+    signal: options?.signal,
+    stoppedError: options?.stoppedError,
   });
 
   const ensureInitialized = async (retryCount = 0): Promise<T> => {
@@ -207,15 +202,19 @@ export const guardInitializedOnce = <T>(
   };
 
   return {
+    get stopped() {
+      return taskProcessor.stopped;
+    },
     ensureInitialized,
     reset: () => {
       initPromise = null;
     },
-    stop: async (stopOptions) => {
-      abortController.abort(
-        new DumboError('Initialized-once guard has been stopped'),
-      );
-      await taskProcessor.stop(stopOptions);
-    },
+    stop: (stopOptions) => taskProcessor.stop(stopOptions),
   };
 };
+
+export const Guard = {
+  exclusiveAccess,
+  boundedAccess,
+  initializedOnce,
+} as const;

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
@@ -1,8 +1,8 @@
+import { DumboError } from '../errors';
 import { v7 as uuid } from 'uuid';
 import { TaskProcessor } from './taskProcessor';
 
 export type ExclusiveAccessGuard = {
-  signal: AbortSignal;
   execute: <Result>(operation: () => Promise<Result>) => Promise<Result>;
   waitForIdle: () => Promise<void>;
   stop: (options?: {
@@ -13,16 +13,16 @@ export type ExclusiveAccessGuard = {
 
 export const guardExclusiveAccess = (options?: {
   maxQueueSize?: number;
+  abortController?: AbortController;
 }): ExclusiveAccessGuard => {
+  const abortController = options?.abortController ?? new AbortController();
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: 1,
     maxQueueSize: options?.maxQueueSize ?? 1000,
+    abortController,
   });
 
   return {
-    get signal() {
-      return taskProcessor.signal;
-    },
     execute: <Result>(operation: () => Promise<Result>): Promise<Result> =>
       taskProcessor.enqueue(async ({ ack }) => {
         try {
@@ -32,12 +32,16 @@ export const guardExclusiveAccess = (options?: {
         }
       }),
     waitForIdle: () => taskProcessor.waitForEndOfProcessing(),
-    stop: (options) => taskProcessor.stop(options),
+    stop: async (stopOptions) => {
+      abortController.abort(
+        new DumboError('Exclusive access guard has been stopped'),
+      );
+      await taskProcessor.stop(stopOptions);
+    },
   };
 };
 
 export type BoundedAccessGuard<Resource> = {
-  signal: AbortSignal;
   acquire: () => Promise<Resource>;
   release: (resource: Resource) => void;
   execute: <Result>(
@@ -57,12 +61,15 @@ export const guardBoundedAccess = <Resource>(
     maxQueueSize?: number;
     reuseResources?: boolean;
     closeResource?: (resource: Resource) => void | Promise<void>;
+    abortController?: AbortController;
   },
 ): BoundedAccessGuard<Resource> => {
   let isStopped = false;
+  const abortController = options.abortController ?? new AbortController();
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: options.maxResources,
     maxQueueSize: options.maxQueueSize ?? 1000,
+    abortController,
   });
 
   const resourcePool: Resource[] = [];
@@ -114,9 +121,6 @@ export const guardBoundedAccess = <Resource>(
   };
 
   return {
-    get signal() {
-      return taskProcessor.signal;
-    },
     acquire,
     release,
     execute,
@@ -125,6 +129,9 @@ export const guardBoundedAccess = <Resource>(
       if (isStopped) return;
       isStopped = true;
 
+      abortController.abort(
+        new DumboError('Bounded access guard has been stopped'),
+      );
       await taskProcessor.stop(stopOptions);
 
       if (options?.closeResource) {
@@ -142,7 +149,6 @@ export const guardBoundedAccess = <Resource>(
 };
 
 export type InitializedOnceGuard<T> = {
-  signal: AbortSignal;
   ensureInitialized: () => Promise<T>;
   reset: () => void;
   stop: (options?: {
@@ -156,13 +162,16 @@ export const guardInitializedOnce = <T>(
   options?: {
     maxQueueSize?: number;
     maxRetries?: number;
+    abortController?: AbortController;
   },
 ): InitializedOnceGuard<T> => {
   let initPromise: Promise<T> | null = null;
+  const abortController = options?.abortController ?? new AbortController();
 
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: 1,
     maxQueueSize: options?.maxQueueSize ?? 1000,
+    abortController,
   });
 
   const ensureInitialized = async (retryCount = 0): Promise<T> => {
@@ -198,13 +207,15 @@ export const guardInitializedOnce = <T>(
   };
 
   return {
-    get signal() {
-      return taskProcessor.signal;
-    },
     ensureInitialized,
     reset: () => {
       initPromise = null;
     },
-    stop: (options) => taskProcessor.stop(options),
+    stop: async (stopOptions) => {
+      abortController.abort(
+        new DumboError('Initialized-once guard has been stopped'),
+      );
+      await taskProcessor.stop(stopOptions);
+    },
   };
 };

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.unit.spec.ts
@@ -77,6 +77,23 @@ describe('Task Processing Guards', () => {
       const result = await operationPromise;
       assert.strictEqual(result, 42);
     });
+
+    it('rejects queued operations on stop instead of leaving them pending', async () => {
+      const guard = guardExclusiveAccess();
+
+      const active = guard.execute(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return 1;
+      });
+      const queued = guard.execute(() => Promise.resolve(2));
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      await guard.stop({ force: true });
+
+      await assert.rejects(() => queued, /TaskProcessor has been stopped/);
+      await active;
+    });
   });
 
   describe('guardBoundedAccess', () => {
@@ -195,6 +212,69 @@ describe('Task Processing Guards', () => {
       );
       const result = await operationPromise;
       assert.strictEqual(result, 1);
+    });
+
+    it('rejects queued acquires on stop', async () => {
+      const guard = guardBoundedAccess(() => ({ id: 1 }), {
+        maxResources: 1,
+        reuseResources: false,
+      });
+
+      const acquired = await guard.acquire();
+      const queuedAcquire = guard.acquire();
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      await guard.stop({ force: true });
+
+      await assert.rejects(
+        () => queuedAcquire,
+        /TaskProcessor has been stopped/,
+      );
+
+      guard.release(acquired);
+    });
+
+    it('closes resources via closeResource on stop', async () => {
+      let closed = 0;
+      const guard = guardBoundedAccess(() => ({ id: ++closed }), {
+        maxResources: 2,
+        reuseResources: true,
+        closeResource: () => {
+          // count via outer closure
+        },
+      });
+
+      const closedIds: number[] = [];
+      const guardWithClose = guardBoundedAccess(
+        () => {
+          const id = closedIds.length;
+          return { id };
+        },
+        {
+          maxResources: 2,
+          reuseResources: true,
+          closeResource: (r: { id: number }) => {
+            closedIds.push(r.id);
+          },
+        },
+      );
+
+      await Promise.all([
+        guardWithClose.execute((r) => Promise.resolve(r.id)),
+        guardWithClose.execute((r) => Promise.resolve(r.id)),
+      ]);
+
+      await guardWithClose.stop();
+
+      assert.strictEqual(
+        closedIds.length,
+        2,
+        'closeResource should be called for every resource at stop',
+      );
+
+      // Unused first guard kept just to demonstrate inert closeResource path
+      void guard;
     });
   });
 

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.unit.spec.ts
@@ -1,15 +1,11 @@
 import assert from 'node:assert';
 import { describe, it } from 'vitest';
-import {
-  guardBoundedAccess,
-  guardExclusiveAccess,
-  guardInitializedOnce,
-} from './executionGuards';
+import { Guard } from './executionGuards';
 
 describe('Task Processing Guards', () => {
-  describe('guardExclusiveAccess', () => {
+  describe('Guard.exclusiveAccess', () => {
     it('ensures operations run one at a time', async () => {
-      const guard = guardExclusiveAccess();
+      const guard = Guard.exclusiveAccess();
       const executionOrder: number[] = [];
       let activeOperations = 0;
 
@@ -36,7 +32,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('propagates errors correctly', async () => {
-      const guard = guardExclusiveAccess();
+      const guard = Guard.exclusiveAccess();
 
       await assert.rejects(
         () => guard.execute(() => Promise.reject(new Error('test error'))),
@@ -45,7 +41,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('stops and rejects new operations after stop with force', async () => {
-      const guard = guardExclusiveAccess();
+      const guard = Guard.exclusiveAccess();
 
       await guard.stop({ force: true });
 
@@ -56,7 +52,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('waits for active operations when stopping without force', async () => {
-      const guard = guardExclusiveAccess();
+      const guard = Guard.exclusiveAccess();
       let operationCompleted = false;
 
       const operationPromise = guard.execute(async () => {
@@ -79,7 +75,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('rejects queued operations on stop instead of leaving them pending', async () => {
-      const guard = guardExclusiveAccess();
+      const guard = Guard.exclusiveAccess();
 
       const active = guard.execute(async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
@@ -96,10 +92,10 @@ describe('Task Processing Guards', () => {
     });
   });
 
-  describe('guardBoundedAccess', () => {
+  describe('Guard.boundedAccess', () => {
     it('limits concurrent access to resources', async () => {
       let resourceId = 0;
-      const guard = guardBoundedAccess(() => ({ id: ++resourceId }), {
+      const guard = Guard.boundedAccess(() => ({ id: ++resourceId }), {
         maxResources: 2,
         reuseResources: true,
       });
@@ -128,7 +124,7 @@ describe('Task Processing Guards', () => {
 
     it('reuses resources when enabled', async () => {
       const createdResources: number[] = [];
-      const guard = guardBoundedAccess(
+      const guard = Guard.boundedAccess(
         () => {
           const id = createdResources.length + 1;
           createdResources.push(id);
@@ -155,7 +151,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('releases resources on error', async () => {
-      const guard = guardBoundedAccess(() => ({ id: 1 }), {
+      const guard = Guard.boundedAccess(() => ({ id: 1 }), {
         maxResources: 1,
         reuseResources: true,
       });
@@ -174,7 +170,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('stops and clears queue on stop with force', async () => {
-      const guard = guardBoundedAccess(() => ({ id: 1 }), {
+      const guard = Guard.boundedAccess(() => ({ id: 1 }), {
         maxResources: 1,
         reuseResources: false,
       });
@@ -188,7 +184,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('waits for active operations when stopping without force', async () => {
-      const guard = guardBoundedAccess(() => ({ id: 1 }), {
+      const guard = Guard.boundedAccess(() => ({ id: 1 }), {
         maxResources: 1,
         reuseResources: true,
       });
@@ -215,7 +211,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('rejects queued acquires on stop', async () => {
-      const guard = guardBoundedAccess(() => ({ id: 1 }), {
+      const guard = Guard.boundedAccess(() => ({ id: 1 }), {
         maxResources: 1,
         reuseResources: false,
       });
@@ -237,7 +233,7 @@ describe('Task Processing Guards', () => {
 
     it('closes resources via closeResource on stop', async () => {
       let closed = 0;
-      const guard = guardBoundedAccess(() => ({ id: ++closed }), {
+      const guard = Guard.boundedAccess(() => ({ id: ++closed }), {
         maxResources: 2,
         reuseResources: true,
         closeResource: () => {
@@ -246,7 +242,7 @@ describe('Task Processing Guards', () => {
       });
 
       const closedIds: number[] = [];
-      const guardWithClose = guardBoundedAccess(
+      const guardWithClose = Guard.boundedAccess(
         () => {
           const id = closedIds.length;
           return { id };
@@ -278,10 +274,10 @@ describe('Task Processing Guards', () => {
     });
   });
 
-  describe('guardInitializedOnce', () => {
+  describe('Guard.initializedOnce', () => {
     it('ensures initialization happens only once', async () => {
       let initCount = 0;
-      const guard = guardInitializedOnce(async () => {
+      const guard = Guard.initializedOnce(async () => {
         initCount++;
         await new Promise((resolve) => setTimeout(resolve, 10));
         return `init-${initCount}`;
@@ -303,7 +299,7 @@ describe('Task Processing Guards', () => {
 
     it('retries on failure', async () => {
       let attempts = 0;
-      const guard = guardInitializedOnce(
+      const guard = Guard.initializedOnce(
         () => {
           attempts++;
           if (attempts < 3) {
@@ -325,7 +321,7 @@ describe('Task Processing Guards', () => {
 
     it('throws after max retries exceeded', async () => {
       let attempts = 0;
-      const guard = guardInitializedOnce(
+      const guard = Guard.initializedOnce(
         async () => {
           attempts++;
           return Promise.reject(new Error('Always fails'));
@@ -339,7 +335,7 @@ describe('Task Processing Guards', () => {
 
     it('allows reset to reinitialize', async () => {
       let initCount = 0;
-      const guard = guardInitializedOnce(() => {
+      const guard = Guard.initializedOnce(() => {
         initCount++;
         return Promise.resolve(`value-${initCount}`);
       });
@@ -359,7 +355,7 @@ describe('Task Processing Guards', () => {
     });
 
     it('stops and prevents new initialization after stop', async () => {
-      const guard = guardInitializedOnce(() => {
+      const guard = Guard.initializedOnce(() => {
         return Promise.resolve('initialized');
       });
 
@@ -369,6 +365,123 @@ describe('Task Processing Guards', () => {
         () => guard.ensureInitialized(),
         /TaskProcessor has been stopped/,
       );
+    });
+  });
+
+  describe('ctx threading via execute', () => {
+    it('exclusive: operation receives ctx with a usable AbortSignal', async () => {
+      const guard = Guard.exclusiveAccess();
+      const seen = await guard.execute((ctx) =>
+        Promise.resolve(ctx.signal instanceof AbortSignal),
+      );
+      assert.strictEqual(seen, true);
+      await guard.stop({ force: true });
+    });
+
+    it('bounded: operation receives (resource, ctx) with a usable AbortSignal', async () => {
+      const guard = Guard.boundedAccess(() => ({ id: 1 }), {
+        maxResources: 1,
+      });
+      const seen = await guard.execute((_resource, ctx) =>
+        Promise.resolve(ctx.signal instanceof AbortSignal),
+      );
+      assert.strictEqual(seen, true);
+      await guard.stop({ force: true });
+    });
+
+    it('bounded: per-call signal fires ctx.signal without affecting the guard', async () => {
+      const guard = Guard.boundedAccess(() => ({ id: 1 }), {
+        maxResources: 1,
+      });
+      const perCall = new AbortController();
+      const sawAbort = Promise.withResolvers<boolean>();
+
+      const done = guard.execute(
+        async (_resource, ctx) => {
+          ctx.signal.addEventListener('abort', () => sawAbort.resolve(true));
+          await new Promise<void>((resolve) => {
+            if (ctx.signal.aborted) return resolve();
+            ctx.signal.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+        },
+        { signal: perCall.signal },
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+      perCall.abort(new Error('per-call'));
+
+      assert.strictEqual(await sawAbort.promise, true);
+      await done;
+      await guard.stop({ force: true });
+    });
+  });
+
+  describe('concurrency', () => {
+    it('bounded guard runs up to maxResources operations concurrently', async () => {
+      const guard = Guard.boundedAccess(() => ({ id: Math.random() }), {
+        maxResources: 3,
+      });
+
+      let inFlight = 0;
+      let peak = 0;
+      const work = () =>
+        guard.execute(async () => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          inFlight--;
+        });
+
+      await Promise.all([work(), work(), work(), work(), work()]);
+
+      assert.strictEqual(
+        peak,
+        3,
+        'no more than maxResources operations should be in-flight at once',
+      );
+      await guard.stop({ force: true });
+    });
+
+    it('bounded guard with maxResources=1 serializes all operations', async () => {
+      const guard = Guard.boundedAccess(() => ({}), {
+        maxResources: 1,
+      });
+
+      let inFlight = 0;
+      let peak = 0;
+      const work = () =>
+        guard.execute(async () => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          inFlight--;
+        });
+
+      await Promise.all([work(), work(), work()]);
+
+      assert.strictEqual(peak, 1);
+      await guard.stop({ force: true });
+    });
+
+    it('concurrent execute calls on exclusive guard never overlap', async () => {
+      const guard = Guard.exclusiveAccess();
+      let inFlight = 0;
+      let peak = 0;
+
+      const work = () =>
+        guard.execute(async () => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          inFlight--;
+        });
+
+      await Promise.all([work(), work(), work(), work()]);
+
+      assert.strictEqual(peak, 1);
+      await guard.stop({ force: true });
     });
   });
 });

--- a/src/packages/dumbo/src/core/taskProcessing/index.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/index.ts
@@ -1,2 +1,4 @@
+export * from './abort';
 export * from './executionGuards';
+export * from './resourcePool';
 export * from './taskProcessor';

--- a/src/packages/dumbo/src/core/taskProcessing/resourcePool.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/resourcePool.ts
@@ -1,0 +1,48 @@
+export type ResourcePool<Resource> = {
+  acquire: () => Promise<Resource>;
+  release: (resource: Resource) => void;
+  close: () => Promise<void>;
+};
+
+export type ResourcePoolOptions<Resource> = {
+  reuseResources?: boolean | undefined;
+  closeResource?: ((resource: Resource) => void | Promise<void>) | undefined;
+};
+
+const create = <Resource>(
+  getResource: () => Resource | Promise<Resource>,
+  options?: ResourcePoolOptions<Resource>,
+): ResourcePool<Resource> => {
+  const cached: Resource[] = [];
+  const allResources = new Set<Resource>();
+  const reuse = options?.reuseResources ?? false;
+
+  return {
+    acquire: async () => {
+      if (reuse) {
+        const cachedOne = cached.pop();
+        if (cachedOne !== undefined) return cachedOne;
+      }
+      const resource = await getResource();
+      allResources.add(resource);
+      return resource;
+    },
+    release: (resource) => {
+      if (reuse) cached.push(resource);
+    },
+    close: async () => {
+      const resources = [...allResources];
+      allResources.clear();
+      cached.length = 0;
+      const closeResource = options?.closeResource;
+      if (!closeResource) return;
+      await Promise.all(
+        resources.map((r) => Promise.resolve(closeResource(r))),
+      );
+    },
+  };
+};
+
+export const ResourcePool = {
+  create,
+} as const;

--- a/src/packages/dumbo/src/core/taskProcessing/resourcePool.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/resourcePool.unit.spec.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert';
+import { describe, it } from 'vitest';
+import { ResourcePool } from './resourcePool';
+
+describe('ResourcePool.create', () => {
+  it('produces a new resource each acquire when reuse is disabled', async () => {
+    let counter = 0;
+    const pool = ResourcePool.create<{ id: number }>(() => ({ id: ++counter }));
+
+    const a = await pool.acquire();
+    pool.release(a);
+    const b = await pool.acquire();
+
+    assert.notStrictEqual(a, b);
+    assert.strictEqual(a.id, 1);
+    assert.strictEqual(b.id, 2);
+  });
+
+  it('reuses released resources when reuseResources is true', async () => {
+    let counter = 0;
+    const pool = ResourcePool.create<{ id: number }>(
+      () => ({ id: ++counter }),
+      { reuseResources: true },
+    );
+
+    const a = await pool.acquire();
+    pool.release(a);
+    const b = await pool.acquire();
+
+    assert.strictEqual(a, b);
+    assert.strictEqual(counter, 1);
+  });
+
+  it('creates new resources when the cache is empty even with reuse enabled', async () => {
+    let counter = 0;
+    const pool = ResourcePool.create<{ id: number }>(
+      () => ({ id: ++counter }),
+      { reuseResources: true },
+    );
+
+    const a = await pool.acquire();
+    const b = await pool.acquire();
+
+    assert.notStrictEqual(a, b);
+    assert.strictEqual(counter, 2);
+  });
+
+  it('release without reuse drops the resource (no caching)', async () => {
+    let counter = 0;
+    const pool = ResourcePool.create<{ id: number }>(() => ({ id: ++counter }));
+
+    const a = await pool.acquire();
+    pool.release(a);
+    const b = await pool.acquire();
+    const c = await pool.acquire();
+
+    assert.strictEqual(counter, 3);
+    assert.notStrictEqual(a, b);
+    assert.notStrictEqual(b, c);
+  });
+
+  it('closeAll invokes closeResource for every acquired resource', async () => {
+    const closed: number[] = [];
+    let counter = 0;
+    const pool = ResourcePool.create<{ id: number }>(
+      () => ({ id: ++counter }),
+      {
+        reuseResources: true,
+        closeResource: (r) => {
+          closed.push(r.id);
+        },
+      },
+    );
+
+    const a = await pool.acquire();
+    const b = await pool.acquire();
+    pool.release(a);
+
+    await pool.close();
+
+    assert.deepStrictEqual(closed.sort(), [a.id, b.id].sort());
+  });
+
+  it('closeAll is a no-op when no resources have been acquired', async () => {
+    const closed: number[] = [];
+    const pool = ResourcePool.create<{ id: number }>(() => ({ id: 1 }), {
+      closeResource: (r) => {
+        closed.push(r.id);
+      },
+    });
+
+    await pool.close();
+    assert.deepStrictEqual(closed, []);
+  });
+
+  it('closeAll clears the cache so subsequent acquire creates fresh resources', async () => {
+    let counter = 0;
+    const pool = ResourcePool.create<{ id: number }>(
+      () => ({ id: ++counter }),
+      { reuseResources: true },
+    );
+
+    const a = await pool.acquire();
+    pool.release(a);
+
+    await pool.close();
+
+    const b = await pool.acquire();
+    assert.notStrictEqual(a, b);
+    assert.strictEqual(b.id, 2);
+  });
+
+  it('awaits async getResource calls', async () => {
+    let counter = 0;
+    const pool = ResourcePool.create<{ id: number }>(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return { id: ++counter };
+    });
+
+    const a = await pool.acquire();
+    assert.strictEqual(a.id, 1);
+  });
+});

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
@@ -19,6 +19,7 @@ export type Task<T> = (context: TaskContext) => Promise<T>;
 
 export type TaskContext = {
   ack: () => void;
+  signal: AbortSignal;
 };
 
 export type EnqueueTaskOptions = { taskGroupId?: string };
@@ -30,9 +31,14 @@ export class TaskProcessor {
   private activeGroups: Set<string> = new Set();
   private options: TaskProcessorOptions;
   private stopped = false;
+  private abortController = new AbortController();
 
   constructor(options: TaskProcessorOptions) {
     this.options = options;
+  }
+
+  get signal(): AbortSignal {
+    return this.abortController.signal;
   }
 
   enqueue<T>(task: Task<T>, options?: EnqueueTaskOptions): Promise<T> {
@@ -66,6 +72,11 @@ export class TaskProcessor {
     const reason = new DumboError('TaskProcessor has been stopped');
     for (const item of cancelled) item.reject(reason);
 
+    // Signal cooperative tasks to wrap up before we wait for them. Honest user
+    // code listening for abort can return early; uncooperative tasks fall back
+    // to the closeDeadline race below.
+    this.abortController.abort(reason);
+
     if (options?.force) return;
 
     const drained = this.waitForEndOfProcessing().catch(() => undefined);
@@ -87,7 +98,10 @@ export class TaskProcessor {
 
     const taskWithContext = () =>
       new Promise<void>((resolveTask, failTask) => {
-        const taskPromise = task({ ack: resolveTask });
+        const taskPromise = task({
+          ack: resolveTask,
+          signal: this.abortController.signal,
+        });
 
         taskPromise
           .then((value) => {

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
@@ -13,13 +13,17 @@ export type TaskProcessorOptions = {
   maxActiveTasks: number;
   maxQueueSize: number;
   maxTaskIdleTime?: number;
+  abortController?: AbortController;
 };
 
 export type Task<T> = (context: TaskContext) => Promise<T>;
 
-export type TaskContext = {
-  ack: () => void;
+export type OperationContext = {
   signal: AbortSignal;
+};
+
+export type TaskContext = OperationContext & {
+  ack: () => void;
 };
 
 export type EnqueueTaskOptions = { taskGroupId?: string };
@@ -31,14 +35,11 @@ export class TaskProcessor {
   private activeGroups: Set<string> = new Set();
   private options: TaskProcessorOptions;
   private stopped = false;
-  private abortController = new AbortController();
+  private abortController: AbortController;
 
   constructor(options: TaskProcessorOptions) {
     this.options = options;
-  }
-
-  get signal(): AbortSignal {
-    return this.abortController.signal;
+    this.abortController = options.abortController ?? new AbortController();
   }
 
   enqueue<T>(task: Task<T>, options?: EnqueueTaskOptions): Promise<T> {

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
@@ -1,4 +1,5 @@
 import { DumboError, TransientDatabaseError } from '../errors';
+import { Abort } from './abort';
 
 export type TaskQueue = TaskQueueItem[];
 
@@ -12,8 +13,9 @@ export type TaskQueueItem = {
 export type TaskProcessorOptions = {
   maxActiveTasks: number;
   maxQueueSize: number;
-  maxTaskIdleTime?: number;
-  abortController?: AbortController;
+  maxTaskIdleTime?: number | undefined;
+  signal?: AbortSignal | undefined;
+  stoppedError?: (() => Error) | undefined;
 };
 
 export type Task<T> = (context: TaskContext) => Promise<T>;
@@ -26,7 +28,11 @@ export type TaskContext = OperationContext & {
   ack: () => void;
 };
 
-export type EnqueueTaskOptions = { taskGroupId?: string };
+export type EnqueueTaskOptions = {
+  taskGroupId?: string | undefined;
+  signal?: AbortSignal | undefined;
+  timeoutMs?: number | undefined;
+};
 
 export class TaskProcessor {
   private queue: TaskQueue = [];
@@ -34,17 +40,29 @@ export class TaskProcessor {
   private activeTasks = 0;
   private activeGroups: Set<string> = new Set();
   private options: TaskProcessorOptions;
-  private stopped = false;
+  private isStopped = false;
   private abortController: AbortController;
+  private idleWaiters: Array<() => void> = [];
 
   constructor(options: TaskProcessorOptions) {
     this.options = options;
-    this.abortController = options.abortController ?? new AbortController();
+    this.abortController = Abort.source(options.signal);
+  }
+
+  get stopped(): boolean {
+    return this.isStopped;
+  }
+
+  private buildStoppedError(): Error {
+    return (
+      this.options.stoppedError?.() ??
+      new DumboError('TaskProcessor has been stopped')
+    );
   }
 
   enqueue<T>(task: Task<T>, options?: EnqueueTaskOptions): Promise<T> {
-    if (this.stopped) {
-      return Promise.reject(new DumboError('TaskProcessor has been stopped'));
+    if (this.isStopped) {
+      return Promise.reject(this.buildStoppedError());
     }
 
     if (this.queue.length >= this.options.maxQueueSize) {
@@ -55,22 +73,40 @@ export class TaskProcessor {
       );
     }
 
-    return this.schedule(task, options);
+    const taskSignal =
+      options?.timeoutMs !== undefined
+        ? Abort.after(
+            options.timeoutMs,
+            this.abortController.signal,
+            options.signal,
+          )
+        : Abort.link(this.abortController.signal, options?.signal);
+
+    if (taskSignal.aborted) {
+      return Promise.reject(Abort.reason(taskSignal));
+    }
+
+    return this.schedule(task, taskSignal, options);
   }
 
   waitForEndOfProcessing(): Promise<void> {
-    return this.schedule(({ ack }) => Promise.resolve(ack()));
+    if (this.activeTasks === 0 && this.queue.length === 0) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.idleWaiters.push(resolve);
+    });
   }
 
   async stop(options?: {
     force?: boolean;
     closeDeadline?: number;
   }): Promise<void> {
-    if (this.stopped) return;
-    this.stopped = true;
+    if (this.isStopped) return;
+    this.isStopped = true;
     const cancelled = this.queue.splice(0);
     this.activeGroups.clear();
-    const reason = new DumboError('TaskProcessor has been stopped');
+    const reason = this.buildStoppedError();
     for (const item of cancelled) item.reject(reason);
 
     // Signal cooperative tasks to wrap up before we wait for them. Honest user
@@ -78,9 +114,15 @@ export class TaskProcessor {
     // to the closeDeadline race below.
     this.abortController.abort(reason);
 
-    if (options?.force) return;
+    if (options?.force) {
+      // Force-stop releases waiters even if active tasks haven't completed —
+      // callers asked us not to drain.
+      const waiters = this.idleWaiters.splice(0);
+      for (const w of waiters) w();
+      return;
+    }
 
-    const drained = this.waitForEndOfProcessing().catch(() => undefined);
+    const drained = this.waitForEndOfProcessing();
     if (options?.closeDeadline !== undefined) {
       await Promise.race([drained, delay(options.closeDeadline)]);
     } else {
@@ -88,7 +130,11 @@ export class TaskProcessor {
     }
   }
 
-  private schedule<T>(task: Task<T>, options?: EnqueueTaskOptions): Promise<T> {
+  private schedule<T>(
+    task: Task<T>,
+    taskSignal: AbortSignal,
+    options?: EnqueueTaskOptions,
+  ): Promise<T> {
     const { promise, resolve, reject } = Promise.withResolvers<T>();
     silenceUnhandledRejection(promise);
 
@@ -101,7 +147,7 @@ export class TaskProcessor {
       new Promise<void>((resolveTask, failTask) => {
         const taskPromise = task({
           ack: resolveTask,
-          signal: this.abortController.signal,
+          signal: taskSignal,
         });
 
         taskPromise
@@ -179,6 +225,10 @@ export class TaskProcessor {
       await item.task();
     } finally {
       this.activeTasks--;
+      if (this.activeTasks === 0 && this.queue.length === 0) {
+        const waiters = this.idleWaiters.splice(0);
+        for (const w of waiters) w();
+      }
 
       // Mark the group as inactive after task completion
       if (item.options && item.options.taskGroupId) {

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
@@ -4,6 +4,8 @@ export type TaskQueue = TaskQueueItem[];
 
 export type TaskQueueItem = {
   task: () => Promise<void>;
+  reject: (reason: unknown) => void;
+  markStarted: () => void;
   options?: EnqueueTaskOptions | undefined;
 };
 
@@ -53,41 +55,67 @@ export class TaskProcessor {
     return this.schedule(({ ack }) => Promise.resolve(ack()));
   }
 
-  async stop(options?: { force?: boolean }): Promise<void> {
+  async stop(options?: {
+    force?: boolean;
+    closeDeadline?: number;
+  }): Promise<void> {
     if (this.stopped) return;
     this.stopped = true;
-    this.queue.length = 0;
+    const cancelled = this.queue.splice(0);
     this.activeGroups.clear();
+    const reason = new DumboError('TaskProcessor has been stopped');
+    for (const item of cancelled) item.reject(reason);
 
-    if (!options?.force) {
-      await this.waitForEndOfProcessing();
+    if (options?.force) return;
+
+    const drained = this.waitForEndOfProcessing().catch(() => undefined);
+    if (options?.closeDeadline !== undefined) {
+      await Promise.race([drained, delay(options.closeDeadline)]);
+    } else {
+      await drained;
     }
   }
 
   private schedule<T>(task: Task<T>, options?: EnqueueTaskOptions): Promise<T> {
-    return promiseWithDeadline(
-      (resolve, reject) => {
-        const taskWithContext = () => {
-          return new Promise<void>((resolveTask, failTask) => {
-            const taskPromise = task({
-              ack: resolveTask,
-            });
+    const { promise, resolve, reject } = Promise.withResolvers<T>();
+    silenceUnhandledRejection(promise);
 
-            taskPromise.then(resolve).catch((err) => {
-              // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-              failTask(err);
-              reject(err);
-            });
-          });
-        };
-
-        this.queue.push({ task: taskWithContext, options });
-        if (!this.isProcessing) {
-          this.ensureProcessing();
-        }
-      },
-      { deadline: this.options.maxTaskIdleTime },
+    const queueWaitTimer = createQueueWaitTimer(
+      this.options.maxTaskIdleTime,
+      reject,
     );
+
+    const taskWithContext = () =>
+      new Promise<void>((resolveTask, failTask) => {
+        const taskPromise = task({ ack: resolveTask });
+
+        taskPromise
+          .then((value) => {
+            queueWaitTimer.cancel();
+            resolve(value);
+          })
+          .catch((err) => {
+            queueWaitTimer.cancel();
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            failTask(err);
+            reject(err);
+          });
+      });
+
+    this.queue.push({
+      task: taskWithContext,
+      reject: (reason) => {
+        queueWaitTimer.cancel();
+        reject(reason);
+      },
+      markStarted: queueWaitTimer.cancel,
+      options,
+    });
+    if (!this.isProcessing) {
+      this.ensureProcessing();
+    }
+
+    return promise;
   }
 
   private ensureProcessing(): void {
@@ -130,15 +158,16 @@ export class TaskProcessor {
     }
   }
 
-  private async executeItem({ task, options }: TaskQueueItem): Promise<void> {
+  private async executeItem(item: TaskQueueItem): Promise<void> {
+    item.markStarted();
     try {
-      await task();
+      await item.task();
     } finally {
       this.activeTasks--;
 
       // Mark the group as inactive after task completion
-      if (options && options.taskGroupId) {
-        this.activeGroups.delete(options.taskGroupId);
+      if (item.options && item.options.taskGroupId) {
+        this.activeGroups.delete(item.options.taskGroupId);
       }
 
       this.ensureProcessing();
@@ -171,47 +200,39 @@ export class TaskProcessor {
     ) !== -1;
 }
 
-const DEFAULT_PROMISE_DEADLINE = 2147483647;
+const silenceUnhandledRejection = (promise: Promise<unknown>): void => {
+  void promise.catch(() => {});
+};
 
-const promiseWithDeadline = <T>(
-  executor: (
-    resolve: (value: T | PromiseLike<T>) => void,
-    reject: (reason?: unknown) => void,
-  ) => void,
-  options: { deadline?: number | undefined },
-) => {
-  return new Promise<T>((resolve, reject) => {
-    let taskStarted = false;
-    let timeoutId: NodeJS.Timeout | null = null;
-
-    const deadline = options.deadline ?? DEFAULT_PROMISE_DEADLINE;
-
-    timeoutId = setTimeout(() => {
-      if (!taskStarted) {
-        reject(
-          new Error('Task was not started within the maximum waiting time'),
-        );
-      }
-    }, deadline);
-    timeoutId.unref();
-
-    executor(
-      (value) => {
-        taskStarted = true;
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-        timeoutId = null;
-        resolve(value);
-      },
-      (reason) => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-        timeoutId = null;
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        reject(reason);
-      },
-    );
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const handle = setTimeout(resolve, ms);
+    handle.unref();
   });
+
+type QueueWaitTimer = { cancel: () => void };
+
+const createQueueWaitTimer = (
+  timeoutMs: number | undefined,
+  reject: (reason: unknown) => void,
+): QueueWaitTimer => {
+  if (timeoutMs === undefined) return { cancel: () => {} };
+
+  let timeoutId: NodeJS.Timeout | null = setTimeout(() => {
+    reject(
+      new TransientDatabaseError(
+        'Task was not started within the maximum waiting time',
+      ),
+    );
+  }, timeoutMs);
+  timeoutId.unref();
+
+  return {
+    cancel: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    },
+  };
 };

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
@@ -2,6 +2,8 @@ import assert from 'assert';
 import { beforeEach, describe, it } from 'vitest';
 import { TaskProcessor, type Task } from './taskProcessor';
 
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
 describe('TaskProcessor', () => {
   let taskProcessor: TaskProcessor;
 
@@ -405,6 +407,151 @@ describe('TaskProcessor', () => {
       'Ungrouped Task 1',
       'Group 1 - Task 2',
     ]);
+  });
+
+  describe('stop()', () => {
+    it('rejects queued tasks that never got the chance to run', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+
+      const active = processor.enqueue(async ({ ack }) => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        ack();
+      });
+
+      const queuedA = processor.enqueue(async ({ ack }) => {
+        ack();
+        return Promise.resolve();
+      });
+      const queuedB = processor.enqueue(async ({ ack }) => {
+        ack();
+        return Promise.resolve();
+      });
+
+      // Make sure the queued items have been scheduled (executor ran).
+      await flushMicrotasks();
+
+      await processor.stop({ force: true });
+
+      await assert.rejects(() => queuedA, /TaskProcessor has been stopped/);
+      await assert.rejects(() => queuedB, /TaskProcessor has been stopped/);
+      await active; // active task still completes
+    });
+
+    it('without force waits for active tasks but cancels queued ones', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+
+      let activeCompleted = false;
+      const active = processor.enqueue(async ({ ack }) => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        activeCompleted = true;
+        ack();
+      });
+
+      const queued = processor.enqueue(async ({ ack }) => {
+        ack();
+        return Promise.resolve();
+      });
+
+      await flushMicrotasks();
+
+      await processor.stop();
+
+      assert.strictEqual(
+        activeCompleted,
+        true,
+        'Active task should finish before stop returns',
+      );
+      await assert.rejects(() => queued, /TaskProcessor has been stopped/);
+      await active;
+    });
+  });
+
+  describe('maxTaskIdleTime', () => {
+    it('rejects a queued task that waits longer than the configured timeout', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+        maxTaskIdleTime: 30,
+      });
+
+      // Hold the only slot
+      const blocker = processor.enqueue(async ({ ack }) => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        ack();
+        return Promise.resolve();
+      });
+
+      const queued = processor.enqueue(async ({ ack }) => {
+        ack();
+        return Promise.resolve();
+      });
+
+      await assert.rejects(
+        () => queued,
+        /Task was not started within the maximum waiting time/,
+      );
+
+      await blocker;
+      await processor.stop({ force: true });
+    });
+
+    it('does not reject when a task gets to run within the timeout', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+        maxTaskIdleTime: 200,
+      });
+
+      const result = await processor.enqueue(({ ack }) => {
+        ack();
+        return Promise.resolve('ok');
+      });
+
+      assert.strictEqual(result, 'ok');
+      await processor.stop({ force: true });
+    });
+
+    it('without a configured timeout waits indefinitely (until stop)', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+
+      const blocker = processor.enqueue(async ({ ack }) => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        ack();
+      });
+
+      const queued = processor.enqueue(async ({ ack }) => {
+        ack();
+        return Promise.resolve();
+      });
+
+      // Wait longer than what any "sane" default would be, to assert there is
+      // no built-in fallback rejecting the queued task.
+      const racer = new Promise<'timeout-fired'>((resolve) =>
+        setTimeout(() => resolve('timeout-fired'), 200),
+      );
+      const winner = await Promise.race([
+        queued.then(() => 'queued-resolved' as const),
+        racer,
+      ]);
+
+      assert.strictEqual(
+        winner,
+        'queued-resolved',
+        'Queued task should resolve once the blocker finishes',
+      );
+
+      await blocker;
+      await processor.stop({ force: true });
+    });
   });
 
   it('should ensure blocked tasks from an active group are eventually processed', async () => {

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
@@ -472,6 +472,73 @@ describe('TaskProcessor', () => {
     });
   });
 
+  describe('AbortSignal cooperation', () => {
+    it("exposes a signal on the task's context", async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+
+      const seen = await processor.enqueue(({ ack, signal }) => {
+        ack();
+        return Promise.resolve(signal instanceof AbortSignal);
+      });
+
+      assert.strictEqual(seen, true);
+      await processor.stop({ force: true });
+    });
+
+    it('aborts the signal of in-flight tasks when stop() is called', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+
+      const sawAbort = Promise.withResolvers<boolean>();
+
+      const active = processor.enqueue(async ({ ack, signal }) => {
+        signal.addEventListener('abort', () => sawAbort.resolve(true));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        ack();
+      });
+
+      await flushMicrotasks();
+      await processor.stop({ force: true });
+
+      const aborted = await sawAbort.promise;
+      assert.strictEqual(aborted, true);
+      await active;
+    });
+
+    it('aborts before draining so cooperative tasks can wrap up', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+
+      let exitedCleanly = false;
+
+      const active = processor.enqueue(async ({ ack, signal }) => {
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        exitedCleanly = true;
+        ack();
+      });
+
+      await flushMicrotasks();
+      await processor.stop();
+
+      assert.strictEqual(
+        exitedCleanly,
+        true,
+        'cooperative task should be allowed to finish after receiving abort',
+      );
+      await active;
+    });
+  });
+
   describe('maxTaskIdleTime', () => {
     it('rejects a queued task that waits longer than the configured timeout', async () => {
       const processor = new TaskProcessor({

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
@@ -655,4 +655,238 @@ describe('TaskProcessor', () => {
       'Group 1 - Task 2',
     ]);
   });
+
+  describe('per-task signal / timeout', () => {
+    it('fires TaskContext.signal when a per-task signal aborts (parent stays open)', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+      const perTask = new AbortController();
+      const sawAbort = Promise.withResolvers<boolean>();
+
+      const task = processor.enqueue(
+        async ({ ack, signal }) => {
+          signal.addEventListener('abort', () => sawAbort.resolve(true));
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+          ack();
+        },
+        { signal: perTask.signal },
+      );
+
+      await flushMicrotasks();
+      perTask.abort(new Error('per-task'));
+
+      assert.strictEqual(await sawAbort.promise, true);
+      await task;
+      await processor.stop({ force: true });
+    });
+
+    it('fires TaskContext.signal after timeoutMs elapses', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+
+      const task = processor.enqueue(
+        async ({ ack, signal }) => {
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+          ack();
+          return signal.reason instanceof Error ? signal.reason.message : null;
+        },
+        { timeoutMs: 20 },
+      );
+
+      const reasonMsg = await task;
+      assert.match(String(reasonMsg), /timed out/i);
+      await processor.stop({ force: true });
+    });
+
+    it('fires TaskContext.signal as soon as either the processor stops OR per-task source aborts (whichever is first)', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+      const perTask = new AbortController();
+
+      const task = processor.enqueue(
+        async ({ ack, signal }) => {
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+          ack();
+          return signal.reason instanceof Error
+            ? signal.reason.message
+            : 'no-reason';
+        },
+        { signal: perTask.signal },
+      );
+
+      await flushMicrotasks();
+      perTask.abort(new Error('per-task fired first'));
+
+      const reason = await task;
+      assert.strictEqual(reason, 'per-task fired first');
+      await processor.stop({ force: true });
+    });
+
+    it('fails fast on enqueue when per-task signal is already aborted (does not invoke task)', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+      const perTask = new AbortController();
+      const preReason = new Error('pre-aborted');
+      perTask.abort(preReason);
+
+      let taskRan = false;
+      await assert.rejects(
+        () =>
+          processor.enqueue(
+            ({ ack }) => {
+              taskRan = true;
+              ack();
+              return Promise.resolve();
+            },
+            { signal: perTask.signal },
+          ),
+        (err) => err === preReason,
+      );
+      assert.strictEqual(taskRan, false);
+      await processor.stop({ force: true });
+    });
+
+    it('parent abort (constructor signal) fires TaskContext.signal of in-flight tasks', async () => {
+      const parent = new AbortController();
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+        signal: parent.signal,
+      });
+
+      const sawAbort = Promise.withResolvers<unknown>();
+
+      const task = processor.enqueue(async ({ ack, signal }) => {
+        signal.addEventListener('abort', () => sawAbort.resolve(signal.reason));
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve();
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        ack();
+      });
+
+      await flushMicrotasks();
+      const parentReason = new Error('parent fired');
+      parent.abort(parentReason);
+
+      assert.strictEqual(await sawAbort.promise, parentReason);
+      await task;
+      await processor.stop({ force: true });
+    });
+
+    it('fails fast on enqueue when the constructor signal is already aborted', async () => {
+      const parent = new AbortController();
+      const preReason = new Error('parent pre-aborted');
+      parent.abort(preReason);
+
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+        signal: parent.signal,
+      });
+
+      let taskRan = false;
+      await assert.rejects(
+        () =>
+          processor.enqueue(({ ack }) => {
+            taskRan = true;
+            ack();
+            return Promise.resolve();
+          }),
+        (err) => err === preReason,
+      );
+      assert.strictEqual(taskRan, false);
+      await processor.stop({ force: true });
+    });
+
+    it('parent abort wins over timeout when parent fires first', async () => {
+      const parent = new AbortController();
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+        signal: parent.signal,
+      });
+
+      const task = processor.enqueue<unknown>(
+        async ({ ack, signal }) => {
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+          ack();
+          return signal.reason as unknown;
+        },
+        { timeoutMs: 5_000 },
+      );
+
+      await flushMicrotasks();
+      const parentReason = new Error('parent first');
+      parent.abort(parentReason);
+
+      assert.strictEqual(await task, parentReason);
+      await processor.stop({ force: true });
+    });
+
+    it('per-call signal wins over timeout when it fires first', async () => {
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+      });
+      const perTask = new AbortController();
+
+      const task = processor.enqueue<unknown>(
+        async ({ ack, signal }) => {
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+          ack();
+          return signal.reason as unknown;
+        },
+        { signal: perTask.signal, timeoutMs: 5_000 },
+      );
+
+      await flushMicrotasks();
+      const perCallReason = new Error('per-call first');
+      perTask.abort(perCallReason);
+
+      assert.strictEqual(await task, perCallReason);
+      await processor.stop({ force: true });
+    });
+
+    it('lifecycle signal does NOT abort tasks finishing before parent fires', async () => {
+      const parent = new AbortController();
+      const processor = new TaskProcessor({
+        maxActiveTasks: 1,
+        maxQueueSize: 10,
+        signal: parent.signal,
+      });
+
+      const finished = await processor.enqueue(({ ack, signal }) => {
+        ack();
+        return Promise.resolve(signal.aborted);
+      });
+
+      assert.strictEqual(finished, false);
+      parent.abort(new Error('after task already done'));
+      await processor.stop({ force: true });
+    });
+  });
 });

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.int.spec.ts
@@ -2,10 +2,11 @@ import {
   PostgreSqlContainer,
   type StartedPostgreSqlContainer,
 } from '@testcontainers/postgresql';
+import assert from 'node:assert';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import pg from 'pg';
 import { pgPool } from '.';
-import { SQL } from '../../../../core';
+import { InvalidOperationError, SQL } from '../../../../core';
 import { pgConnection } from './connection';
 import { endPgPool, getPgPool } from './pool';
 
@@ -372,6 +373,180 @@ describe('pg', () => {
         );
 
         await pool.execute.command(SQL`DROP TABLE test_iso_readonly`);
+      } finally {
+        await pool.close();
+      }
+    });
+
+    it('respects allowNestedTransactions from pool options', async () => {
+      const pool = pgPool({
+        connectionString,
+        transactionOptions: { allowNestedTransactions: true },
+      });
+
+      try {
+        await pool.execute.command(
+          SQL`CREATE TABLE IF NOT EXISTS test_nested_tx (id SERIAL PRIMARY KEY, value TEXT)`,
+        );
+        await pool.execute.command(SQL`TRUNCATE test_nested_tx`);
+
+        await pool.withTransaction(async (outerTx) => {
+          await outerTx.execute.command(
+            SQL`INSERT INTO test_nested_tx (value) VALUES ('outer')`,
+          );
+
+          await pool.withTransaction(async (innerTx) => {
+            await innerTx.execute.command(
+              SQL`INSERT INTO test_nested_tx (value) VALUES ('inner')`,
+            );
+          });
+        });
+
+        const result = await pool.execute.query<{ count: string }>(
+          SQL`SELECT COUNT(*)::text as count FROM test_nested_tx`,
+        );
+        assert.strictEqual(
+          result.rows[0]?.count,
+          '2',
+          'Both outer and inner rows should be persisted',
+        );
+
+        await pool.execute.command(SQL`DROP TABLE test_nested_tx`);
+      } finally {
+        await pool.close();
+      }
+    });
+
+    it('throws actionable InvalidOperationError on nested withTransaction when allowNestedTransactions is false', async () => {
+      const pool = pgPool({ connectionString });
+
+      try {
+        await pool.execute.command(
+          SQL`CREATE TABLE IF NOT EXISTS test_nested_tx_fail (id SERIAL PRIMARY KEY, value TEXT)`,
+        );
+        await pool.execute.command(SQL`TRUNCATE test_nested_tx_fail`);
+
+        await assert.rejects(
+          () =>
+            pool.withTransaction(async (outerTx) => {
+              await outerTx.execute.command(
+                SQL`INSERT INTO test_nested_tx_fail (value) VALUES ('outer')`,
+              );
+              await pool.withTransaction(async (innerTx) => {
+                await innerTx.execute.command(
+                  SQL`INSERT INTO test_nested_tx_fail (value) VALUES ('inner')`,
+                );
+              });
+            }),
+          (err: unknown) => {
+            assert.ok(
+              err instanceof InvalidOperationError,
+              `Expected InvalidOperationError, got ${String(err)}`,
+            );
+            assert.ok(
+              err.message.includes('allowNestedTransactions'),
+              `Error message should mention allowNestedTransactions, got: ${err.message}`,
+            );
+            return true;
+          },
+        );
+
+        await pool.execute.command(SQL`DROP TABLE test_nested_tx_fail`);
+      } finally {
+        await pool.close();
+      }
+    });
+
+    it('nested rollback rolls back outer when allowNestedTransactions is true (no savepoints)', async () => {
+      const pool = pgPool({
+        connectionString,
+        transactionOptions: { allowNestedTransactions: true },
+      });
+
+      try {
+        await pool.execute.command(
+          SQL`CREATE TABLE IF NOT EXISTS test_nested_rollback (id SERIAL PRIMARY KEY, value TEXT)`,
+        );
+        await pool.execute.command(SQL`TRUNCATE test_nested_rollback`);
+
+        await assert.rejects(
+          () =>
+            pool.withTransaction(async (outerTx) => {
+              await outerTx.execute.command(
+                SQL`INSERT INTO test_nested_rollback (value) VALUES ('outer')`,
+              );
+              await pool.withTransaction(async (innerTx) => {
+                await innerTx.execute.command(
+                  SQL`INSERT INTO test_nested_rollback (value) VALUES ('inner')`,
+                );
+                throw new Error('inner failure');
+              });
+            }),
+          /inner failure/,
+        );
+
+        const result = await pool.execute.query<{ count: string }>(
+          SQL`SELECT COUNT(*)::text as count FROM test_nested_rollback`,
+        );
+        assert.strictEqual(
+          result.rows[0]?.count,
+          '0',
+          'Nested failure must roll back outer transaction (no savepoint isolation)',
+        );
+
+        await pool.execute.command(SQL`DROP TABLE test_nested_rollback`);
+      } finally {
+        await pool.close();
+      }
+    });
+
+    it('useSavepoints isolates nested rollback so outer can still commit', async () => {
+      const pool = pgPool({
+        connectionString,
+        transactionOptions: {
+          allowNestedTransactions: true,
+          useSavepoints: true,
+        },
+      });
+
+      try {
+        await pool.execute.command(
+          SQL`CREATE TABLE IF NOT EXISTS test_savepoint (id SERIAL PRIMARY KEY, value TEXT)`,
+        );
+        await pool.execute.command(SQL`TRUNCATE test_savepoint`);
+
+        await pool.withTransaction(async (outerTx) => {
+          await outerTx.execute.command(
+            SQL`INSERT INTO test_savepoint (value) VALUES ('outer')`,
+          );
+
+          try {
+            await pool.withTransaction(async (innerTx) => {
+              await innerTx.execute.command(
+                SQL`INSERT INTO test_savepoint (value) VALUES ('inner')`,
+              );
+              throw new Error('inner failure');
+            });
+          } catch (err) {
+            assert.ok((err as Error).message.includes('inner failure'));
+          }
+
+          await outerTx.execute.command(
+            SQL`INSERT INTO test_savepoint (value) VALUES ('after-rollback')`,
+          );
+        });
+
+        const result = await pool.execute.query<{
+          value: string;
+        }>(SQL`SELECT value FROM test_savepoint ORDER BY id`);
+
+        assert.deepStrictEqual(
+          result.rows.map((r) => r.value),
+          ['outer', 'after-rollback'],
+          'Inner savepoint must roll back without taking outer with it',
+        );
+
+        await pool.execute.command(SQL`DROP TABLE test_savepoint`);
       } finally {
         await pool.close();
       }

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
@@ -49,23 +49,31 @@ export type PgClientOptions = {
 
 export type PgClientConnectionOptions = PgClientOptions & {
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions;
 };
 
 export type PgPoolClientConnectionOptions = PgPoolClientOptions & {
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions;
 };
 
 export const pgClientConnection = (
   options: PgClientConnectionOptions,
 ): PgClientConnection => {
-  const { connect, close } = options;
+  const { connect, close, transactionOptions } = options;
 
   return createConnection({
     driverType: PgDriverType,
     connect,
     close,
-    initTransaction: (connection) =>
-      pgTransaction(connection, options.serializer),
+    initTransaction: (connection) => {
+      const txFactory = pgTransaction(connection, options.serializer);
+      return (client, perCallOptions) =>
+        txFactory(client, {
+          ...(transactionOptions ?? {}),
+          ...(perCallOptions ?? ({} as Parameters<typeof txFactory>[1])),
+        } as Parameters<typeof txFactory>[1]);
+    },
     executor: pgSQLExecutor,
     serializer: options.serializer,
   });
@@ -74,14 +82,20 @@ export const pgClientConnection = (
 export const pgPoolClientConnection = (
   options: PgPoolClientConnectionOptions,
 ): PgPoolClientConnection => {
-  const { connect, close } = options;
+  const { connect, close, transactionOptions } = options;
 
   return createConnection({
     driverType: PgDriverType,
     connect,
     close,
-    initTransaction: (connection) =>
-      pgTransaction(connection, options.serializer),
+    initTransaction: (connection) => {
+      const txFactory = pgTransaction(connection, options.serializer);
+      return (client, perCallOptions) =>
+        txFactory(client, {
+          ...(transactionOptions ?? {}),
+          ...(perCallOptions ?? ({} as Parameters<typeof txFactory>[1])),
+        } as Parameters<typeof txFactory>[1]);
+    },
     executor: pgSQLExecutor,
     serializer: options.serializer,
   });

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
@@ -15,6 +15,7 @@ import {
   type PgClientConnection,
   type PgPoolClientConnection,
 } from './connection';
+import type { PgTransactionOptions } from './transaction';
 
 export type PgNativePool = ConnectionPool<PgPoolClientConnection>;
 
@@ -33,8 +34,9 @@ export const pgNativePool = (options: {
   connectionString: string;
   database?: string | undefined;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgNativePool => {
-  const { connectionString, database } = options;
+  const { connectionString, database, transactionOptions } = options;
   const pool = getPgPool({ connectionString, database });
 
   const getConnection = () =>
@@ -52,6 +54,7 @@ export const pgNativePool = (options: {
       },
       close: (client) => Promise.resolve(client.release()),
       serializer: options.serializer,
+      ...(transactionOptions ? { transactionOptions } : {}),
     });
 
   const open = () => Promise.resolve(getConnection());
@@ -68,8 +71,9 @@ export const pgNativePool = (options: {
 export const pgAmbientNativePool = (options: {
   pool: pg.Pool;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgNativePool => {
-  const { pool } = options;
+  const { pool, transactionOptions } = options;
 
   return createConnectionPool({
     driverType: PgDriverType,
@@ -79,6 +83,7 @@ export const pgAmbientNativePool = (options: {
         connect: () => pool.connect(),
         close: (client) => Promise.resolve(client.release()),
         serializer: options.serializer,
+        ...(transactionOptions ? { transactionOptions } : {}),
       }),
   });
 };
@@ -98,8 +103,9 @@ export const pgClientPool = (options: {
   connectionString: string;
   database?: string | undefined;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgAmbientClientPool => {
-  const { connectionString, database } = options;
+  const { connectionString, database, transactionOptions } = options;
 
   return createConnectionPool({
     driverType: PgDriverType,
@@ -121,6 +127,7 @@ export const pgClientPool = (options: {
         connect,
         close: (client) => client.end(),
         serializer: options.serializer,
+        ...(transactionOptions ? { transactionOptions } : {}),
       });
     },
   });
@@ -129,8 +136,9 @@ export const pgClientPool = (options: {
 export const pgAmbientClientPool = (options: {
   client: pg.Client;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgAmbientClientPool => {
-  const { client } = options;
+  const { client, transactionOptions } = options;
 
   const getConnection = () => {
     const connect = () => Promise.resolve(client);
@@ -140,6 +148,7 @@ export const pgAmbientClientPool = (options: {
       connect,
       close: () => Promise.resolve(),
       serializer: options.serializer,
+      ...(transactionOptions ? { transactionOptions } : {}),
     });
   };
 
@@ -201,19 +210,33 @@ export type PgPoolNotPooledOptions =
     };
 
 export type PgPoolOptions = (PgPoolPooledOptions | PgPoolNotPooledOptions) &
-  JSONSerializationOptions;
+  JSONSerializationOptions & {
+    transactionOptions?: PgTransactionOptions;
+  };
 
-export function pgPool(options: PgPoolPooledOptions): PgNativePool;
-export function pgPool(options: PgPoolNotPooledOptions): PgAmbientClientPool;
+export function pgPool(
+  options: PgPoolPooledOptions & { transactionOptions?: PgTransactionOptions },
+): PgNativePool;
+export function pgPool(
+  options: PgPoolNotPooledOptions & {
+    transactionOptions?: PgTransactionOptions;
+  },
+): PgAmbientClientPool;
 export function pgPool(
   options: PgPoolOptions,
 ): PgNativePool | PgAmbientClientPool | PgAmbientConnectionPool {
-  const { connectionString, database } = options;
+  const { connectionString, database, transactionOptions } = options;
 
   const serializer = options.serialization?.serializer ?? JSONSerializer;
 
+  const txOpts = transactionOptions ? { transactionOptions } : {};
+
   if ('client' in options && options.client)
-    return pgAmbientClientPool({ client: options.client, serializer });
+    return pgAmbientClientPool({
+      client: options.client,
+      serializer,
+      ...txOpts,
+    });
 
   if ('connection' in options && options.connection)
     return pgAmbientConnectionPool({
@@ -221,15 +244,25 @@ export function pgPool(
     });
 
   if ('pooled' in options && options.pooled === false)
-    return pgClientPool({ connectionString, database, serializer });
+    return pgClientPool({
+      connectionString,
+      database,
+      serializer,
+      ...txOpts,
+    });
 
   if ('pool' in options && options.pool)
-    return pgAmbientNativePool({ pool: options.pool, serializer });
+    return pgAmbientNativePool({
+      pool: options.pool,
+      serializer,
+      ...txOpts,
+    });
 
   return pgNativePool({
     connectionString,
     database,
     serializer,
+    ...txOpts,
   });
 }
 

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
@@ -1,9 +1,10 @@
-import type { JSONSerializer } from '../../../../core';
 import {
+  databaseTransaction,
   sqlExecutor,
   type AnyConnection,
   type DatabaseTransaction,
   type DatabaseTransactionOptions,
+  type JSONSerializer,
 } from '../../../../core';
 import { pgSQLExecutor } from '../execute';
 import {
@@ -25,6 +26,7 @@ export type PgIsolationLevel =
 
 export type PgTransactionOptions = DatabaseTransactionOptions & {
   isolationLevel?: PgIsolationLevel;
+  useSavepoints?: boolean;
 };
 
 export const pgTransaction =
@@ -37,39 +39,67 @@ export const pgTransaction =
     options?: {
       close: (client: DbClient, error?: unknown) => Promise<void>;
     } & PgTransactionOptions,
-  ): DatabaseTransaction<ConnectionType> => ({
-    connection: connection(),
-    driverType: PgDriverType,
-    begin: async () => {
-      const client = await getClient;
-      const parts = ['BEGIN'];
-      if (options?.isolationLevel) {
-        parts.push(`ISOLATION LEVEL ${options.isolationLevel}`);
-      }
-      if (options?.readonly) {
-        parts.push('READ ONLY');
-      }
-      await client.query(parts.join(' '));
-    },
-    commit: async () => {
-      const client = await getClient;
+  ): DatabaseTransaction<ConnectionType> => {
+    const allowNestedTransactions = options?.allowNestedTransactions ?? false;
+    const useSavepoints = options?.useSavepoints ?? false;
 
-      try {
-        await client.query('COMMIT');
-      } finally {
-        if (options?.close) await options?.close(client);
-      }
-    },
-    rollback: async (error?: unknown) => {
-      const client = await getClient;
-      try {
-        await client.query('ROLLBACK');
-      } finally {
-        if (options?.close) await options?.close(client, error);
-      }
-    },
-    execute: sqlExecutor(pgSQLExecutor({ serializer }), {
-      connect: () => getClient,
-    }),
-    _transactionOptions: options ?? {},
-  });
+    const tx = databaseTransaction(
+      {
+        begin: async () => {
+          const client = await getClient;
+          const parts = ['BEGIN'];
+          if (options?.isolationLevel) {
+            parts.push(`ISOLATION LEVEL ${options.isolationLevel}`);
+          }
+          if (options?.readonly) {
+            parts.push('READ ONLY');
+          }
+          await client.query(parts.join(' '));
+        },
+        commit: async () => {
+          const client = await getClient;
+          try {
+            await client.query('COMMIT');
+          } finally {
+            if (options?.close) await options.close(client);
+          }
+        },
+        rollback: async (error?: unknown) => {
+          const client = await getClient;
+          try {
+            await client.query('ROLLBACK');
+          } finally {
+            if (options?.close) await options.close(client, error);
+          }
+        },
+        savepoint: async (level) => {
+          const client = await getClient;
+          await client.query(`SAVEPOINT pg_savepoint_${level}`);
+        },
+        releaseSavepoint: async (level) => {
+          const client = await getClient;
+          await client.query(`RELEASE SAVEPOINT pg_savepoint_${level}`);
+        },
+        rollbackToSavepoint: async (level) => {
+          const client = await getClient;
+          await client.query(`ROLLBACK TO SAVEPOINT pg_savepoint_${level}`);
+        },
+      },
+      { allowNestedTransactions, useSavepoints },
+    );
+
+    return {
+      connection: connection(),
+      driverType: PgDriverType,
+      begin: tx.begin,
+      commit: tx.commit,
+      rollback: tx.rollback,
+      execute: sqlExecutor(pgSQLExecutor({ serializer }), {
+        connect: () => getClient,
+      }),
+      _transactionOptions: {
+        ...(options ?? {}),
+        allowNestedTransactions,
+      },
+    };
+  };

--- a/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
@@ -163,36 +163,6 @@ export type SQLiteConnectionFactory<
   ConnectionOptions extends SQLiteConnectionOptions = SQLiteConnectionOptions,
 > = (options: ConnectionOptions) => SQLiteConnectionType;
 
-export type TransactionNestingCounter = {
-  increment: () => void;
-  decrement: () => void;
-  reset: () => void;
-  level: number;
-};
-
-export const transactionNestingCounter = (): TransactionNestingCounter => {
-  let transactionLevel = 0;
-
-  return {
-    reset: () => {
-      transactionLevel = 0;
-    },
-    increment: () => {
-      transactionLevel++;
-    },
-    decrement: () => {
-      transactionLevel--;
-
-      if (transactionLevel < 0) {
-        throw new Error('Transaction level is out of bounds');
-      }
-    },
-    get level() {
-      return transactionLevel;
-    },
-  };
-};
-
 export type SqliteAmbientClientConnectionOptions<
   SQLiteConnectionType extends AnySQLiteClientConnection =
     AnySQLiteClientConnection,

--- a/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
@@ -3,7 +3,7 @@ import type {
   JSONSerializer,
 } from '../../../../core';
 import {
-  InvalidOperationError,
+  databaseTransaction,
   SQL,
   sqlExecutor,
   type DatabaseTransaction,
@@ -11,10 +11,9 @@ import {
   type InferDbClientFromConnection,
 } from '../../../../core';
 import { sqliteSQLExecutor } from '../../core/execute';
-import {
-  transactionNestingCounter,
-  type AnySQLiteConnection,
-  type SQLiteClientOrPoolClient,
+import type {
+  AnySQLiteConnection,
+  SQLiteClientOrPoolClient,
 } from '../connections';
 
 export type SQLiteTransaction<
@@ -47,84 +46,62 @@ export const sqliteTransaction =
       ) => Promise<void>;
     } & SQLiteTransactionOptions,
   ): InferTransactionFromConnection<ConnectionType> => {
-    const transactionCounter = transactionNestingCounter();
     allowNestedTransactions =
       options?.allowNestedTransactions ?? allowNestedTransactions;
+    const useSavepoints = options?.useSavepoints ?? false;
 
-    let hasBegun = false;
+    const tx = databaseTransaction(
+      {
+        begin: async () => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          const mode = options?.mode ?? defaultTransactionMode ?? 'IMMEDIATE';
+          await client.command(SQL`BEGIN ${SQL.plain(mode)} TRANSACTION`);
+        },
+        commit: async () => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          try {
+            await client.command(SQL`COMMIT`);
+          } finally {
+            if (options?.close)
+              await options.close(
+                client as InferDbClientFromConnection<ConnectionType>,
+              );
+          }
+        },
+        rollback: async (error?: unknown) => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          try {
+            await client.command(SQL`ROLLBACK`);
+          } finally {
+            if (options?.close)
+              await options.close(
+                client as InferDbClientFromConnection<ConnectionType>,
+                error,
+              );
+          }
+        },
+        savepoint: async (level) => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          await client.command(
+            SQL`SAVEPOINT transaction${SQL.plain(level.toString())}`,
+          );
+        },
+        releaseSavepoint: async (level) => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          await client.command(
+            SQL`RELEASE transaction${SQL.plain(level.toString())}`,
+          );
+        },
+      },
+      { allowNestedTransactions, useSavepoints },
+    );
 
     const transaction: DatabaseTransaction<ConnectionType> = {
       connection: connection(),
       driverType,
-      begin: async function () {
-        const client = (await getClient) as SQLiteClientOrPoolClient;
-
-        if (allowNestedTransactions) {
-          if (transactionCounter.level >= 1) {
-            transactionCounter.increment();
-            if (options?.useSavepoints) {
-              await client.command(
-                SQL`SAVEPOINT transaction${SQL.plain(transactionCounter.level.toString())}`,
-              );
-            }
-            return;
-          }
-
-          transactionCounter.increment();
-        } else if (hasBegun) {
-          throw new InvalidOperationError(
-            'Cannot start a nested transaction: allowNestedTransactions is false. ' +
-              'Set transactionOptions: { allowNestedTransactions: true } on your pool or connection.',
-          );
-        }
-
-        hasBegun = true;
-        const mode = options?.mode ?? defaultTransactionMode ?? 'IMMEDIATE';
-        await client.command(SQL`BEGIN ${SQL.plain(mode)} TRANSACTION`);
-      },
-      commit: async function () {
-        const client = (await getClient) as SQLiteClientOrPoolClient;
-
-        if (allowNestedTransactions && transactionCounter.level > 1) {
-          if (options?.useSavepoints) {
-            await client.command(
-              SQL`RELEASE transaction${SQL.plain(transactionCounter.level.toString())}`,
-            );
-          }
-          transactionCounter.decrement();
-          return;
-        }
-
-        try {
-          if (allowNestedTransactions) transactionCounter.reset();
-          hasBegun = false;
-          await client.command(SQL`COMMIT`);
-        } finally {
-          if (options?.close)
-            await options?.close(
-              client as InferDbClientFromConnection<ConnectionType>,
-            );
-        }
-      },
-      rollback: async function (error?: unknown) {
-        const client = (await getClient) as SQLiteClientOrPoolClient;
-
-        if (allowNestedTransactions && transactionCounter.level > 1) {
-          transactionCounter.decrement();
-          return;
-        }
-
-        try {
-          hasBegun = false;
-          await client.command(SQL`ROLLBACK`);
-        } finally {
-          if (options?.close)
-            await options?.close(
-              client as InferDbClientFromConnection<ConnectionType>,
-              error,
-            );
-        }
-      },
+      begin: tx.begin,
+      commit: tx.commit,
+      rollback: tx.rollback,
       execute: sqlExecutor(sqliteSQLExecutor(driverType, serializer), {
         connect: () => getClient,
       }),

--- a/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
@@ -1,10 +1,10 @@
 import type { JSONSerializer } from '../../../../core';
 import {
   sqlExecutor,
+  transactionNestingCounter,
   type DatabaseTransaction,
   type DatabaseTransactionOptions,
 } from '../../../../core';
-import { transactionNestingCounter } from '../../core';
 import {
   D1DriverType,
   type D1Client,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -63,10 +63,13 @@ export const sqlite3Pool = (
     ('client' in options && Boolean(options.client)) ||
     options.singleton === true;
 
+  const lifecycleOptions = extractLifecycleOptions(options);
+
   if (isSingleton) {
     return sqlite3SingletonPool<SQLite3Connection>({
       driverType: SQLite3DriverType,
       getConnection: () => sqliteConnectionFactory(options),
+      ...lifecycleOptions,
     });
   }
 
@@ -79,7 +82,25 @@ export const sqlite3Pool = (
     sqliteConnectionFactory,
     connectionOptions: options,
     ...(readerPoolSize !== undefined ? { readerPoolSize } : {}),
+    ...lifecycleOptions,
   });
+};
+
+const extractLifecycleOptions = (
+  options: SQLite3DumboOptions,
+): { maxTaskIdleTime?: number; closeDeadline?: number } => {
+  const lifecycle = options as {
+    maxTaskIdleTime?: number;
+    closeDeadline?: number;
+  };
+  return {
+    ...(lifecycle.maxTaskIdleTime !== undefined
+      ? { maxTaskIdleTime: lifecycle.maxTaskIdleTime }
+      : {}),
+    ...(lifecycle.closeDeadline !== undefined
+      ? { closeDeadline: lifecycle.closeDeadline }
+      : {}),
+  };
 };
 
 const tryParseConnectionString = (connectionString: string) => {

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
@@ -20,6 +20,8 @@ export type SQLiteDualPoolOptions<
   pooled?: true;
   connection?: never;
   readerPoolSize?: number;
+  maxTaskIdleTime?: number;
+  closeDeadline?: number;
   sqliteConnectionFactory: SQLiteConnectionFactory<
     SQLiteConnectionType,
     ConnectionOptions
@@ -90,12 +92,21 @@ export const sqliteDualConnectionPool = <
   const writerPool = sqlite3SingletonPool<SQLiteConnectionType>({
     driverType: options.driverType,
     getConnection: () => wrappedConnectionFactory(false, connectionOptions),
+    ...(options.maxTaskIdleTime !== undefined
+      ? { maxTaskIdleTime: options.maxTaskIdleTime }
+      : {}),
+    ...(options.closeDeadline !== undefined
+      ? { closeDeadline: options.closeDeadline }
+      : {}),
   });
 
   const readerPool = createBoundedConnectionPool({
     driverType: options.driverType,
     getConnection: () => wrappedConnectionFactory(true, connectionOptions),
     maxConnections: readerPoolSize,
+    ...(options.closeDeadline !== undefined
+      ? { closeDeadline: options.closeDeadline }
+      : {}),
   });
 
   return {

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
@@ -1,6 +1,6 @@
 import { cpus } from 'os';
 import { createBoundedConnectionPool } from '../../../../core';
-import { guardInitializedOnce } from '../../../../core/taskProcessing';
+import { Guard } from '../../../../core/taskProcessing';
 import type {
   AnySQLiteConnection,
   SQLiteConnectionFactory,
@@ -40,7 +40,7 @@ export const sqliteDualConnectionPool = <
 
   let databaseInitPromise: Promise<void> | null = null;
 
-  const guardSingleConnection = guardInitializedOnce(async () => {
+  const guardSingleConnection = Guard.initializedOnce(async () => {
     if (databaseInitPromise !== null) {
       return databaseInitPromise;
     }

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
@@ -2,9 +2,13 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   createSingletonConnectionPool,
   type ConnectionPool,
+  type PoolCloseOptions,
 } from '../../../../core';
 import { TaskProcessor } from '../../../../core/taskProcessing';
 import type { AnySQLiteConnection } from '../../core';
+
+export const DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS = 30_000;
+export const DEFAULT_SQLITE_CLOSE_DEADLINE_MS = 30_000;
 
 export type SQLite3SingletonPoolOptions<
   SQLiteConnectionType extends AnySQLiteConnection,
@@ -13,6 +17,8 @@ export type SQLite3SingletonPoolOptions<
   getConnection: () => SQLiteConnectionType | Promise<SQLiteConnectionType>;
   closeConnection?: (connection: SQLiteConnectionType) => void | Promise<void>;
   maxQueueSize?: number;
+  maxTaskIdleTime?: number;
+  closeDeadline?: number;
 };
 
 // Creates a singleton-connection pool whose callers serialise through a
@@ -25,9 +31,15 @@ export const sqlite3SingletonPool = <
 >(
   options: SQLite3SingletonPoolOptions<SQLiteConnectionType>,
 ): ConnectionPool<SQLiteConnectionType> => {
+  const maxTaskIdleTime =
+    options.maxTaskIdleTime ?? DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS;
+  const closeDeadline =
+    options.closeDeadline ?? DEFAULT_SQLITE_CLOSE_DEADLINE_MS;
+
   const inner = createSingletonConnectionPool<SQLiteConnectionType>({
     driverType: options.driverType,
     getConnection: options.getConnection,
+    closeDeadline,
     ...(options.closeConnection
       ? { closeConnection: options.closeConnection }
       : {}),
@@ -36,6 +48,7 @@ export const sqlite3SingletonPool = <
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: 1,
     maxQueueSize: options.maxQueueSize ?? 1000,
+    maxTaskIdleTime,
   });
   const insideWriterTask = new AsyncLocalStorage<true>();
 
@@ -72,9 +85,12 @@ export const sqlite3SingletonPool = <
       batchCommand: (sqls, commandOptions) =>
         enqueue(() => inner.execute.batchCommand(sqls, commandOptions)),
     },
-    close: async () => {
-      await taskProcessor.stop();
-      await inner.close();
+    close: async (closeOptions?: PoolCloseOptions) => {
+      await taskProcessor.stop({
+        ...(closeOptions?.force ? { force: true } : {}),
+        closeDeadline: closeOptions?.closeDeadline ?? closeDeadline,
+      });
+      await inner.close(closeOptions);
     },
   };
 };


### PR DESCRIPTION
`TaskProcessor.stop()` cleared its queue with `this.queue.length = 0` without rejecting the captured promises. 

Anyone waiting on a queued task hung for ~24 days until the fallback deadline fired. Triggered in Emmett when one consumer's `pool.close()` orphaned the other multiple consumers' pending writes.