### PR TITLE
Removed SQL literal quote escaping from bound object parameters

### DIFF
--- a/src/packages/dumbo/src/core/sql/valueMappers/sqlValueMapper.ts
+++ b/src/packages/dumbo/src/core/sql/valueMappers/sqlValueMapper.ts
@@ -126,7 +126,7 @@ export function mapSQLParamValue(
   } else if (typeof value === 'object') {
     return options?.mapObject
       ? options.mapObject(value)
-      : `${serializer.serialize(value).replace(/'/g, "''")}`;
+      : serializer.serialize(value);
   } else {
     return serializer.serialize(value);
   }

--- a/src/packages/dumbo/src/core/sql/valueMappers/sqlValueMapper.unit.spec.ts
+++ b/src/packages/dumbo/src/core/sql/valueMappers/sqlValueMapper.unit.spec.ts
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import { describe, it } from 'vitest';
+import { JSONSerializer } from '../../serializer';
+import { mapSQLParamValue } from './sqlValueMapper';
+
+describe('mapSQLParamValue', () => {
+  it('maps object values to serialized JSON without escaping single quotes', () => {
+    const result = mapSQLParamValue(
+      { title: "director's cut" },
+      JSONSerializer,
+    );
+
+    assert.strictEqual(result, `{"title":"director's cut"}`);
+  });
+
+  it('maps nested object values without escaping single quotes', () => {
+    const result = mapSQLParamValue(
+      { title: "director's cut", metadata: { note: "author's note" } },
+      JSONSerializer,
+    );
+
+    assert.strictEqual(
+      result,
+      `{"title":"director's cut","metadata":{"note":"author's note"}}`,
+    );
+  });
+
+  it('maps objects nested in arrays without escaping single quotes', () => {
+    const result = mapSQLParamValue(
+      [{ title: "director's cut" }],
+      JSONSerializer,
+    );
+
+    assert.deepStrictEqual(result, [`{"title":"director's cut"}`]);
+  });
+
+  it('keeps primitive values unchanged', () => {
+    assert.strictEqual(
+      mapSQLParamValue("director's cut", JSONSerializer),
+      "director's cut",
+    );
+    assert.strictEqual(mapSQLParamValue(123, JSONSerializer), 123);
+    assert.strictEqual(mapSQLParamValue(true, JSONSerializer), true);
+    assert.strictEqual(mapSQLParamValue(null, JSONSerializer), null);
+  });
+
+  it('honors the mapObject override', () => {
+    const document = { title: "director's cut" };
+
+    const result = mapSQLParamValue(document, JSONSerializer, {
+      mapObject: (value) => value,
+    });
+
+    assert.strictEqual(result, document);
+  });
+});

--- a/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/parametrizedFormatter.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/sql/formatter/parametrizedFormatter.unit.spec.ts
@@ -183,6 +183,19 @@ describe('SQLite Parametrized Formatter', () => {
       assert.ok(result.includes('test'));
       assert.ok(result.includes('\n'));
     });
+
+    it('describes object params without escaping single quotes', () => {
+      const document = { title: "director's cut" };
+      const sql = SQL`INSERT INTO test (data) VALUES (${document})`;
+      const result = sqliteFormatter.describe(sql, {
+        serializer: JSONSerializer,
+      });
+
+      assert.strictEqual(
+        result,
+        `INSERT INTO test (data) VALUES ("{\\"title\\":\\"director's cut\\"}")`,
+      );
+    });
   });
 
   describe('mapSQLValue method', () => {

--- a/src/packages/dumbo/src/storage/sqlite/d1/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/formatter/sqlFormatter.int.spec.ts
@@ -3,7 +3,7 @@ import { Miniflare } from 'miniflare';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import { d1DumboDriver, type D1ConnectionPool } from '..';
 import { dumbo } from '../../../..';
-import { count, SQL } from '../../../../core';
+import { count, JSONSerializer, SQL } from '../../../../core';
 
 describe('D1 SQL Formatter Integration Tests', () => {
   let mf: Miniflare;
@@ -119,6 +119,51 @@ describe('D1 SQL Formatter Integration Tests', () => {
       );
 
       assert.strictEqual(result, 0);
+    });
+  });
+
+  describe('Object Params Handling', () => {
+    beforeAll(async () => {
+      await pool.execute.query(
+        SQL`CREATE TABLE test_documents (id INTEGER PRIMARY KEY, data TEXT)`,
+      );
+    });
+
+    it('stores object params with single quotes without escaping them', async () => {
+      const document = { title: "director's cut" };
+
+      await pool.execute.command(
+        SQL`INSERT INTO test_documents (id, data) VALUES (1, ${document})`,
+      );
+
+      const result = await pool.execute.query<{ data: string }>(
+        SQL`SELECT data FROM test_documents WHERE id = 1`,
+      );
+
+      assert.strictEqual(
+        result.rows[0]!.data,
+        JSONSerializer.serialize(document),
+      );
+    });
+
+    it('stores nested object params with single quotes without escaping them', async () => {
+      const document = {
+        title: "director's cut",
+        metadata: { note: "author's note" },
+      };
+
+      await pool.execute.command(
+        SQL`INSERT INTO test_documents (id, data) VALUES (2, ${document})`,
+      );
+
+      const result = await pool.execute.query<{ data: string }>(
+        SQL`SELECT data FROM test_documents WHERE id = 2`,
+      );
+
+      assert.strictEqual(
+        result.rows[0]!.data,
+        JSONSerializer.serialize(document),
+      );
     });
   });
 });

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/formatter/sqlFormatter.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/formatter/sqlFormatter.int.spec.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import { sqlite3DumboDriver } from '..';
 import { dumbo, type Dumbo } from '../../../..';
-import { count, SQL } from '../../../../core';
+import { count, JSONSerializer, SQL } from '../../../../core';
 import { InMemorySQLiteDatabase } from '../../core/connections';
 
 describe('SQLite3 SQL Formatter Integration Tests', () => {
@@ -184,6 +184,51 @@ describe('SQLite3 SQL Formatter Integration Tests', () => {
       );
 
       assert.strictEqual(result, 2);
+    });
+  });
+
+  describe('Object Params Handling', () => {
+    beforeAll(async () => {
+      await pool.execute.query(
+        SQL`CREATE TABLE test_documents (id INTEGER PRIMARY KEY, data TEXT)`,
+      );
+    });
+
+    it('stores object params with single quotes without escaping them', async () => {
+      const document = { title: "director's cut" };
+
+      await pool.execute.command(
+        SQL`INSERT INTO test_documents (id, data) VALUES (1, ${document})`,
+      );
+
+      const result = await pool.execute.query<{ data: string }>(
+        SQL`SELECT data FROM test_documents WHERE id = 1`,
+      );
+
+      assert.strictEqual(
+        result.rows[0]!.data,
+        JSONSerializer.serialize(document),
+      );
+    });
+
+    it('stores nested object params with single quotes without escaping them', async () => {
+      const document = {
+        title: "director's cut",
+        metadata: { note: "author's note" },
+      };
+
+      await pool.execute.command(
+        SQL`INSERT INTO test_documents (id, data) VALUES (2, ${document})`,
+      );
+
+      const result = await pool.execute.query<{ data: string }>(
+        SQL`SELECT data FROM test_documents WHERE id = 2`,
+      );
+
+      assert.strictEqual(
+        result.rows[0]!.data,
+        JSONSerializer.serialize(document),
+      );
     });
   });
 });

--- a/src/packages/pongo/src/e2e/sqlite/d1/d1.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/sqlite/d1/d1.e2e.spec.ts
@@ -151,6 +151,19 @@ describe('SQLite MongoDB Compatibility Tests', () => {
       );
     });
 
+    it('should insert and find back a document with single quotes in values', async () => {
+      const pongoCollection = pongoDb.collection<User>('insertOne');
+      const doc = { name: "Anita O'Connor", age: 25 };
+      const pongoInsertResult = await pongoCollection.insertOne(doc);
+      assert(pongoInsertResult.insertedId);
+
+      const pongoDoc = await pongoCollection.findOne({
+        _id: pongoInsertResult.insertedId,
+      });
+
+      assert.strictEqual(pongoDoc!.name, "Anita O'Connor");
+    });
+
     it('should insert many documents into both SQLite and MongoDB shim', async () => {
       const pongoCollection = pongoDb.collection<User>('insertMany');
       const mongoCollection = mongoDb.collection<User>('shiminsertMany');

--- a/src/packages/pongo/src/e2e/sqlite/sqlite3/sqlite3.e2e.spec.ts
+++ b/src/packages/pongo/src/e2e/sqlite/sqlite3/sqlite3.e2e.spec.ts
@@ -157,6 +157,19 @@ describe('SQLite MongoDB Compatibility Tests', () => {
       );
     });
 
+    it('should insert and find back a document with single quotes in values', async () => {
+      const pongoCollection = pongoDb.collection<User>('insertOne');
+      const doc = { name: "Anita O'Connor", age: 25 };
+      const pongoInsertResult = await pongoCollection.insertOne(doc);
+      assert(pongoInsertResult.insertedId);
+
+      const pongoDoc = await pongoCollection.findOne({
+        _id: pongoInsertResult.insertedId,
+      });
+
+      assert.strictEqual(pongoDoc!.name, "Anita O'Connor");
+    });
+
     it('should insert many documents into both SQLite and MongoDB shim', async () => {
       const pongoCollection = pongoDb.collection<User>('insertMany');
       const mongoCollection = mongoDb.collection<User>('shiminsertMany');

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/index.ts
@@ -52,7 +52,7 @@ export const sqliteSQLBuilder = (
 ): PongoCollectionSQLBuilder => ({
   createCollection: (): SQL => createCollection(collectionName),
   insertOne: <T>(document: OptionalUnlessRequiredIdAndVersion<T>): SQL => {
-    const serialized = document;
+    const serialized = serializer.serialize(document);
     const id = document._id;
     const version = document._version ?? 1n;
 

--- a/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
+++ b/src/packages/pongo/src/storage/sqlite/core/sqlBuilder/sqlBuilder.unit.spec.ts
@@ -1,4 +1,9 @@
-import { JSONSerializer, SQL } from '@event-driven-io/dumbo';
+import {
+  JSONSerializer,
+  SQL,
+  SQLLiteral,
+  type TokenizedSQL,
+} from '@event-driven-io/dumbo';
 import { sqliteFormatter } from '@event-driven-io/dumbo/sqlite';
 import { randomUUID } from 'crypto';
 import assert from 'node:assert/strict';
@@ -39,6 +44,19 @@ describe('sqliteSQLBuilder', () => {
 
       assert.ok(query.includes('INSERT OR IGNORE INTO'));
       assert.ok(query.includes('(_id, data, _version)'));
+    });
+
+    it('serializes document with single quotes without escaping them', () => {
+      const document = { _id: randomUUID(), name: "director's cut" };
+      const result = builder.insertOne(document);
+      const { sqlTokens } = result as unknown as TokenizedSQL;
+
+      const literals = sqlTokens.filter(SQLLiteral.check);
+      assert.ok(
+        literals.some(
+          (literal) => literal.value === JSONSerializer.serialize(document),
+        ),
+      );
     });
   });
 


### PR DESCRIPTION
Follow-up to the Discord report about pongo projections on D1: object params were getting SQL literal quote-doubling (`.replace(/'/g, "''")` in `mapSQLParamValue`), but they are passed as **bound parameters** — binding transmits the string verbatim, so the doubled apostrophes were stored physically in the database and read back corrupted:

```ts
await eventStore.appendToStream('stream-1', [
  { type: 'TestEvent', data: { title: "director's cut" } },
]);
const { events } = await eventStore.readStream('stream-1');
events[0].data.title; // "director''s cut" — expected "director's cut"
```

Affects both sqlite3 and D1 drivers (shared core) for any string inside object-typed params (emmett event `data`/`metadata`, nested objects, arrays). PostgreSQL shares the same default object branch.

**Commit 1** removes the escaping from the bound-parameter mapping path (quote doubling belongs only to inlined SQL literals). Covered by mapper unit specs (nested objects, arrays of objects, `mapObject` override untouched) and sqlite3 + D1 (Miniflare) integration round-trips.

**Commit 2** aligns the SQLite `insertOne` builder with `insertMany` to pre-serialize the document before interpolation (it interpolated the raw document, so it hit the same path), with a build-time unit assertion and pongo-level e2e round-trips on sqlite3 and D1. PostgreSQL's `insertOne` already pre-serializes.

Two notes:

- `SQL.describe()` output for apostrophe-bearing object params changes accordingly (no longer doubled) — locked with a regression test. Internal pongo/emmett migrations are static DDL, so their hashes are unaffected; a custom user migration interpolating such an object could see a hash mismatch once, and the existing `ignoreMigrationHashMismatch` migrator option re-baselines it.
- The fix changes the write path only: data written by earlier versions remains doubled at rest. A blind `''` → `'` repair is ambiguous (legitimate doubled apostrophes are indistinguishable), so any healing needs to be application-aware.

All unit suites green (672 tests), lint clean; the only failing int specs on my machine are the 4 pre-existing `connection.int.generic.spec.ts` D1 transaction cases, reproduced on clean `main`.