### PR TITLE
Fixed the CommonJS issue where multiple bundles were mixed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,5 +57,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify bundle boundaries
+        run: npm run test:bundles
+
       - name: Test
         run: npm run test

--- a/src/e2e/bundleBoundaries.bundle.spec.ts
+++ b/src/e2e/bundleBoundaries.bundle.spec.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type ModuleFormat = 'cjs' | 'js';
+
+const bundleDefinitions = {
+  dumbo: {
+    index:
+      /^(?:core\/|storage\/all\/|storage\/postgresql\/core\/(?:connections\/connectionString|schema\/(?:schema|postgreSQLMetadata))\.ts$|storage\/sqlite\/core\/schema\/(?:schema|sqliteMetadata)\.ts$|index\.ts$)/,
+    postgresql: /^(?:core\/|storage\/postgresql\/core\/|postgresql\.ts$)/,
+    pg: /^(?:core\/|storage\/postgresql\/|pg\.ts$)/,
+    sqlite: /^(?:core\/|storage\/sqlite\/core\/|sqlite\.ts$)/,
+    sqlite3: /^(?:core\/|storage\/sqlite\/(?:core|sqlite3)\/|sqlite3\.ts$)/,
+    cloudflare: /^(?:core\/|storage\/sqlite\/(?:core|d1)\/|cloudflare\.ts$)/,
+  },
+  pongo: {
+    index: /^(?:core\/|storage\/|(?:index|pg|sqlite3|cloudflare)\.ts$)/,
+    shim: /^(?:core\/|mongo\/|shim\.ts$)/,
+    cli: /^(?:core\/|commandLine\/|cli\.ts$)/,
+    pg: /^(?:core\/|storage\/postgresql\/|pg\.ts$)/,
+    sqlite3: /^(?:core\/|storage\/sqlite\/(?:core|sqlite3)\/|sqlite3\.ts$)/,
+    cloudflare: /^(?:core\/|storage\/sqlite\/(?:core|d1)\/|cloudflare\.ts$)/,
+  },
+} as const;
+
+const localImportPatterns: Record<ModuleFormat, RegExp> = {
+  cjs: /require\(['"]\.\/([^'"]+\.cjs)['"]\)/g,
+  js: /(?:from\s+|import\s*\()\s*['"]\.\/([^'"]+\.js)['"]/g,
+};
+
+const reachableFiles = (
+  distDirectory: string,
+  entry: string,
+  format: ModuleFormat,
+): Set<string> => {
+  const pending = [`${entry}.${format}`];
+  const visited = new Set<string>();
+
+  while (pending.length > 0) {
+    const file = pending.pop();
+
+    if (file === undefined || visited.has(file)) continue;
+
+    visited.add(file);
+    const source = fs.readFileSync(path.join(distDirectory, file), 'utf8');
+    pending.push(
+      ...[...source.matchAll(localImportPatterns[format])].map(
+        (match) => match[1],
+      ),
+    );
+  }
+
+  return visited;
+};
+
+describe.each(Object.entries(bundleDefinitions))(
+  '%s bundle boundaries',
+  (packageName, definitions) => {
+    const distDirectory = path.resolve(`packages/${packageName}/dist`);
+    const entries = Object.keys(definitions);
+
+    it.each<ModuleFormat>(['cjs', 'js'])(
+      'keeps public %s entries in independent graphs',
+      (format) => {
+        for (const entry of entries) {
+          const reachable = reachableFiles(distDirectory, entry, format);
+          const otherEntries = entries
+            .filter((otherEntry) => otherEntry !== entry)
+            .map((otherEntry) => `${otherEntry}.${format}`);
+
+          expect(
+            [...reachable].filter((file) => otherEntries.includes(file)),
+            `${packageName}/${entry}.${format} reaches another public entry`,
+          ).toEqual([]);
+        }
+      },
+    );
+  },
+);
+
+describe.each(Object.entries(bundleDefinitions))(
+  '%s source boundaries',
+  (packageName, definitions) => {
+    const distDirectory = path.resolve(`packages/${packageName}/dist`);
+
+    it.each<ModuleFormat>(['cjs', 'js'])(
+      'keeps every %s graph within its allowed sources',
+      (format) => {
+        for (const [entry, allowedSource] of Object.entries(definitions)) {
+          const reachable = reachableFiles(distDirectory, entry, format);
+          const unexpectedSources: string[] = [];
+
+          for (const file of reachable) {
+            const sourceMap = JSON.parse(
+              fs.readFileSync(path.join(distDirectory, `${file}.map`), 'utf8'),
+            ) as { sources: string[] };
+
+            for (const source of sourceMap.sources) {
+              const packageSource = source.match(/(?:^|\/)src\/(.+)$/)?.[1];
+
+              if (
+                packageSource !== undefined &&
+                !allowedSource.test(packageSource)
+              ) {
+                unexpectedSources.push(`${file}: ${packageSource}`);
+              }
+            }
+          }
+
+          expect(
+            unexpectedSources,
+            `${packageName}/${entry}.${format} crosses a source boundary`,
+          ).toEqual([]);
+        }
+      },
+    );
+  },
+);

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -191,4 +191,23 @@ export default [
       ],
     },
   },
+  {
+    files: ['packages/pongo/src/**/*.ts'],
+    ignores: [
+      'packages/pongo/src/cli.ts',
+      'packages/pongo/src/bin.ts',
+      'packages/pongo/src/commandLine/**/*.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            ':matches(ImportDeclaration, ExportNamedDeclaration, ExportAllDeclaration, ImportExpression)[source.value=/(^|\\/)(cli|bin|commandLine)(\\/|$)/]',
+          message:
+            'Pongo library code cannot import CLI implementation. Keep CLI code behind the CLI entry point.',
+        },
+      ],
+    },
+  },
 ];

--- a/src/package.json
+++ b/src/package.json
@@ -33,6 +33,7 @@
     "test:e2e": "vitest run \".e2e.spec\"",
     "test:e2e:postgresql": "vitest run postgresql \".e2e.spec\"",
     "test:e2e:sqlite": "vitest run sqlite \".e2e.spec\"",
+    "test:bundles": "vitest run --project bundle",
     "test:file": "vitest run --no-file-parallelism",
     "test:watch": "vitest",
     "test:unit:watch": "vitest \".unit.spec\"",

--- a/src/packages/dumbo/tsdown.config.ts
+++ b/src/packages/dumbo/tsdown.config.ts
@@ -1,31 +1,33 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig({
-  dts: true,
-  format: ['esm', 'cjs'],
-  fixedExtension: false,
-  minify: false,
-  target: 'esnext',
-  outDir: 'dist',
-  entry: [
+export default defineConfig(
+  [
     'src/index.ts',
     'src/postgresql.ts',
     'src/pg.ts',
     'src/sqlite.ts',
     'src/sqlite3.ts',
     'src/cloudflare.ts',
-  ],
-  sourcemap: true,
-  deps: {
-    skipNodeModulesBundle: true,
-    neverBundle: [
-      '@cloudflare/workers-types',
-      '@types/mongodb',
-      '@types/pg',
-      'pg',
-      'sqlite3',
-      'uuid',
-    ],
-  },
-  tsconfig: 'tsconfig.build.json',
-});
+  ].map((entry) => ({
+    dts: true,
+    format: ['esm', 'cjs'],
+    fixedExtension: false,
+    minify: false,
+    target: 'esnext',
+    outDir: 'dist',
+    sourcemap: true,
+    deps: {
+      skipNodeModulesBundle: true,
+      neverBundle: [
+        '@cloudflare/workers-types',
+        '@types/mongodb',
+        '@types/pg',
+        'pg',
+        'sqlite3',
+        'uuid',
+      ],
+    },
+    tsconfig: 'tsconfig.build.json',
+    entry,
+  })),
+);

--- a/src/packages/pongo/tsdown.config.ts
+++ b/src/packages/pongo/tsdown.config.ts
@@ -1,35 +1,37 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig({
-  dts: true,
-  format: ['esm', 'cjs'],
-  fixedExtension: false,
-  minify: false,
-  target: 'esnext',
-  outDir: 'dist',
-  entry: [
+export default defineConfig(
+  [
     'src/index.ts',
     'src/shim.ts',
     'src/cli.ts',
     'src/pg.ts',
     'src/sqlite3.ts',
     'src/cloudflare.ts',
-  ],
-  sourcemap: true,
-  deps: {
-    skipNodeModulesBundle: true,
-    neverBundle: [
-      '@cloudflare/workers-types',
-      '@types/mongodb',
-      '@types/pg',
-      'pg',
-      'sqlite3',
-      'ansis',
-      'cli-table3',
-      'commander',
-      'uuid',
-      '@event-driven-io/dumbo',
-    ],
-  },
-  tsconfig: 'tsconfig.build.json',
-});
+  ].map((entry) => ({
+    dts: true,
+    format: ['esm', 'cjs'],
+    fixedExtension: false,
+    minify: false,
+    target: 'esnext',
+    outDir: 'dist',
+    sourcemap: true,
+    deps: {
+      skipNodeModulesBundle: true,
+      neverBundle: [
+        '@cloudflare/workers-types',
+        '@types/mongodb',
+        '@types/pg',
+        'pg',
+        'sqlite3',
+        'ansis',
+        'cli-table3',
+        'commander',
+        'uuid',
+        '@event-driven-io/dumbo',
+      ],
+    },
+    tsconfig: 'tsconfig.build.json',
+    entry,
+  })),
+);

--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -2,6 +2,16 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['packages/dumbo', 'packages/pongo'],
+    projects: [
+      'packages/dumbo',
+      'packages/pongo',
+      {
+        test: {
+          name: 'bundle',
+          environment: 'node',
+          include: ['e2e/bundleBoundaries.bundle.spec.ts'],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
The problem was caused by building all public entry points in one tsdown configuration. Rolldown shared generated code between them, causing the CommonJS core chunk to require cli.cjs. Loading the main package therefore executed the CLI.

The fix:
- Build every public Dumbo and Pongo entry using a separate tsdown configuration.
- Keep code splitting enabled inside each configuration so Pongo can still load database drivers lazily.
- Add an ESLint rule preventing non-CLI Pongo source code from importing cli, bin, or commandLine.
- Add bundling tests checking if the bundles are not mixed (both ESM and CJS).

Supersedes https://github.com/event-driven-io/Pongo/pull/194
Fixes https://github.com/event-driven-io/Pongo/issues/193.