### PR TITLE
Unified transaction handling and ensured that open connections are closed in pool

### DIFF
--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -19,6 +19,10 @@ import {
   type WithDatabaseTransactionFactory,
 } from './transaction';
 
+export type PoolCloseOptions = {
+  force?: boolean;
+};
+
 export interface ConnectionPool<
   ConnectionType extends AnyConnection = AnyConnection,
 >
@@ -27,7 +31,7 @@ export interface ConnectionPool<
     WithConnectionFactory<ConnectionType>,
     WithDatabaseTransactionFactory<ConnectionType> {
   driverType: ConnectionType['driverType'];
-  close: () => Promise<void>;
+  close: (options?: PoolCloseOptions) => Promise<void>;
 }
 
 const wrapPooledConnection = <ConnectionType extends AnyConnection>(
@@ -87,6 +91,26 @@ export const createSingletonConnectionPool = <
   const { driverType, getConnection } = options;
 
   let connectionPromise: Promise<ConnectionType> | null = null;
+  let closed = false;
+  const activeOperations = new Set<Promise<unknown>>();
+
+  const closedError = () =>
+    new Error('Singleton connection pool has been closed');
+
+  const run = async <Result>(
+    operation: () => Promise<Result>,
+  ): Promise<Result> => {
+    if (closed) throw closedError();
+
+    const activeOperation = operation();
+    activeOperations.add(activeOperation);
+
+    try {
+      return await activeOperation;
+    } finally {
+      activeOperations.delete(activeOperation);
+    }
+  };
 
   const getExistingOrNewConnection = () => {
     if (!connectionPromise) {
@@ -95,31 +119,63 @@ export const createSingletonConnectionPool = <
     return connectionPromise;
   };
 
+  const innerTransactionFactory = transactionFactoryWithAsyncAmbientConnection(
+    options.driverType,
+    getExistingOrNewConnection,
+    options.closeConnection,
+  );
+
   const result: ConnectionPool<ConnectionType> = {
     driverType,
     connection: () =>
-      getExistingOrNewConnection().then((conn) =>
-        wrapPooledConnection(conn, () => Promise.resolve()),
+      run(() =>
+        getExistingOrNewConnection().then((conn) =>
+          wrapPooledConnection(conn, () => Promise.resolve()),
+        ),
       ),
-    execute: sqlExecutorInAmbientConnection({
-      driverType,
-      connection: getExistingOrNewConnection,
-    }),
+    execute: (() => {
+      const ambientExecutor = sqlExecutorInAmbientConnection({
+        driverType,
+        connection: getExistingOrNewConnection,
+      });
+
+      return {
+        query: (sql, opts) => run(() => ambientExecutor.query(sql, opts)),
+        batchQuery: (sqls, opts) =>
+          run(() => ambientExecutor.batchQuery(sqls, opts)),
+        command: (sql, opts) => run(() => ambientExecutor.command(sql, opts)),
+        batchCommand: (sqls, opts) =>
+          run(() => ambientExecutor.batchCommand(sqls, opts)),
+      };
+    })(),
     withConnection: <Result>(
       handle: (connection: ConnectionType) => Promise<Result>,
       _options?: WithConnectionOptions,
     ) =>
-      executeInAmbientConnection<ConnectionType, Result>(handle, {
-        connection: getExistingOrNewConnection,
-      }),
-    ...transactionFactoryWithAsyncAmbientConnection(
-      options.driverType,
-      getExistingOrNewConnection,
-      options.closeConnection,
-    ),
-    close: async () => {
+      run(() =>
+        executeInAmbientConnection<ConnectionType, Result>(handle, {
+          connection: getExistingOrNewConnection,
+        }),
+      ),
+    transaction: (transactionOptions) => {
+      if (closed) throw closedError();
+      return innerTransactionFactory.transaction(transactionOptions);
+    },
+    withTransaction: (handle, transactionOptions) =>
+      run(() =>
+        innerTransactionFactory.withTransaction(handle, transactionOptions),
+      ),
+    close: async (closeOptions) => {
+      if (closed) return;
+      closed = true;
+
+      if (!closeOptions?.force) {
+        await Promise.allSettled([...activeOperations]);
+      }
+
       if (!connectionPromise) return;
       const connection = await connectionPromise;
+      connectionPromise = null;
       await connection.close();
     },
   };
@@ -142,16 +198,37 @@ export const createBoundedConnectionPool = <
 ): ConnectionPool<ConnectionType> => {
   const { driverType, maxConnections } = options;
 
-  const guardMaxConnections = guardBoundedAccess(options.getConnection, {
+  const allConnections = new Set<ConnectionType>();
+  const getTrackedConnection = async () => {
+    const connection = await options.getConnection();
+    allConnections.add(connection);
+    return connection;
+  };
+
+  const guardMaxConnections = guardBoundedAccess(getTrackedConnection, {
     maxResources: maxConnections,
     reuseResources: true,
   });
 
   let closed = false;
 
+  const closedError = () =>
+    new Error('Bounded connection pool has been closed');
+
+  const ensureOpen = () => {
+    if (closed) throw closedError();
+  };
+
+  const closeAllConnections = async () => {
+    const connections = [...allConnections];
+    allConnections.clear();
+    await Promise.all(connections.map((conn) => conn.close()));
+  };
+
   const executeWithPooling = async <Result>(
     operation: (conn: ConnectionType) => Promise<Result>,
   ): Promise<Result> => {
+    ensureOpen();
     const conn = await guardMaxConnections.acquire();
     try {
       return await operation(conn);
@@ -163,6 +240,7 @@ export const createBoundedConnectionPool = <
   return {
     driverType,
     connection: async () => {
+      ensureOpen();
       const conn = await guardMaxConnections.acquire();
       return wrapPooledConnection(conn, () =>
         Promise.resolve(guardMaxConnections.release(conn)),
@@ -179,16 +257,30 @@ export const createBoundedConnectionPool = <
         executeWithPooling((c) => c.execute.batchCommand(sqls, opts)),
     },
     withConnection: executeWithPooling,
-    ...transactionFactoryWithAsyncAmbientConnection(
-      driverType,
-      guardMaxConnections.acquire,
-      guardMaxConnections.release,
-    ),
-    close: async () => {
+    transaction: (transactionOptions) => {
+      ensureOpen();
+      return transactionFactoryWithAsyncAmbientConnection(
+        driverType,
+        guardMaxConnections.acquire,
+        guardMaxConnections.release,
+      ).transaction(transactionOptions);
+    },
+    withTransaction: (handle, transactionOptions) =>
+      executeWithPooling((conn) => {
+        const withTx =
+          conn.withTransaction as WithDatabaseTransactionFactory<ConnectionType>['withTransaction'];
+        return withTx(handle, transactionOptions);
+      }),
+    close: async (closeOptions) => {
       if (closed) return;
       closed = true;
 
+      if (!closeOptions?.force) {
+        await guardMaxConnections.waitForIdle();
+      }
+
       await guardMaxConnections.stop({ force: true });
+      await closeAllConnections();
     },
   };
 };

--- a/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
+++ b/src/packages/dumbo/src/core/connections/pool.unit.spec.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert';
+import { describe, it } from 'vitest';
+import type { AnyConnection } from './connection';
+import {
+  createBoundedConnectionPool,
+  createSingletonConnectionPool,
+} from './pool';
+
+type FakeConnection = AnyConnection & { id: number; closed: boolean };
+
+const fakeDriverType = 'fake-driver' as unknown as AnyConnection['driverType'];
+
+const makeFakeConnection = (id: number): FakeConnection => {
+  const conn = {
+    id,
+    closed: false,
+    driverType: fakeDriverType,
+    open: () => Promise.resolve(undefined),
+    close: () => {
+      conn.closed = true;
+      return Promise.resolve();
+    },
+    execute: {
+      query: () => Promise.resolve([]),
+      batchQuery: () => Promise.resolve([]),
+      command: () => Promise.resolve([]),
+      batchCommand: () => Promise.resolve([]),
+    },
+    transaction: () => undefined,
+    withTransaction: async <Result>(
+      handle: (
+        tx: unknown,
+      ) => Promise<Result | { success: boolean; result: Result }>,
+    ): Promise<Result> => {
+      const outcome = await handle({ id: `tx-${id}` });
+      if (
+        outcome !== null &&
+        typeof outcome === 'object' &&
+        'success' in outcome &&
+        'result' in outcome
+      ) {
+        return (outcome as { result: Result }).result;
+      }
+      return outcome;
+    },
+  };
+  return conn as unknown as FakeConnection;
+};
+
+describe('createBoundedConnectionPool', () => {
+  it('closes acquired connections when the pool is closed', async () => {
+    const created: FakeConnection[] = [];
+
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 2,
+      getConnection: () => {
+        const conn = makeFakeConnection(created.length + 1);
+        created.push(conn);
+        return conn;
+      },
+    });
+
+    await Promise.all([
+      pool.withConnection(() => Promise.resolve(1)),
+      pool.withConnection(() => Promise.resolve(2)),
+    ]);
+
+    await pool.close();
+
+    assert.strictEqual(created.length, 2);
+    assert.ok(created.every((c) => c.closed));
+  });
+
+  it('waits for in-flight operations before closing', async () => {
+    const created: FakeConnection[] = [];
+
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => {
+        const conn = makeFakeConnection(created.length + 1);
+        created.push(conn);
+        return conn;
+      },
+    });
+
+    let callbackStarted = false;
+    let callbackFinished = false;
+
+    const inFlight = pool.withConnection(async (conn) => {
+      callbackStarted = true;
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      assert.strictEqual(conn.closed, false);
+      callbackFinished = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(callbackStarted, true);
+
+    await pool.close();
+
+    assert.strictEqual(callbackFinished, true);
+    await inFlight;
+  });
+
+  it('rejects new operations attempted after close', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 1,
+      getConnection: () => makeFakeConnection(1),
+    });
+
+    await pool.close();
+
+    await assert.rejects(
+      () => pool.withConnection(() => Promise.resolve(1)),
+      /closed/i,
+    );
+  });
+
+  it('respects maxConnections cap', async () => {
+    const pool = createBoundedConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      maxConnections: 2,
+      getConnection: () => makeFakeConnection(Math.random()),
+    });
+
+    let inFlight = 0;
+    let peak = 0;
+
+    const work = () =>
+      pool.withConnection(async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight--;
+      });
+
+    await Promise.all([work(), work(), work(), work(), work()]);
+
+    assert.strictEqual(peak, 2);
+    await pool.close();
+  });
+});
+
+describe('createSingletonConnectionPool', () => {
+  it('drains in-flight callbacks before closing the underlying connection', async () => {
+    const conn = makeFakeConnection(1);
+
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    let callbackFinished = false;
+    let observedClosedDuringCall = false;
+
+    const inFlight = pool.withConnection(async (c) => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      observedClosedDuringCall = c.closed;
+      callbackFinished = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await pool.close();
+
+    assert.strictEqual(callbackFinished, true);
+    assert.strictEqual(observedClosedDuringCall, false);
+    assert.strictEqual(conn.closed, true);
+    await inFlight;
+  });
+
+  it('force close does not wait for in-flight callbacks', async () => {
+    const conn = makeFakeConnection(1);
+
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    const release = Promise.withResolvers<void>();
+    const inFlight = pool.withConnection(() => release.promise);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const start = Date.now();
+    await pool.close({ force: true });
+    const elapsed = Date.now() - start;
+
+    assert.ok(elapsed < 200);
+    assert.strictEqual(conn.closed, true);
+
+    release.resolve();
+    await inFlight;
+  });
+
+  it('rejects new operations attempted after close', async () => {
+    const conn = makeFakeConnection(1);
+
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    await pool.close();
+
+    await assert.rejects(
+      () => pool.withConnection(() => Promise.resolve(1)),
+      /closed/i,
+    );
+  });
+
+  it('does not serialize concurrent calls', async () => {
+    const conn = makeFakeConnection(1);
+    const pool = createSingletonConnectionPool<FakeConnection>({
+      driverType: fakeDriverType,
+      getConnection: () => conn,
+    });
+
+    let inFlight = 0;
+    let peak = 0;
+    const work = () =>
+      pool.withConnection(async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight--;
+      });
+
+    await Promise.all([work(), work(), work(), work(), work()]);
+
+    assert.strictEqual(peak, 5);
+    await pool.close();
+  });
+});

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -1,3 +1,4 @@
+import { InvalidOperationError } from '../errors';
 import type { WithSQLExecutor } from '../execute';
 import type {
   AnyConnection,
@@ -25,6 +26,102 @@ export type AnyDatabaseTransaction = DatabaseTransaction<any, any>;
 export type DatabaseTransactionOptions = {
   allowNestedTransactions?: boolean;
   readonly?: boolean;
+};
+
+export type TransactionNestingCounter = {
+  increment: () => void;
+  decrement: () => void;
+  reset: () => void;
+  level: number;
+};
+
+export const transactionNestingCounter = (): TransactionNestingCounter => {
+  let transactionLevel = 0;
+
+  return {
+    reset: () => {
+      transactionLevel = 0;
+    },
+    increment: () => {
+      transactionLevel++;
+    },
+    decrement: () => {
+      transactionLevel--;
+
+      if (transactionLevel < 0) {
+        throw new Error('Transaction level is out of bounds');
+      }
+    },
+    get level() {
+      return transactionLevel;
+    },
+  };
+};
+
+export const databaseTransaction = (
+  backend: Pick<DatabaseTransaction, 'begin' | 'commit' | 'rollback'> & {
+    savepoint?: ((level: number) => Promise<void>) | undefined;
+    releaseSavepoint?: ((level: number) => Promise<void>) | undefined;
+    rollbackToSavepoint?: ((level: number) => Promise<void>) | undefined;
+  },
+  options?: {
+    allowNestedTransactions?: boolean | undefined;
+    useSavepoints?: boolean | undefined;
+  },
+): Pick<DatabaseTransaction, 'begin' | 'commit' | 'rollback'> => {
+  const allowNestedTransactions = options?.allowNestedTransactions ?? false;
+  const useSavepoints = options?.useSavepoints ?? false;
+  const counter = transactionNestingCounter();
+  let hasBegun = false;
+
+  return {
+    begin: async () => {
+      if (allowNestedTransactions) {
+        if (counter.level >= 1) {
+          counter.increment();
+          if (useSavepoints && backend.savepoint) {
+            await backend.savepoint(counter.level);
+          }
+          return;
+        }
+        counter.increment();
+      } else if (hasBegun) {
+        throw new InvalidOperationError(
+          'Cannot start a nested transaction: allowNestedTransactions is false. ' +
+            'Set transactionOptions: { allowNestedTransactions: true } on your pool or connection.',
+        );
+      }
+
+      hasBegun = true;
+      await backend.begin();
+    },
+    commit: async () => {
+      if (allowNestedTransactions && counter.level > 1) {
+        if (useSavepoints && backend.releaseSavepoint) {
+          await backend.releaseSavepoint(counter.level);
+        }
+        counter.decrement();
+        return;
+      }
+
+      if (allowNestedTransactions) counter.reset();
+      hasBegun = false;
+      await backend.commit();
+    },
+    rollback: async (error?: unknown) => {
+      if (allowNestedTransactions && counter.level > 1) {
+        if (useSavepoints && backend.rollbackToSavepoint) {
+          await backend.rollbackToSavepoint(counter.level);
+        }
+        counter.decrement();
+        return;
+      }
+
+      if (allowNestedTransactions) counter.reset();
+      hasBegun = false;
+      await backend.rollback(error);
+    },
+  };
 };
 
 export type InferTransactionOptionsFromTransaction<

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -76,6 +76,12 @@ export const databaseTransaction = (
 
   return {
     begin: async () => {
+      if (!allowNestedTransactions && hasBegun) {
+        throw new InvalidOperationError(
+          'Cannot start a nested transaction: allowNestedTransactions is false. ' +
+            'Set transactionOptions: { allowNestedTransactions: true } on your pool or connection.',
+        );
+      }
       if (allowNestedTransactions) {
         if (counter.level >= 1) {
           counter.increment();
@@ -85,11 +91,6 @@ export const databaseTransaction = (
           return;
         }
         counter.increment();
-      } else if (hasBegun) {
-        throw new InvalidOperationError(
-          'Cannot start a nested transaction: allowNestedTransactions is false. ' +
-            'Set transactionOptions: { allowNestedTransactions: true } on your pool or connection.',
-        );
       }
 
       hasBegun = true;

--- a/src/packages/dumbo/src/core/connections/transaction.unit.spec.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.unit.spec.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert';
+import { describe, it } from 'vitest';
+import { InvalidOperationError } from '../errors';
+import { databaseTransaction, transactionNestingCounter } from './transaction';
+
+describe('transactionNestingCounter', () => {
+  it('starts at level 0', () => {
+    const counter = transactionNestingCounter();
+    assert.strictEqual(counter.level, 0);
+  });
+
+  it('increments, decrements, and resets', () => {
+    const counter = transactionNestingCounter();
+    counter.increment();
+    counter.increment();
+    assert.strictEqual(counter.level, 2);
+    counter.decrement();
+    assert.strictEqual(counter.level, 1);
+    counter.reset();
+    assert.strictEqual(counter.level, 0);
+  });
+
+  it('throws when decremented below zero', () => {
+    const counter = transactionNestingCounter();
+    assert.throws(() => counter.decrement(), /out of bounds/i);
+  });
+});
+
+const makeBackend = () => {
+  const calls: string[] = [];
+  return {
+    calls,
+    backend: {
+      begin: () => {
+        calls.push('begin');
+        return Promise.resolve();
+      },
+      commit: () => {
+        calls.push('commit');
+        return Promise.resolve();
+      },
+      rollback: () => {
+        calls.push('rollback');
+        return Promise.resolve();
+      },
+      savepoint: (level: number) => {
+        calls.push(`savepoint:${level}`);
+        return Promise.resolve();
+      },
+      releaseSavepoint: (level: number) => {
+        calls.push(`release:${level}`);
+        return Promise.resolve();
+      },
+      rollbackToSavepoint: (level: number) => {
+        calls.push(`rollbackTo:${level}`);
+        return Promise.resolve();
+      },
+    },
+  };
+};
+
+describe('databaseTransaction', () => {
+  it('runs backend begin and commit for a single transaction', async () => {
+    const { backend, calls } = makeBackend();
+    const tx = databaseTransaction(backend);
+
+    await tx.begin();
+    await tx.commit();
+
+    assert.deepStrictEqual(calls, ['begin', 'commit']);
+  });
+
+  it('rejects nested begin when nested transactions are disabled', async () => {
+    const { backend, calls } = makeBackend();
+    const tx = databaseTransaction(backend);
+
+    await tx.begin();
+    await assert.rejects(
+      () => tx.begin(),
+      (err) =>
+        err instanceof InvalidOperationError &&
+        /allowNestedTransactions/.test(err.message),
+    );
+
+    assert.deepStrictEqual(calls, ['begin']);
+  });
+
+  it('treats nested commit and rollback as backend no-ops without savepoints', async () => {
+    const { backend, calls } = makeBackend();
+    const tx = databaseTransaction(backend, {
+      allowNestedTransactions: true,
+    });
+
+    await tx.begin();
+    await tx.begin();
+    await tx.commit();
+    await tx.commit();
+    await tx.begin();
+    await tx.begin();
+    await tx.rollback();
+    await tx.rollback();
+
+    assert.deepStrictEqual(calls, ['begin', 'commit', 'begin', 'rollback']);
+  });
+
+  it('uses savepoints for nested commit and rollback when enabled', async () => {
+    const { backend, calls } = makeBackend();
+    const tx = databaseTransaction(backend, {
+      allowNestedTransactions: true,
+      useSavepoints: true,
+    });
+
+    await tx.begin();
+    await tx.begin();
+    await tx.begin();
+    await tx.commit();
+    await tx.rollback();
+    await tx.commit();
+
+    assert.deepStrictEqual(calls, [
+      'begin',
+      'savepoint:2',
+      'savepoint:3',
+      'release:3',
+      'rollbackTo:2',
+      'commit',
+    ]);
+  });
+
+  it('skips savepoint calls when hooks are not provided', async () => {
+    const calls: string[] = [];
+    const tx = databaseTransaction(
+      {
+        begin: () => {
+          calls.push('begin');
+          return Promise.resolve();
+        },
+        commit: () => {
+          calls.push('commit');
+          return Promise.resolve();
+        },
+        rollback: () => {
+          calls.push('rollback');
+          return Promise.resolve();
+        },
+      },
+      { allowNestedTransactions: true, useSavepoints: true },
+    );
+
+    await tx.begin();
+    await tx.begin();
+    await tx.commit();
+    await tx.commit();
+
+    assert.deepStrictEqual(calls, ['begin', 'commit']);
+  });
+});

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.int.spec.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.int.spec.ts
@@ -2,6 +2,7 @@ import {
   PostgreSqlContainer,
   type StartedPostgreSqlContainer,
 } from '@testcontainers/postgresql';
+import assert from 'assert';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import pg from 'pg';
 import { pgPool } from '.';
@@ -373,6 +374,161 @@ describe('pg', () => {
 
         await pool.execute.command(SQL`DROP TABLE test_iso_readonly`);
       } finally {
+        await pool.close();
+      }
+    });
+
+    it('throws an actionable error for nested transactions by default', async () => {
+      const pool = pgPool({ connectionString });
+      const connection = await pool.connection();
+
+      try {
+        await assert.rejects(
+          () =>
+            connection.withTransaction(async () => {
+              await connection.withTransaction(async () => {
+                await connection.execute.query(SQL`SELECT 1`);
+              });
+            }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /allowNestedTransactions/);
+            return true;
+          },
+        );
+      } finally {
+        await connection.close();
+        await pool.close();
+      }
+    });
+
+    it('treats nested rollback as a no-op without savepoints', async () => {
+      const pool = pgPool({ connectionString });
+      const connection = await pool.connection();
+
+      try {
+        await connection.execute.command(
+          SQL`CREATE TEMP TABLE tx_nested_no_savepoints (id INTEGER PRIMARY KEY)`,
+        );
+
+        await connection.withTransaction(
+          async () => {
+            await connection.execute.command(
+              SQL`INSERT INTO tx_nested_no_savepoints (id) VALUES (1)`,
+            );
+
+            await connection.withTransaction(async () => {
+              await connection.execute.command(
+                SQL`INSERT INTO tx_nested_no_savepoints (id) VALUES (2)`,
+              );
+
+              return { success: false, result: undefined };
+            });
+
+            await connection.execute.command(
+              SQL`INSERT INTO tx_nested_no_savepoints (id) VALUES (3)`,
+            );
+          },
+          { allowNestedTransactions: true },
+        );
+
+        const result = await connection.execute.query<{ id: number }>(
+          SQL`SELECT id FROM tx_nested_no_savepoints ORDER BY id`,
+        );
+
+        assert.deepStrictEqual(
+          result.rows.map((row) => row.id),
+          [1, 2, 3],
+        );
+      } finally {
+        await connection.close();
+        await pool.close();
+      }
+    });
+
+    it('rolls back only nested work when savepoints are enabled', async () => {
+      const pool = pgPool({ connectionString });
+      const connection = await pool.connection();
+
+      try {
+        await connection.execute.command(
+          SQL`CREATE TEMP TABLE tx_nested_savepoints (id INTEGER PRIMARY KEY)`,
+        );
+
+        await connection.withTransaction(
+          async () => {
+            await connection.execute.command(
+              SQL`INSERT INTO tx_nested_savepoints (id) VALUES (1)`,
+            );
+
+            await connection.withTransaction(async () => {
+              await connection.execute.command(
+                SQL`INSERT INTO tx_nested_savepoints (id) VALUES (2)`,
+              );
+
+              return { success: false, result: undefined };
+            });
+
+            await connection.execute.command(
+              SQL`INSERT INTO tx_nested_savepoints (id) VALUES (3)`,
+            );
+          },
+          { allowNestedTransactions: true, useSavepoints: true },
+        );
+
+        const result = await connection.execute.query<{ id: number }>(
+          SQL`SELECT id FROM tx_nested_savepoints ORDER BY id`,
+        );
+
+        assert.deepStrictEqual(
+          result.rows.map((row) => row.id),
+          [1, 3],
+        );
+      } finally {
+        await connection.close();
+        await pool.close();
+      }
+    });
+
+    it('propagates pool transaction options to acquired connections', async () => {
+      const pool = pgPool({
+        connectionString,
+        transactionOptions: {
+          allowNestedTransactions: true,
+          useSavepoints: true,
+        },
+      });
+      const connection = await pool.connection();
+
+      try {
+        await connection.execute.command(
+          SQL`CREATE TEMP TABLE tx_pool_default_savepoints (id INTEGER PRIMARY KEY)`,
+        );
+
+        await connection.withTransaction(async () => {
+          await connection.execute.command(
+            SQL`INSERT INTO tx_pool_default_savepoints (id) VALUES (1)`,
+          );
+
+          await connection.withTransaction(async () => {
+            await connection.execute.command(
+              SQL`INSERT INTO tx_pool_default_savepoints (id) VALUES (2)`,
+            );
+
+            return { success: false, result: undefined };
+          });
+        });
+
+        const result = await connection.execute.query<{ id: number }>(
+          SQL`SELECT id FROM tx_pool_default_savepoints ORDER BY id`,
+        );
+
+        assert.deepStrictEqual(
+          result.rows.map((row) => row.id),
+          [1],
+        );
+      } finally {
+        await connection.close();
         await pool.close();
       }
     });

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/connection.ts
@@ -49,23 +49,31 @@ export type PgClientOptions = {
 
 export type PgClientConnectionOptions = PgClientOptions & {
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions;
 };
 
 export type PgPoolClientConnectionOptions = PgPoolClientOptions & {
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions;
 };
 
 export const pgClientConnection = (
   options: PgClientConnectionOptions,
 ): PgClientConnection => {
-  const { connect, close } = options;
+  const { connect, close, transactionOptions } = options;
 
   return createConnection({
     driverType: PgDriverType,
     connect,
     close,
-    initTransaction: (connection) =>
-      pgTransaction(connection, options.serializer),
+    initTransaction: (connection) => {
+      const txFactory = pgTransaction(connection, options.serializer);
+      return (client, perCallOptions) =>
+        txFactory(client, {
+          ...(transactionOptions ?? {}),
+          ...(perCallOptions ?? ({} as Parameters<typeof txFactory>[1])),
+        } as Parameters<typeof txFactory>[1]);
+    },
     executor: pgSQLExecutor,
     serializer: options.serializer,
   });
@@ -74,14 +82,20 @@ export const pgClientConnection = (
 export const pgPoolClientConnection = (
   options: PgPoolClientConnectionOptions,
 ): PgPoolClientConnection => {
-  const { connect, close } = options;
+  const { connect, close, transactionOptions } = options;
 
   return createConnection({
     driverType: PgDriverType,
     connect,
     close,
-    initTransaction: (connection) =>
-      pgTransaction(connection, options.serializer),
+    initTransaction: (connection) => {
+      const txFactory = pgTransaction(connection, options.serializer);
+      return (client, perCallOptions) =>
+        txFactory(client, {
+          ...(transactionOptions ?? {}),
+          ...(perCallOptions ?? ({} as Parameters<typeof txFactory>[1])),
+        } as Parameters<typeof txFactory>[1]);
+    },
     executor: pgSQLExecutor,
     serializer: options.serializer,
   });

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/pool.ts
@@ -15,6 +15,7 @@ import {
   type PgClientConnection,
   type PgPoolClientConnection,
 } from './connection';
+import type { PgTransactionOptions } from './transaction';
 
 export type PgNativePool = ConnectionPool<PgPoolClientConnection>;
 
@@ -31,8 +32,9 @@ export const pgNativePool = (options: {
   connectionString: string;
   database?: string | undefined;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgNativePool => {
-  const { connectionString, database } = options;
+  const { connectionString, database, transactionOptions } = options;
   const pool = getPgPool({ connectionString, database });
 
   const getConnection = () =>
@@ -50,6 +52,7 @@ export const pgNativePool = (options: {
       },
       close: (client) => Promise.resolve(client.release()),
       serializer: options.serializer,
+      ...(transactionOptions ? { transactionOptions } : {}),
     });
 
   const open = () => Promise.resolve(getConnection());
@@ -66,8 +69,9 @@ export const pgNativePool = (options: {
 export const pgAmbientNativePool = (options: {
   pool: pg.Pool;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgNativePool => {
-  const { pool } = options;
+  const { pool, transactionOptions } = options;
 
   return createConnectionPool({
     driverType: PgDriverType,
@@ -77,6 +81,7 @@ export const pgAmbientNativePool = (options: {
         connect: () => pool.connect(),
         close: (client) => Promise.resolve(client.release()),
         serializer: options.serializer,
+        ...(transactionOptions ? { transactionOptions } : {}),
       }),
   });
 };
@@ -96,8 +101,9 @@ export const pgClientPool = (options: {
   connectionString: string;
   database?: string | undefined;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgAmbientClientPool => {
-  const { connectionString, database } = options;
+  const { connectionString, database, transactionOptions } = options;
 
   return createConnectionPool({
     driverType: PgDriverType,
@@ -119,6 +125,7 @@ export const pgClientPool = (options: {
         connect,
         close: (client) => client.end(),
         serializer: options.serializer,
+        ...(transactionOptions ? { transactionOptions } : {}),
       });
     },
   });
@@ -127,8 +134,9 @@ export const pgClientPool = (options: {
 export const pgAmbientClientPool = (options: {
   client: pg.Client;
   serializer: JSONSerializer;
+  transactionOptions?: PgTransactionOptions | undefined;
 }): PgAmbientClientPool => {
-  const { client } = options;
+  const { client, transactionOptions } = options;
 
   const getConnection = () => {
     const connect = () => Promise.resolve(client);
@@ -138,6 +146,7 @@ export const pgAmbientClientPool = (options: {
       connect,
       close: () => Promise.resolve(),
       serializer: options.serializer,
+      ...(transactionOptions ? { transactionOptions } : {}),
     });
   };
 
@@ -199,19 +208,33 @@ export type PgPoolNotPooledOptions =
     };
 
 export type PgPoolOptions = (PgPoolPooledOptions | PgPoolNotPooledOptions) &
-  JSONSerializationOptions;
+  JSONSerializationOptions & {
+    transactionOptions?: PgTransactionOptions;
+  };
 
-export function pgPool(options: PgPoolPooledOptions): PgNativePool;
-export function pgPool(options: PgPoolNotPooledOptions): PgAmbientClientPool;
+export function pgPool(
+  options: PgPoolPooledOptions & { transactionOptions?: PgTransactionOptions },
+): PgNativePool;
+export function pgPool(
+  options: PgPoolNotPooledOptions & {
+    transactionOptions?: PgTransactionOptions;
+  },
+): PgAmbientClientPool;
 export function pgPool(
   options: PgPoolOptions,
 ): PgNativePool | PgAmbientClientPool | PgAmbientConnectionPool {
-  const { connectionString, database } = options;
+  const { connectionString, database, transactionOptions } = options;
 
   const serializer = options.serialization?.serializer ?? JSONSerializer;
 
+  const txOpts = transactionOptions ? { transactionOptions } : {};
+
   if ('client' in options && options.client)
-    return pgAmbientClientPool({ client: options.client, serializer });
+    return pgAmbientClientPool({
+      client: options.client,
+      serializer,
+      ...txOpts,
+    });
 
   if ('connection' in options && options.connection)
     return pgAmbientConnectionPool({
@@ -219,15 +242,16 @@ export function pgPool(
     });
 
   if ('pooled' in options && options.pooled === false)
-    return pgClientPool({ connectionString, database, serializer });
+    return pgClientPool({ connectionString, database, serializer, ...txOpts });
 
   if ('pool' in options && options.pool)
-    return pgAmbientNativePool({ pool: options.pool, serializer });
+    return pgAmbientNativePool({ pool: options.pool, serializer, ...txOpts });
 
   return pgNativePool({
     connectionString,
     database,
     serializer,
+    ...txOpts,
   });
 }
 

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
@@ -1,9 +1,10 @@
-import type { JSONSerializer } from '../../../../core';
 import {
+  databaseTransaction,
   sqlExecutor,
   type AnyConnection,
   type DatabaseTransaction,
   type DatabaseTransactionOptions,
+  type JSONSerializer,
 } from '../../../../core';
 import { pgSQLExecutor } from '../execute';
 import {
@@ -22,6 +23,7 @@ export type PgIsolationLevel =
 
 export type PgTransactionOptions = DatabaseTransactionOptions & {
   isolationLevel?: PgIsolationLevel;
+  useSavepoints?: boolean;
 };
 
 export const pgTransaction =
@@ -34,39 +36,68 @@ export const pgTransaction =
     options?: {
       close: (client: DbClient, error?: unknown) => Promise<void>;
     } & PgTransactionOptions,
-  ): DatabaseTransaction<ConnectionType> => ({
-    connection: connection(),
-    driverType: PgDriverType,
-    begin: async () => {
-      const client = await getClient;
-      const parts = ['BEGIN'];
-      if (options?.isolationLevel) {
-        parts.push(`ISOLATION LEVEL ${options.isolationLevel}`);
-      }
-      if (options?.readonly) {
-        parts.push('READ ONLY');
-      }
-      await client.query(parts.join(' '));
-    },
-    commit: async () => {
-      const client = await getClient;
+  ): DatabaseTransaction<ConnectionType> => {
+    const allowNestedTransactions = options?.allowNestedTransactions ?? false;
+    const useSavepoints = options?.useSavepoints ?? false;
 
-      try {
-        await client.query('COMMIT');
-      } finally {
-        if (options?.close) await options?.close(client);
-      }
-    },
-    rollback: async (error?: unknown) => {
-      const client = await getClient;
-      try {
-        await client.query('ROLLBACK');
-      } finally {
-        if (options?.close) await options?.close(client, error);
-      }
-    },
-    execute: sqlExecutor(pgSQLExecutor({ serializer }), {
-      connect: () => getClient,
-    }),
-    _transactionOptions: options ?? {},
-  });
+    const tx = databaseTransaction(
+      {
+        begin: async () => {
+          const client = await getClient;
+          const parts = ['BEGIN'];
+          if (options?.isolationLevel) {
+            parts.push(`ISOLATION LEVEL ${options.isolationLevel}`);
+          }
+          if (options?.readonly) {
+            parts.push('READ ONLY');
+          }
+          await client.query(parts.join(' '));
+        },
+        commit: async () => {
+          const client = await getClient;
+
+          try {
+            await client.query('COMMIT');
+          } finally {
+            if (options?.close) await options.close(client);
+          }
+        },
+        rollback: async (error?: unknown) => {
+          const client = await getClient;
+          try {
+            await client.query('ROLLBACK');
+          } finally {
+            if (options?.close) await options.close(client, error);
+          }
+        },
+        savepoint: async (level) => {
+          const client = await getClient;
+          await client.query(`SAVEPOINT pg_savepoint_${level}`);
+        },
+        releaseSavepoint: async (level) => {
+          const client = await getClient;
+          await client.query(`RELEASE SAVEPOINT pg_savepoint_${level}`);
+        },
+        rollbackToSavepoint: async (level) => {
+          const client = await getClient;
+          await client.query(`ROLLBACK TO SAVEPOINT pg_savepoint_${level}`);
+        },
+      },
+      { allowNestedTransactions, useSavepoints },
+    );
+
+    return {
+      connection: connection(),
+      driverType: PgDriverType,
+      begin: tx.begin,
+      commit: tx.commit,
+      rollback: tx.rollback,
+      execute: sqlExecutor(pgSQLExecutor({ serializer }), {
+        connect: () => getClient,
+      }),
+      _transactionOptions: {
+        ...(options ?? {}),
+        allowNestedTransactions,
+      },
+    };
+  };

--- a/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
@@ -157,36 +157,6 @@ export type SQLiteConnectionFactory<
   ConnectionOptions extends SQLiteConnectionOptions = SQLiteConnectionOptions,
 > = (options: ConnectionOptions) => SQLiteConnectionType;
 
-export type TransactionNestingCounter = {
-  increment: () => void;
-  decrement: () => void;
-  reset: () => void;
-  level: number;
-};
-
-export const transactionNestingCounter = (): TransactionNestingCounter => {
-  let transactionLevel = 0;
-
-  return {
-    reset: () => {
-      transactionLevel = 0;
-    },
-    increment: () => {
-      transactionLevel++;
-    },
-    decrement: () => {
-      transactionLevel--;
-
-      if (transactionLevel < 0) {
-        throw new Error('Transaction level is out of bounds');
-      }
-    },
-    get level() {
-      return transactionLevel;
-    },
-  };
-};
-
 export type SqliteAmbientClientConnectionOptions<
   SQLiteConnectionType extends AnySQLiteClientConnection =
     AnySQLiteClientConnection,

--- a/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
@@ -3,7 +3,7 @@ import type {
   JSONSerializer,
 } from '../../../../core';
 import {
-  InvalidOperationError,
+  databaseTransaction,
   SQL,
   sqlExecutor,
   type DatabaseTransaction,
@@ -11,10 +11,9 @@ import {
   type InferDbClientFromConnection,
 } from '../../../../core';
 import { sqliteSQLExecutor } from '../../core/execute';
-import {
-  transactionNestingCounter,
-  type AnySQLiteConnection,
-  type SQLiteClientOrPoolClient,
+import type {
+  AnySQLiteConnection,
+  SQLiteClientOrPoolClient,
 } from '../connections';
 
 export type SQLiteTransaction<
@@ -47,84 +46,64 @@ export const sqliteTransaction =
       ) => Promise<void>;
     } & SQLiteTransactionOptions,
   ): InferTransactionFromConnection<ConnectionType> => {
-    const transactionCounter = transactionNestingCounter();
     allowNestedTransactions =
       options?.allowNestedTransactions ?? allowNestedTransactions;
+    const useSavepoints = options?.useSavepoints ?? false;
 
-    let hasBegun = false;
+    const tx = databaseTransaction(
+      {
+        begin: async () => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          const mode = options?.mode ?? defaultTransactionMode ?? 'IMMEDIATE';
+          await client.command(SQL`BEGIN ${SQL.plain(mode)} TRANSACTION`);
+        },
+        commit: async () => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          try {
+            await client.command(SQL`COMMIT`);
+          } finally {
+            if (options?.close) {
+              await options.close(
+                client as InferDbClientFromConnection<ConnectionType>,
+              );
+            }
+          }
+        },
+        rollback: async (error?: unknown) => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          try {
+            await client.command(SQL`ROLLBACK`);
+          } finally {
+            if (options?.close) {
+              await options.close(
+                client as InferDbClientFromConnection<ConnectionType>,
+                error,
+              );
+            }
+          }
+        },
+        savepoint: async (level) => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          await client.command(
+            SQL`SAVEPOINT transaction${SQL.plain(level.toString())}`,
+          );
+        },
+        releaseSavepoint: async (level) => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          await client.command(
+            SQL`RELEASE transaction${SQL.plain(level.toString())}`,
+          );
+        },
+      },
+      { allowNestedTransactions, useSavepoints },
+    );
 
     const transaction: DatabaseTransaction<ConnectionType> = {
       connection: connection(),
       driverType,
-      begin: async function () {
-        const client = (await getClient) as SQLiteClientOrPoolClient;
-
-        if (allowNestedTransactions) {
-          if (transactionCounter.level >= 1) {
-            transactionCounter.increment();
-            if (options?.useSavepoints) {
-              await client.command(
-                SQL`SAVEPOINT transaction${SQL.plain(transactionCounter.level.toString())}`,
-              );
-            }
-            return;
-          }
-
-          transactionCounter.increment();
-        } else if (hasBegun) {
-          throw new InvalidOperationError(
-            'Cannot start a nested transaction: allowNestedTransactions is false. ' +
-              'Set transactionOptions: { allowNestedTransactions: true } on your pool or connection.',
-          );
-        }
-
-        hasBegun = true;
-        const mode = options?.mode ?? defaultTransactionMode ?? 'IMMEDIATE';
-        await client.command(SQL`BEGIN ${SQL.plain(mode)} TRANSACTION`);
-      },
-      commit: async function () {
-        const client = (await getClient) as SQLiteClientOrPoolClient;
-
-        if (allowNestedTransactions && transactionCounter.level > 1) {
-          if (options?.useSavepoints) {
-            await client.command(
-              SQL`RELEASE transaction${SQL.plain(transactionCounter.level.toString())}`,
-            );
-          }
-          transactionCounter.decrement();
-          return;
-        }
-
-        try {
-          if (allowNestedTransactions) transactionCounter.reset();
-          hasBegun = false;
-          await client.command(SQL`COMMIT`);
-        } finally {
-          if (options?.close)
-            await options?.close(
-              client as InferDbClientFromConnection<ConnectionType>,
-            );
-        }
-      },
-      rollback: async function (error?: unknown) {
-        const client = (await getClient) as SQLiteClientOrPoolClient;
-
-        if (allowNestedTransactions && transactionCounter.level > 1) {
-          transactionCounter.decrement();
-          return;
-        }
-
-        try {
-          hasBegun = false;
-          await client.command(SQL`ROLLBACK`);
-        } finally {
-          if (options?.close)
-            await options?.close(
-              client as InferDbClientFromConnection<ConnectionType>,
-              error,
-            );
-        }
-      },
+      begin: tx.begin,
+      commit: tx.commit,
+      rollback: tx.rollback,
       execute: sqlExecutor(sqliteSQLExecutor(driverType, serializer), {
         connect: () => getClient,
       }),

--- a/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
@@ -1,10 +1,10 @@
 import type { JSONSerializer } from '../../../../core';
 import {
   sqlExecutor,
+  transactionNestingCounter,
   type DatabaseTransaction,
   type DatabaseTransactionOptions,
 } from '../../../../core';
-import { transactionNestingCounter } from '../../core';
 import {
   D1DriverType,
   type D1Client,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/index.ts
@@ -63,10 +63,13 @@ export const sqlite3Pool = (
     ('client' in options && Boolean(options.client)) ||
     options.singleton === true;
 
+  const lifecycleOptions = extractLifecycleOptions(options);
+
   if (isSingleton) {
     return sqlite3SingletonPool<SQLite3Connection>({
       driverType: SQLite3DriverType,
       getConnection: () => sqliteConnectionFactory(options),
+      ...lifecycleOptions,
     });
   }
 
@@ -79,7 +82,21 @@ export const sqlite3Pool = (
     sqliteConnectionFactory,
     connectionOptions: options,
     ...(readerPoolSize !== undefined ? { readerPoolSize } : {}),
+    ...lifecycleOptions,
   });
+};
+
+const extractLifecycleOptions = (
+  options: SQLite3DumboOptions,
+): { maxTaskIdleTime?: number } => {
+  const lifecycle = options as {
+    maxTaskIdleTime?: number;
+  };
+  return {
+    ...(lifecycle.maxTaskIdleTime !== undefined
+      ? { maxTaskIdleTime: lifecycle.maxTaskIdleTime }
+      : {}),
+  };
 };
 
 const tryParseConnectionString = (connectionString: string) => {

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
@@ -20,6 +20,7 @@ export type SQLiteDualPoolOptions<
   pooled?: true;
   connection?: never;
   readerPoolSize?: number;
+  maxTaskIdleTime?: number;
   sqliteConnectionFactory: SQLiteConnectionFactory<
     SQLiteConnectionType,
     ConnectionOptions
@@ -90,6 +91,9 @@ export const sqliteDualConnectionPool = <
   const writerPool = sqlite3SingletonPool<SQLiteConnectionType>({
     driverType: options.driverType,
     getConnection: () => wrappedConnectionFactory(false, connectionOptions),
+    ...(options.maxTaskIdleTime !== undefined
+      ? { maxTaskIdleTime: options.maxTaskIdleTime }
+      : {}),
   });
 
   const readerPool = createBoundedConnectionPool({

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
@@ -2,9 +2,12 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   createSingletonConnectionPool,
   type ConnectionPool,
+  type PoolCloseOptions,
 } from '../../../../core';
 import { TaskProcessor } from '../../../../core/taskProcessing';
 import type { AnySQLiteConnection } from '../../core';
+
+export const DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS = 30_000;
 
 export type SQLite3SingletonPoolOptions<
   SQLiteConnectionType extends AnySQLiteConnection,
@@ -13,6 +16,7 @@ export type SQLite3SingletonPoolOptions<
   getConnection: () => SQLiteConnectionType | Promise<SQLiteConnectionType>;
   closeConnection?: (connection: SQLiteConnectionType) => void | Promise<void>;
   maxQueueSize?: number;
+  maxTaskIdleTime?: number;
 };
 
 // Creates a singleton-connection pool whose callers serialise through a
@@ -25,6 +29,9 @@ export const sqlite3SingletonPool = <
 >(
   options: SQLite3SingletonPoolOptions<SQLiteConnectionType>,
 ): ConnectionPool<SQLiteConnectionType> => {
+  const maxTaskIdleTime =
+    options.maxTaskIdleTime ?? DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS;
+
   const inner = createSingletonConnectionPool<SQLiteConnectionType>({
     driverType: options.driverType,
     getConnection: options.getConnection,
@@ -36,6 +43,7 @@ export const sqlite3SingletonPool = <
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: 1,
     maxQueueSize: options.maxQueueSize ?? 1000,
+    maxTaskIdleTime,
   });
   const insideWriterTask = new AsyncLocalStorage<true>();
 
@@ -72,9 +80,11 @@ export const sqlite3SingletonPool = <
       batchCommand: (sqls, commandOptions) =>
         enqueue(() => inner.execute.batchCommand(sqls, commandOptions)),
     },
-    close: async () => {
-      await taskProcessor.stop();
-      await inner.close();
+    close: async (closeOptions?: PoolCloseOptions) => {
+      await taskProcessor.stop({
+        ...(closeOptions?.force ? { force: true } : {}),
+      });
+      await inner.close(closeOptions);
     },
   };
 };


### PR DESCRIPTION
Ensured also that transaction options are correctly threaded

- D1 and PostgreSQL now use the shared transaction nesting counter from core.
- Connection pool close lifecycle improvements: closes tracked bounded-pool connections, rejects new operations after close, drains singleton/bounded

Taken changes from https://github.com/event-driven-io/Pongo/pull/186 excluding task processing changes.