### PR TITLE
Fixed collection document matching when using upcasting

### DIFF
--- a/src/packages/pongo/src/core/collection/handle.ts
+++ b/src/packages/pongo/src/core/collection/handle.ts
@@ -76,12 +76,12 @@ export function DocumentCommandHandler<T extends PongoDocument>(
 ): {
   (
     id: string | DocumentCommandHandlerInput,
-    handler: DocumentHandler<T>,
+    handler: DocumentHandler<T> | DocumentHandler<T>[],
     options?: HandleOptions,
   ): Promise<PongoHandleResult<T>>;
   (
     ids: string[] | DocumentCommandHandlerInput[],
-    handler: DocumentHandler<T>,
+    handler: DocumentHandler<T> | DocumentHandler<T>[],
     options?: HandleOptions & BatchHandleOptions,
   ): Promise<PongoHandleResult<T>[]>;
 } {
@@ -91,13 +91,13 @@ export function DocumentCommandHandler<T extends PongoDocument>(
       | string[]
       | DocumentCommandHandlerInput
       | DocumentCommandHandlerInput[],
-    handler: DocumentHandler<T>,
+    handle: DocumentHandler<T> | DocumentHandler<T>[],
     options?: HandleOptions | BatchHandleOptions,
   ): Promise<PongoHandleResult<T> | PongoHandleResult<T>[]> => {
     const changes = await handleDocuments(
       deps.storage,
       normalizeInput(input),
-      handler,
+      handle,
       options,
     );
 
@@ -113,7 +113,7 @@ export function DocumentCommandHandler<T extends PongoDocument>(
 async function handleDocuments<T extends PongoDocument>(
   storage: DocumentCommandHandlerOptions<T>['storage'],
   inputs: DocumentCommandHandlerInput[],
-  handler: DocumentHandler<T>,
+  handle: DocumentHandler<T> | DocumentHandler<T>[],
   options?: BatchHandleOptions,
 ): Promise<{ change: DocumentChange<T>; result: DocumentHandlerResult }[]> {
   if (inputs.length === 0) return [];
@@ -135,7 +135,7 @@ async function handleDocuments<T extends PongoDocument>(
           ...item,
           existing: docs[i] ?? null,
         },
-        handler,
+        handle,
       ),
     { parallel },
   );
@@ -149,14 +149,20 @@ async function handleDocument<T extends PongoDocument>(
     expectedVersion?: ExpectedDocumentVersion | undefined;
     existing: WithIdAndVersion<T> | null;
   },
-  handler: DocumentHandler<T>,
+  handle: DocumentHandler<T> | DocumentHandler<T>[],
 ): Promise<DocumentChange<T>> {
   const { _id: id, existing, expectedVersion } = item;
 
   if (hasVersionMismatch(existing, expectedVersion))
     return { type: 'noop', existing, versionMismatch: true };
 
-  const result = await handler(existing ? ({ ...existing } as T) : null, id);
+  const handlers = Array.isArray(handle) ? handle : [handle];
+
+  let result = existing ? ({ ...existing } as T) : null;
+
+  for (const handler of handlers) {
+    result = await handler(result, id);
+  }
 
   return toDocumentChange(id, existing, result);
 }
@@ -267,7 +273,7 @@ function toDocumentChange<T extends PongoDocument>(
   if (!existing && result)
     return {
       type: 'insert',
-      doc: { ...result, _id: docId } as WithId<T>,
+      doc: { ...result, _id: docId },
     };
 
   if (existing && !result)
@@ -306,7 +312,7 @@ function toHandleResult<T extends PongoDocument>(
     }) as unknown as PongoHandleResult<T>;
 
   if (change.type === 'noop')
-    return toResult({ successful: succeeded }, change.existing as T | null);
+    return toResult({ successful: succeeded }, change.existing);
 
   if (change.type === 'insert')
     return toResult(
@@ -315,7 +321,7 @@ function toHandleResult<T extends PongoDocument>(
         insertedId: succeeded ? change.doc._id : null,
         nextExpectedVersion: 1n,
       },
-      succeeded ? ({ ...change.doc, _version: 1n } as unknown as T) : null,
+      succeeded ? { ...change.doc, _version: 1n } : null,
     );
 
   if (change.type === 'delete')
@@ -335,8 +341,6 @@ function toHandleResult<T extends PongoDocument>(
       matchedCount: 1,
       nextExpectedVersion: newVersion ?? 0n,
     },
-    succeeded
-      ? ({ ...change.result, _version: newVersion } as unknown as T)
-      : (change.existing as T | null),
+    succeeded ? { ...change.result, _version: newVersion } : change.existing,
   );
 }

--- a/src/packages/pongo/src/core/collection/pongoCollection.ts
+++ b/src/packages/pongo/src/core/collection/pongoCollection.ts
@@ -163,22 +163,33 @@ export const pongoCollection = <
   const downcast =
     schema?.versioning?.downcast ?? ((doc: T) => doc as unknown as Payload);
 
-  const rowToDoc = (row: { data: T; _version: bigint }): WithIdAndVersion<T> =>
-    upcast({
-      ...row.data,
-      _version: row._version,
-    } as unknown as Payload) as WithIdAndVersion<T>;
+  const toStored = (
+    document: WithIdAndVersion<T>,
+  ): WithIdAndVersion<Payload> => ({
+    ...downcast(document),
+    _id: document._id,
+    _version: document._version,
+  });
 
-  const findOneFromDb = async (
+  const fromStored = (
+    stored: WithIdAndVersion<Payload>,
+  ): WithIdAndVersion<T> => ({
+    ...upcast(stored),
+    _id: stored._id,
+    _version: stored._version,
+  });
+
+  const findOneStoredFromDb = async (
     filter: PongoFilter<T>,
     options?: CollectionOperationOptions,
-  ): Promise<WithIdAndVersion<T> | null> => {
-    const result = await query<{ data: T; _version: bigint }>(
-      SqlFor.findOne(filter),
-      options,
-    );
+  ): Promise<WithIdAndVersion<Payload> | null> => {
+    const result = await query<{
+      data: Payload;
+      _id: string;
+      _version: bigint;
+    }>(SqlFor.findOne(filter), options);
     const row = result.rows[0];
-    return row ? rowToDoc(row) : null;
+    return row ? { ...row.data, _id: row._id, _version: row._version } : null;
   };
 
   const cacheKey = (id: string): PongoDocumentCacheKey =>
@@ -190,27 +201,27 @@ export const pongoCollection = <
   const resolveFromCache = async (
     key: PongoDocumentCacheKey,
     options: CollectionOperationOptions | undefined,
-  ): Promise<T | null | undefined> => {
+  ): Promise<WithIdAndVersion<Payload> | null | undefined> => {
     const txCache = txCacheFor(options);
     if (txCache) {
-      const cached = await txCache.get<T>(key);
+      const cached = await txCache.get<WithIdAndVersion<Payload>>(key);
       if (cached !== undefined) return cached;
     }
-    return cache.get<T>(key);
+    return cache.get<WithIdAndVersion<Payload>>(key);
   };
 
   const findManyFromCache = async (
     keys: PongoDocumentCacheKey[],
     options: CollectionOperationOptions | undefined,
-  ): Promise<(T | null | undefined)[]> => {
+  ): Promise<(WithIdAndVersion<Payload> | null | undefined)[]> => {
     const txCache = txCacheFor(options);
 
     if (!txCache) {
-      return cache.getMany<T>(keys);
+      return cache.getMany<WithIdAndVersion<Payload>>(keys);
     }
 
-    const txResults = await txCache.getMany<T>(keys);
-    const mainResults = await cache.getMany<T>(keys);
+    const txResults = await txCache.getMany<WithIdAndVersion<Payload>>(keys);
+    const mainResults = await cache.getMany<WithIdAndVersion<Payload>>(keys);
     return keys.map((_, i) =>
       txResults[i] !== undefined ? txResults[i] : mainResults[i],
     );
@@ -219,23 +230,29 @@ export const pongoCollection = <
   const fetchByIds = async (
     ids: string[],
     options: CollectionOperationOptions | undefined,
-  ): Promise<(WithIdAndVersion<T> | null)[]> => {
+  ): Promise<(WithIdAndVersion<Payload> | null)[]> => {
     const cachedResults = await findManyFromCache(ids.map(cacheKey), options);
 
     const missIds = ids.filter((_, i) => cachedResults[i] === undefined);
 
-    let dbDocsById = new Map<string, WithIdAndVersion<T>>();
+    let dbDocsById = new Map<string, WithIdAndVersion<Payload>>();
     if (missIds.length > 0) {
-      const dbResult = await query<{ data: T; _version: bigint }>(
+      const dbResult = await query<{
+        data: Payload;
+        _id: string;
+        _version: bigint;
+      }>(
         SqlFor.find(
           { _id: { $in: missIds } } as unknown as PongoFilter<T>,
           options,
         ),
       );
-      const dbDocs = dbResult.rows.map(rowToDoc);
-      dbDocsById = new Map(
-        dbDocs.map((d) => [(d as PongoDocument)['_id'] as string, d]),
-      );
+      const dbDocs = dbResult.rows.map((row) => ({
+        ...row.data,
+        _id: row._id,
+        _version: row._version,
+      }));
+      dbDocsById = new Map(dbDocs.map((d) => [d._id, d]));
       const leftovers = missIds.map(
         (id) => [id, dbDocsById.get(id) ?? null] as const,
       );
@@ -251,11 +268,7 @@ export const pongoCollection = <
 
     return ids.map((id, i) => {
       const cached = cachedResults[i];
-      if (cached !== undefined) {
-        return cached !== null
-          ? (upcast({ ...cached } as unknown as Payload) as WithIdAndVersion<T>)
-          : null;
-      }
+      if (cached !== undefined) return cached;
       return dbDocsById.get(id) ?? null;
     });
   };
@@ -265,11 +278,11 @@ export const pongoCollection = <
     options: FindOptions | undefined,
   ): Promise<WithIdAndVersion<T>[]> => {
     const results = await fetchByIds(ids, options);
-    return results.filter((doc): doc is WithIdAndVersion<T> => doc !== null);
+    return results.filter((doc) => doc !== null).map(fromStored);
   };
 
   const cacheSet = (
-    value: WithId<T>,
+    value: WithIdAndVersion<Payload>,
     options: CollectionOperationOptions | undefined,
   ) => {
     const key = cacheKey(value._id);
@@ -281,7 +294,7 @@ export const pongoCollection = <
   };
 
   const cacheSetMany = (
-    documents: WithId<T>[],
+    documents: WithIdAndVersion<Payload>[],
     options: CollectionOperationOptions | undefined,
   ) => {
     const txCache = txCacheFor(options);
@@ -362,22 +375,23 @@ export const pongoCollection = <
 
       const _id = (document._id as string | undefined | null) ?? uuid();
       const _version = document._version ?? 1n;
-      const downcasted = downcast(document as T);
+      const stored = toStored({
+        ...(document as T),
+        _id,
+        _version: _version,
+      });
 
       const result = await command(
-        SqlFor.insertOne({
-          ...downcasted,
-          _id,
-          _version,
-        } as unknown as OptionalUnlessRequiredIdAndVersion<Payload>),
+        SqlFor.insertOne(
+          stored as unknown as OptionalUnlessRequiredIdAndVersion<Payload>,
+        ),
         options,
       );
 
       const successful = (result.rowCount ?? 0) > 0;
 
       if (successful && !options?.skipCache) {
-        const doc = { ...document, _id, _version } as WithId<T>;
-        await cacheSet(doc, options);
+        await cacheSet(stored, options);
       }
 
       return operationResult<PongoInsertOneResult>(
@@ -405,11 +419,9 @@ export const pongoCollection = <
             } as WithIdAndVersion<T>),
       );
 
-      const rows = documentsWithMetadata.map((d) => ({
-        ...downcast(d as T),
-        _id: d._id,
-        _version: d._version,
-      }));
+      const rows: WithIdAndVersion<Payload>[] = documentsWithMetadata.map((d) =>
+        toStored(d),
+      );
 
       const result = await command(
         SqlFor.insertMany(
@@ -421,7 +433,7 @@ export const pongoCollection = <
       if (!options?.skipCache) {
         const insertedIdSet = new Set(result.rows.map((d) => d._id as string));
         await cacheSetMany(
-          documentsWithMetadata.filter((d) => insertedIdSet.has(d._id)),
+          rows.filter((r) => insertedIdSet.has(r._id)),
           options,
         );
       }
@@ -473,10 +485,14 @@ export const pongoCollection = <
     ): Promise<PongoUpdateResult> => {
       await ensureCollectionCreated(options);
 
-      const downcasted = downcast(document as T) as unknown as WithoutId<T>;
+      const downcasted = downcast(document as T);
 
       const result = await command<UpdateSqlResult>(
-        SqlFor.replaceOne(filter, downcasted, options),
+        SqlFor.replaceOne(
+          filter,
+          downcasted as unknown as WithoutId<T>,
+          options,
+        ),
         options,
       );
 
@@ -494,11 +510,11 @@ export const pongoCollection = <
         const _id = idFromFilter(filter);
         if (_id) {
           await cacheSet(
-            {
+            toStored({
               ...document,
               _id,
               _version: opResult.nextExpectedVersion,
-            } as unknown as WithId<T>,
+            } as WithIdAndVersion<T>),
             options,
           );
         }
@@ -587,19 +603,16 @@ export const pongoCollection = <
       if (id) {
         const cached = await resolveFromCache(cacheKey(id), options);
         if (cached !== undefined)
-          return cached !== null
-            ? (upcast({
-                ...cached,
-              } as unknown as Payload) as WithIdAndVersion<T>)
-            : null;
+          return cached !== null ? fromStored(cached) : null;
 
-        const doc = await findOneFromDb(filter!, options);
-        if (doc) await cacheSet(doc, options);
+        const stored = await findOneStoredFromDb(filter!, options);
+        if (stored) await cacheSet(stored, options);
         else await cacheDelete(id, options);
-        return doc;
+        return stored ? fromStored(stored) : null;
       }
 
-      return findOneFromDb(filter ?? {}, options);
+      const stored = await findOneStoredFromDb(filter ?? {}, options);
+      return stored ? fromStored(stored) : null;
     },
     findOneAndDelete: async (
       filter: PongoFilter<T>,
@@ -648,14 +661,13 @@ export const pongoCollection = <
     ): Promise<PongoReplaceManyResult> => {
       await ensureCollectionCreated(options);
 
-      const downcasted = documents.map(
-        (d) => downcast(d as T) as WithIdAndVersion<T>,
-      );
+      const rows: (WithIdAndVersion<Payload> | WithId<Payload>)[] =
+        documents.map((d) => toStored(d as WithIdAndVersion<T>));
 
       const result = await command<{
         _id: string;
         version?: bigint | string | number;
-      }>(SqlFor.replaceMany(downcasted), options);
+      }>(SqlFor.replaceMany(rows), options);
 
       const modifiedIds = result.rows.map((row) => row._id);
       const conflictIds = documents
@@ -666,16 +678,13 @@ export const pongoCollection = <
       );
 
       if (!options?.skipCache) {
-        const cacheEntries = documents
-          .filter((d) => modifiedIds.includes(d._id))
-          .map((doc) =>
-            doc._version
-              ? doc
-              : {
-                  ...doc,
-                  _version: versions.get(doc._id) ?? 1n,
-                },
-          );
+        const cacheEntries = rows
+          .filter((r) => modifiedIds.includes(r._id))
+          .map((r) => ({
+            ...r,
+            _version:
+              versions.get(r._id) ?? (r._version as bigint | undefined) ?? 1n,
+          }));
         if (cacheEntries.length > 0) await cacheSetMany(cacheEntries, options);
 
         if (conflictIds.length > 0)
@@ -700,7 +709,10 @@ export const pongoCollection = <
       errors,
       storage: {
         ensureCollectionCreated,
-        fetchByIds,
+        fetchByIds: (ids, options) =>
+          fetchByIds(ids, options).then((rows) =>
+            rows.map((stored) => (stored ? fromStored(stored) : null)),
+          ),
         insertMany: (docs, options) => collection.insertMany(docs, options),
         replaceMany: (docs, options) => collection.replaceMany(docs, options),
         deleteManyByIds,
@@ -717,10 +729,14 @@ export const pongoCollection = <
         if (ids && ids.length > 0) return findManyByIds(ids, options);
       }
 
-      const result = await query<{ data: T; _version: bigint }>(
-        SqlFor.find(filter ?? {}, options),
+      const result = await query<{
+        data: Payload;
+        _id: string;
+        _version: bigint;
+      }>(SqlFor.find(filter ?? {}, options));
+      return result.rows.map((row) =>
+        fromStored({ ...row.data, _id: row._id, _version: row._version }),
       );
-      return result.rows.map(rowToDoc);
     },
     countDocuments: async (
       filter?: PongoFilter<T>,

--- a/src/packages/pongo/src/core/typing/operations.ts
+++ b/src/packages/pongo/src/core/typing/operations.ts
@@ -361,12 +361,12 @@ export declare type OptionalUnlessRequiredVersion<TSchema> = TSchema extends {
 export declare type OptionalUnlessRequiredIdAndVersion<TSchema> =
   OptionalUnlessRequiredId<TSchema> & OptionalUnlessRequiredVersion<TSchema>;
 
-export declare type WithId<TSchema> = EnhancedOmit<TSchema, '_id'> & {
+export declare type WithId<TSchema> = TSchema & {
   _id: string | ObjectId;
 };
 export type WithoutId<T> = Omit<T, '_id'>;
 
-export declare type WithVersion<TSchema> = EnhancedOmit<TSchema, '_version'> & {
+export declare type WithVersion<TSchema> = TSchema & {
   _version: bigint;
 };
 export type WithoutVersion<T> = Omit<T, '_version'>;

--- a/src/packages/pongo/src/mongo/mongoCollection.ts
+++ b/src/packages/pongo/src/mongo/mongoCollection.ts
@@ -290,10 +290,10 @@ export class Collection<T extends Document> implements MongoCollection<T> {
     filter?: unknown,
     options?: FindOptions,
   ): Promise<WithId<T> | T | null> {
-    return (await this.collection.findOne(
+    return await this.collection.findOne(
       filter as PongoFilter<T>,
       toCollectionOperationOptions(options),
-    )) as T;
+    );
   }
   find(): MongoFindCursor<WithId<T>>;
   find(filter: Filter<T>, options?: FindOptions): MongoFindCursor<WithId<T>>;

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/index.ts
@@ -302,7 +302,7 @@ export const postgresSQLBuilder = (
       ? filter
       : constructFilterQuery(filter, serializer);
 
-    return SQL`SELECT data, _version FROM ${SQL.identifier(collectionName)} ${where(filterQuery)} LIMIT 1;`;
+    return SQL`SELECT data, _id, _version FROM ${SQL.identifier(collectionName)} ${where(filterQuery)} LIMIT 1;`;
   },
   find: <T>(filter: PongoFilter<T> | SQL, options?: FindOptions): SQL => {
     const filterQuery = isSQL(filter)
@@ -311,7 +311,7 @@ export const postgresSQLBuilder = (
     const query: SQL[] = [];
 
     query.push(
-      SQL`SELECT data, _version FROM ${SQL.identifier(collectionName)}`,
+      SQL`SELECT data, _id, _version FROM ${SQL.identifier(collectionName)}`,
     );
 
     query.push(where(filterQuery));

--- a/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -11,7 +11,7 @@ describe('find() query options', () => {
       { limit: 4 },
     );
     assert.deepStrictEqual(SQL.format(query, pgFormatter), {
-      query: 'SELECT data, _version FROM users LIMIT $1 ;',
+      query: 'SELECT data, _id, _version FROM users LIMIT $1 ;',
       params: [4],
     });
   });
@@ -22,7 +22,7 @@ describe('find() query options', () => {
       { skip: 123 },
     );
     assert.deepStrictEqual(SQL.format(query, pgFormatter), {
-      query: 'SELECT data, _version FROM users OFFSET $1 ;',
+      query: 'SELECT data, _id, _version FROM users OFFSET $1 ;',
       params: [123],
     });
   });
@@ -33,7 +33,7 @@ describe('find() query options', () => {
       { limit: 20, skip: 123 },
     );
     assert.deepStrictEqual(SQL.format(query, pgFormatter), {
-      query: 'SELECT data, _version FROM users LIMIT $1 OFFSET $2 ;',
+      query: 'SELECT data, _id, _version FROM users LIMIT $1 OFFSET $2 ;',
       params: [20, 123],
     });
   });

--- a/src/packages/pongo/src/storage/postgresql/pg/versioningCache.int.spec.ts
+++ b/src/packages/pongo/src/storage/postgresql/pg/versioningCache.int.spec.ts
@@ -1,0 +1,138 @@
+import { PostgreSQLConnectionString } from '@event-driven-io/dumbo/pg';
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { pongoClient, type PongoClient, type PongoDb } from '../../..';
+import { pgDriver } from './';
+
+type StoredPayload = { n: number };
+type Domain = { value: number };
+
+const upcast = (doc: StoredPayload): Domain => ({ value: doc.n });
+const downcast = (doc: Domain): StoredPayload => ({ n: doc.value });
+
+describe('versioned collection: id reads, handle and replaceMany keep working', () => {
+  let client: PongoClient;
+  let db: PongoDb;
+  let postgres: StartedPostgreSqlContainer;
+
+  beforeAll(async () => {
+    postgres = await new PostgreSqlContainer('postgres:18.0').start();
+    const connectionString = PostgreSQLConnectionString(
+      postgres.getConnectionUri(),
+    );
+    client = pongoClient({
+      driver: pgDriver,
+      connectionString,
+    });
+    await client.connect();
+    db = client.db('db');
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await postgres.stop();
+  });
+
+  const versioned = (name: string, cache?: { type: 'identity-map' }) =>
+    db.collection<Domain, StoredPayload>(name, {
+      schema: { versioning: { upcast, downcast } },
+      ...(cache ? { cache } : {}),
+    });
+
+  it('find by _id with $in returns the versioned document', async () => {
+    const col = versioned('find_in');
+    const { insertedId } = await col.insertOne({ value: 7 });
+
+    const found = await col.find({ _id: { $in: [insertedId!] } });
+
+    expect(found).toHaveLength(1);
+    expect(found[0]?.value).toBe(7);
+  });
+
+  it('handle loads the existing document instead of treating it as new', async () => {
+    const col = versioned('handle_existing');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    let received: Domain | null = undefined as unknown as Domain | null;
+    const result = await col.handle(insertedId!, (existing) => {
+      received = existing;
+      return { value: 2 };
+    });
+
+    expect(received).not.toBeNull();
+    expect(received?.value).toBe(1);
+    expect(result.successful).toBe(true);
+
+    const updated = await col.findOne({ _id: insertedId! });
+    expect(updated?.value).toBe(2);
+
+    const second = await col.handle(insertedId!, (existing) => ({
+      value: (existing?.value ?? 0) + 1,
+    }));
+    expect(second.successful).toBe(true);
+    const updatedAgain = await col.findOne({ _id: insertedId! });
+    expect(updatedAgain?.value).toBe(3);
+  });
+
+  it('replaceMany updates a versioned document by _id', async () => {
+    const col = versioned('replace_many');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    const result = await col.replaceMany([{ _id: insertedId!, value: 9 }]);
+
+    expect(result.successful).toBe(true);
+    const doc = await col.findOne({ _id: insertedId! });
+    expect(doc?.value).toBe(9);
+  });
+
+  it('handle enforces optimistic concurrency via the stored version', async () => {
+    const col = versioned('handle_occ');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    const ok = await col.handle(
+      { _id: insertedId!, expectedVersion: 1n },
+      () => ({ value: 2 }),
+    );
+    expect(ok.successful).toBe(true);
+
+    const stale = await col.handle(
+      { _id: insertedId!, expectedVersion: 1n },
+      () => ({ value: 3 }),
+    );
+    expect(stale.successful).toBe(false);
+
+    const doc = await col.findOne({ _id: insertedId! });
+    expect(doc?.value).toBe(2);
+  });
+
+  it('passes the upcast read model with id and version to the handle callback', async () => {
+    const col = versioned('handle_pure');
+    const { insertedId } = await col.insertOne({ value: 4 });
+
+    let received: (Domain & { _id?: string; _version?: bigint }) | null = null;
+    await col.handle(insertedId!, (existing) => {
+      received = existing;
+      return existing;
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.value).toBe(4);
+    expect(received!._id).toBe(insertedId);
+    expect(received!._version).toBe(1n);
+  });
+
+  it('serves a correct upcast value from the document cache on the second read', async () => {
+    const col = versioned('cache_read', { type: 'identity-map' });
+    const { insertedId } = await col.insertOne({ value: 6 });
+
+    const first = await col.findOne({ _id: insertedId! });
+    expect(first?.value).toBe(6);
+
+    const second = await col.findOne({ _id: insertedId! });
+    expect(second?.value).toBe(6);
+
+    const viaIn = await col.find({ _id: { $in: [insertedId!] } });
+    expect(viaIn[0]?.value).toBe(6);
+  });
+});

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
@@ -257,7 +257,7 @@ export const sqliteSQLBuilder = (
       ? filter
       : constructFilterQuery(filter, serializer);
 
-    return SQL`SELECT data, _version FROM ${SQL.identifier(collectionName)} ${where(filterQuery)} LIMIT 1;`;
+    return SQL`SELECT data, _id, _version FROM ${SQL.identifier(collectionName)} ${where(filterQuery)} LIMIT 1;`;
   },
   find: <T>(filter: PongoFilter<T> | SQL, options?: FindOptions): SQL => {
     const filterQuery = isSQL(filter)
@@ -266,7 +266,7 @@ export const sqliteSQLBuilder = (
     const query: SQL[] = [];
 
     query.push(
-      SQL`SELECT data, _version FROM ${SQL.identifier(collectionName)}`,
+      SQL`SELECT data, _id, _version FROM ${SQL.identifier(collectionName)}`,
     );
 
     query.push(where(filterQuery));

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -46,7 +46,7 @@ describe('sqliteSQLBuilder', () => {
       const result = builder.find({});
       const { query } = SQL.format(result, sqliteFormatter);
 
-      assert.ok(query.includes('SELECT data, _version FROM'));
+      assert.ok(query.includes('SELECT data, _id, _version FROM'));
       assert.ok(!query.includes('WHERE'));
     });
 
@@ -155,7 +155,7 @@ describe('sqliteSQLBuilder', () => {
 
   describe('update operations', () => {
     it('should handle $set operator', () => {
-      const result = builder.updateOne(
+      const result = builder.updateOne<{ name: string }>(
         { _id: 'test-id' },
         { $set: { name: 'Updated' } },
       );
@@ -166,7 +166,7 @@ describe('sqliteSQLBuilder', () => {
     });
 
     it('should handle $inc operator', () => {
-      const result = builder.updateOne(
+      const result = builder.updateOne<{ count: number }>(
         { _id: 'test-id' },
         { $inc: { count: 1 } },
       );
@@ -177,7 +177,7 @@ describe('sqliteSQLBuilder', () => {
     });
 
     it('should handle $push operator', () => {
-      const result = builder.updateOne(
+      const result = builder.updateOne<{ tags: string }>(
         { _id: 'test-id' },
         { $push: { tags: 'new-tag' } },
       );

--- a/src/packages/pongo/src/storage/sqlite/d1/versioningCache.int.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/d1/versioningCache.int.spec.ts
@@ -1,0 +1,138 @@
+import { Miniflare } from 'miniflare';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pongoClient, type PongoClient, type PongoDb } from '../../..';
+import { d1Driver } from './';
+
+type StoredPayload = { n: number };
+type Domain = { value: number };
+
+const upcast = (doc: StoredPayload): Domain => ({ value: doc.n });
+const downcast = (doc: Domain): StoredPayload => ({ n: doc.value });
+
+describe('versioned collection: id reads, handle and replaceMany keep working', () => {
+  let mf: Miniflare;
+  let client: PongoClient;
+  let db: PongoDb;
+
+  beforeEach(async () => {
+    mf = new Miniflare({
+      modules: true,
+      script: 'export default { fetch() { return new Response("ok"); } }',
+      d1Databases: { DB: 'test-db-id' },
+    });
+    const database = await mf.getD1Database('DB');
+    client = pongoClient({
+      driver: d1Driver,
+      database,
+    });
+    await client.connect();
+    db = client.db('db');
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await mf.dispose();
+  });
+
+  const versioned = (name: string, cache?: { type: 'identity-map' }) =>
+    db.collection<Domain, StoredPayload>(name, {
+      schema: { versioning: { upcast, downcast } },
+      ...(cache ? { cache } : {}),
+    });
+
+  it('find by _id with $in returns the versioned document', async () => {
+    const col = versioned('find_in');
+    const { insertedId } = await col.insertOne({ value: 7 });
+
+    const found = await col.find({ _id: { $in: [insertedId!] } });
+
+    expect(found).toHaveLength(1);
+    expect(found[0]?.value).toBe(7);
+  });
+
+  it('handle loads the existing document instead of treating it as new', async () => {
+    const col = versioned('handle_existing');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    let received: Domain | null = undefined as unknown as Domain | null;
+    const result = await col.handle(insertedId!, (existing) => {
+      received = existing;
+      return { value: 2 };
+    });
+
+    expect(received).not.toBeNull();
+    expect(received?.value).toBe(1);
+    expect(result.successful).toBe(true);
+
+    const updated = await col.findOne({ _id: insertedId! });
+    expect(updated?.value).toBe(2);
+
+    const second = await col.handle(insertedId!, (existing) => ({
+      value: (existing?.value ?? 0) + 1,
+    }));
+    expect(second.successful).toBe(true);
+    const updatedAgain = await col.findOne({ _id: insertedId! });
+    expect(updatedAgain?.value).toBe(3);
+  });
+
+  it('replaceMany updates a versioned document by _id', async () => {
+    const col = versioned('replace_many');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    const result = await col.replaceMany([{ _id: insertedId!, value: 9 }]);
+
+    expect(result.successful).toBe(true);
+    const doc = await col.findOne({ _id: insertedId! });
+    expect(doc?.value).toBe(9);
+  });
+
+  it('handle enforces optimistic concurrency via the stored version', async () => {
+    const col = versioned('handle_occ');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    const ok = await col.handle(
+      { _id: insertedId!, expectedVersion: 1n },
+      () => ({ value: 2 }),
+    );
+    expect(ok.successful).toBe(true);
+
+    const stale = await col.handle(
+      { _id: insertedId!, expectedVersion: 1n },
+      () => ({ value: 3 }),
+    );
+    expect(stale.successful).toBe(false);
+
+    const doc = await col.findOne({ _id: insertedId! });
+    expect(doc?.value).toBe(2);
+  });
+
+  it('passes the upcast read model with id and version to the handle callback', async () => {
+    const col = versioned('handle_pure');
+    const { insertedId } = await col.insertOne({ value: 4 });
+
+    let received: (Domain & { _id?: string; _version?: bigint }) | null = null;
+    await col.handle(insertedId!, (existing) => {
+      received = existing;
+      return existing;
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.value).toBe(4);
+    expect(received!._id).toBe(insertedId);
+    expect(received!._version).toBe(1n);
+  });
+
+  it('serves a correct upcast value from the document cache on the second read', async () => {
+    const col = versioned('cache_read', { type: 'identity-map' });
+    const { insertedId } = await col.insertOne({ value: 6 });
+
+    const first = await col.findOne({ _id: insertedId! });
+    expect(first?.value).toBe(6);
+
+    const second = await col.findOne({ _id: insertedId! });
+    expect(second?.value).toBe(6);
+
+    const viaIn = await col.find({ _id: { $in: [insertedId!] } });
+    expect(viaIn[0]?.value).toBe(6);
+  });
+});

--- a/src/packages/pongo/src/storage/sqlite/sqlite3/versioningCache.int.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/sqlite3/versioningCache.int.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pongoClient, type PongoClient, type PongoDb } from '../../..';
+import { sqlite3Driver } from './';
+
+type StoredPayload = { n: number };
+type Domain = { value: number };
+
+const upcast = (doc: StoredPayload): Domain => ({ value: doc.n });
+const downcast = (doc: Domain): StoredPayload => ({ n: doc.value });
+
+const memoryConnectionString = () =>
+  `file::memory:?cache=shared&_${Math.random()}`;
+
+describe('versioned collection: id reads, handle and replaceMany keep working', () => {
+  let client: PongoClient;
+  let db: PongoDb;
+
+  beforeEach(async () => {
+    client = pongoClient({
+      driver: sqlite3Driver,
+      connectionString: memoryConnectionString(),
+    });
+    await client.connect();
+    db = client.db('db');
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  const versioned = (name: string, cache?: { type: 'identity-map' }) =>
+    db.collection<Domain, StoredPayload>(name, {
+      schema: { versioning: { upcast, downcast } },
+      ...(cache ? { cache } : {}),
+    });
+
+  it('find by _id with $in returns the versioned document', async () => {
+    const col = versioned('find_in');
+    const { insertedId } = await col.insertOne({ value: 7 });
+
+    const found = await col.find({ _id: { $in: [insertedId!] } });
+
+    expect(found).toHaveLength(1);
+    expect(found[0]?.value).toBe(7);
+  });
+
+  it('handle loads the existing document instead of treating it as new', async () => {
+    const col = versioned('handle_existing');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    let received: Domain | null = undefined as unknown as Domain | null;
+    const result = await col.handle(insertedId!, (existing) => {
+      received = existing;
+      return { value: 2 };
+    });
+
+    expect(received).not.toBeNull();
+    expect(received?.value).toBe(1);
+    expect(result.successful).toBe(true);
+
+    const updated = await col.findOne({ _id: insertedId! });
+    expect(updated?.value).toBe(2);
+
+    const second = await col.handle(insertedId!, (existing) => ({
+      value: (existing?.value ?? 0) + 1,
+    }));
+    expect(second.successful).toBe(true);
+    const updatedAgain = await col.findOne({ _id: insertedId! });
+    expect(updatedAgain?.value).toBe(3);
+  });
+
+  it('replaceMany updates a versioned document by _id', async () => {
+    const col = versioned('replace_many');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    const result = await col.replaceMany([{ _id: insertedId!, value: 9 }]);
+
+    expect(result.successful).toBe(true);
+    const doc = await col.findOne({ _id: insertedId! });
+    expect(doc?.value).toBe(9);
+  });
+
+  it('handle enforces optimistic concurrency via the stored version', async () => {
+    const col = versioned('handle_occ');
+    const { insertedId } = await col.insertOne({ value: 1 });
+
+    const ok = await col.handle(
+      { _id: insertedId!, expectedVersion: 1n },
+      () => ({ value: 2 }),
+    );
+    expect(ok.successful).toBe(true);
+
+    const stale = await col.handle(
+      { _id: insertedId!, expectedVersion: 1n },
+      () => ({ value: 3 }),
+    );
+    expect(stale.successful).toBe(false);
+
+    const doc = await col.findOne({ _id: insertedId! });
+    expect(doc?.value).toBe(2);
+  });
+
+  it('passes the upcast read model with id and version to the handle callback', async () => {
+    const col = versioned('handle_pure');
+    const { insertedId } = await col.insertOne({ value: 4 });
+
+    let received: (Domain & { _id?: string; _version?: bigint }) | null = null;
+    await col.handle(insertedId!, (existing) => {
+      received = existing;
+      return existing;
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.value).toBe(4);
+    expect(received!._id).toBe(insertedId);
+    expect(received!._version).toBe(1n);
+  });
+
+  it('serves a correct upcast value from the document cache on the second read', async () => {
+    const col = versioned('cache_read', { type: 'identity-map' });
+    const { insertedId } = await col.insertOne({ value: 6 });
+
+    const first = await col.findOne({ _id: insertedId! });
+    expect(first?.value).toBe(6);
+
+    const second = await col.findOne({ _id: insertedId! });
+    expect(second?.value).toBe(6);
+
+    const viaIn = await col.find({ _id: { $in: [insertedId!] } });
+    expect(viaIn[0]?.value).toBe(6);
+  });
+});


### PR DESCRIPTION
Made upcasted and downcasted documents always contain _id and _version to enable proper matching for the handle method.