### PR TITLE
Fixed issue with the sqlite3 transactions scopes reentrancy causing potentially deadlocks in inner scope

### DIFF
--- a/src/packages/dumbo/src/core/connections/pool.ts
+++ b/src/packages/dumbo/src/core/connections/pool.ts
@@ -198,16 +198,10 @@ export const createBoundedConnectionPool = <
 ): ConnectionPool<ConnectionType> => {
   const { driverType, maxConnections } = options;
 
-  const allConnections = new Set<ConnectionType>();
-  const getTrackedConnection = async () => {
-    const connection = await options.getConnection();
-    allConnections.add(connection);
-    return connection;
-  };
-
-  const guardMaxConnections = guardBoundedAccess(getTrackedConnection, {
+  const guardMaxConnections = guardBoundedAccess(options.getConnection, {
     maxResources: maxConnections,
     reuseResources: true,
+    closeResource: (connection) => connection.close(),
   });
 
   let closed = false;
@@ -219,22 +213,11 @@ export const createBoundedConnectionPool = <
     if (closed) throw closedError();
   };
 
-  const closeAllConnections = async () => {
-    const connections = [...allConnections];
-    allConnections.clear();
-    await Promise.all(connections.map((conn) => conn.close()));
-  };
-
   const executeWithPooling = async <Result>(
     operation: (conn: ConnectionType) => Promise<Result>,
   ): Promise<Result> => {
     ensureOpen();
-    const conn = await guardMaxConnections.acquire();
-    try {
-      return await operation(conn);
-    } finally {
-      guardMaxConnections.release(conn);
-    }
+    return guardMaxConnections.execute(operation);
   };
 
   return {
@@ -280,7 +263,6 @@ export const createBoundedConnectionPool = <
       }
 
       await guardMaxConnections.stop({ force: true });
-      await closeAllConnections();
     },
   };
 };

--- a/src/packages/dumbo/src/core/connections/transaction.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.ts
@@ -17,6 +17,12 @@ export interface DatabaseTransaction<
   begin: () => Promise<void>;
   commit: () => Promise<void>;
   rollback: (error?: unknown) => Promise<void>;
+  withTransaction: <Result = never>(
+    handle: (
+      transaction: DatabaseTransaction<ConnectionType, TransactionOptionsType>,
+    ) => Promise<TransactionResult<Result> | Result>,
+    options?: TransactionOptionsType,
+  ) => Promise<Result>;
   _transactionOptions: TransactionOptionsType;
 }
 
@@ -148,6 +154,18 @@ export interface WithDatabaseTransactionFactory<
 
 export type TransactionResult<Result> = { success: boolean; result: Result };
 
+type TransactionLifecycle = {
+  begin: () => Promise<void>;
+  commit: () => Promise<void>;
+  rollback: (error?: unknown) => Promise<void>;
+};
+
+type NestedTransactionLifecycle<
+  TransactionOptionsType extends DatabaseTransactionOptions,
+> = TransactionLifecycle & {
+  _transactionOptions: TransactionOptionsType;
+};
+
 const toTransactionResult = <Result>(
   transactionResult: TransactionResult<Result> | Result,
 ): TransactionResult<Result> =>
@@ -159,8 +177,7 @@ const toTransactionResult = <Result>(
     : { success: true, result: transactionResult };
 
 export const executeInTransaction = async <
-  DatabaseTransactionType extends AnyDatabaseTransaction =
-    AnyDatabaseTransaction,
+  DatabaseTransactionType extends TransactionLifecycle = TransactionLifecycle,
   Result = void,
 >(
   transaction: DatabaseTransactionType,
@@ -181,6 +198,35 @@ export const executeInTransaction = async <
     await transaction.rollback();
     throw e;
   }
+};
+
+export const executeInNestedTransaction = async <
+  TransactionOptionsType extends DatabaseTransactionOptions =
+    DatabaseTransactionOptions,
+  DatabaseTransactionType extends
+    NestedTransactionLifecycle<TransactionOptionsType> =
+    NestedTransactionLifecycle<TransactionOptionsType>,
+  Result = void,
+>(
+  transaction: DatabaseTransactionType,
+  handle: (
+    transaction: DatabaseTransactionType,
+  ) => Promise<TransactionResult<Result> | Result>,
+  options?: TransactionOptionsType,
+): Promise<Result> => {
+  const allowNestedTransactions =
+    options?.allowNestedTransactions ??
+    transaction._transactionOptions.allowNestedTransactions ??
+    false;
+
+  if (!allowNestedTransactions) {
+    throw new InvalidOperationError(
+      'Cannot start a nested transaction: allowNestedTransactions is false. ' +
+        'Set transactionOptions: { allowNestedTransactions: true } on your pool or connection.',
+    );
+  }
+
+  return executeInTransaction(transaction, handle);
 };
 
 export const transactionFactoryWithDbClient = <
@@ -363,7 +409,9 @@ export const transactionFactoryWithAsyncAmbientConnection = <
             if (conn) await close(conn);
           }
         },
-        _transactionOptions: undefined as unknown as DatabaseTransactionOptions,
+        withTransaction: (handle, options) =>
+          executeInNestedTransaction(tx, handle, options),
+        _transactionOptions: options ?? {},
       };
 
       return tx as InferTransactionFromConnection<ConnectionType>;

--- a/src/packages/dumbo/src/core/connections/transaction.unit.spec.ts
+++ b/src/packages/dumbo/src/core/connections/transaction.unit.spec.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert';
 import { describe, it } from 'vitest';
 import { InvalidOperationError } from '../errors';
-import { databaseTransaction, transactionNestingCounter } from './transaction';
+import {
+  databaseTransaction,
+  executeInNestedTransaction,
+  transactionNestingCounter,
+} from './transaction';
 
 describe('transactionNestingCounter', () => {
   it('starts at level 0', () => {
@@ -153,5 +157,22 @@ describe('databaseTransaction', () => {
     await tx.commit();
 
     assert.deepStrictEqual(calls, ['begin', 'commit']);
+  });
+});
+
+describe('executeInNestedTransaction', () => {
+  it('rejects when nested transactions are disabled on the transaction object', async () => {
+    const { backend } = makeBackend();
+    const tx = {
+      ...databaseTransaction(backend),
+      _transactionOptions: { allowNestedTransactions: false },
+    };
+
+    await assert.rejects(
+      () => executeInNestedTransaction(tx, () => Promise.resolve(undefined)),
+      (err) =>
+        err instanceof InvalidOperationError &&
+        /allowNestedTransactions/.test(err.message),
+    );
   });
 });

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.ts
@@ -9,10 +9,14 @@ export type ExclusiveAccessGuard = {
 
 export const guardExclusiveAccess = (options?: {
   maxQueueSize?: number;
+  maxTaskIdleTime?: number;
 }): ExclusiveAccessGuard => {
   const taskProcessor = new TaskProcessor({
     maxActiveTasks: 1,
     maxQueueSize: options?.maxQueueSize ?? 1000,
+    ...(options?.maxTaskIdleTime !== undefined
+      ? { maxTaskIdleTime: options.maxTaskIdleTime }
+      : {}),
   });
 
   return {
@@ -110,6 +114,8 @@ export const guardBoundedAccess = <Resource>(
     stop: async (stopOptions) => {
       if (isStopped) return;
       isStopped = true;
+      await taskProcessor.stop(stopOptions);
+
       if (options?.closeResource) {
         const resources = [...allResources];
         allResources.clear();
@@ -120,8 +126,6 @@ export const guardBoundedAccess = <Resource>(
           ),
         );
       }
-
-      await taskProcessor.stop(stopOptions);
     },
   };
 };

--- a/src/packages/dumbo/src/core/taskProcessing/executionGuards.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/executionGuards.unit.spec.ts
@@ -156,6 +156,28 @@ describe('Task Processing Guards', () => {
       );
     });
 
+    it('closes resources after active operations complete on stop', async () => {
+      const closedResources: number[] = [];
+      const guard = guardBoundedAccess(() => ({ id: 1 }), {
+        maxResources: 1,
+        reuseResources: true,
+        closeResource: (resource) => {
+          closedResources.push(resource.id);
+        },
+      });
+
+      const operationPromise = guard.execute(async (resource) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        assert.deepStrictEqual(closedResources, []);
+        return resource.id;
+      });
+
+      await guard.stop();
+
+      assert.strictEqual(await operationPromise, 1);
+      assert.deepStrictEqual(closedResources, [1]);
+    });
+
     it('stops and clears queue on stop with force', async () => {
       const guard = guardBoundedAccess(() => ({ id: 1 }), {
         maxResources: 1,

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.ts
@@ -5,6 +5,8 @@ export type TaskQueue = TaskQueueItem[];
 export type TaskQueueItem = {
   task: () => Promise<void>;
   options?: EnqueueTaskOptions | undefined;
+  reject: (reason?: unknown) => void;
+  markStarted: () => void;
 };
 
 export type TaskProcessorOptions = {
@@ -28,6 +30,7 @@ export class TaskProcessor {
   private activeGroups: Set<string> = new Set();
   private options: TaskProcessorOptions;
   private stopped = false;
+  private idleWaiters: Array<() => void> = [];
 
   constructor(options: TaskProcessorOptions) {
     this.options = options;
@@ -50,13 +53,22 @@ export class TaskProcessor {
   }
 
   waitForEndOfProcessing(): Promise<void> {
-    return this.schedule(({ ack }) => Promise.resolve(ack()));
+    if (this.activeTasks === 0 && this.queue.length === 0) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      this.idleWaiters.push(resolve);
+    });
   }
 
   async stop(options?: { force?: boolean }): Promise<void> {
     if (this.stopped) return;
     this.stopped = true;
-    this.queue.length = 0;
+    const stoppedError = new DumboError('TaskProcessor has been stopped');
+    for (const item of this.queue.splice(0)) {
+      item.reject(stoppedError);
+    }
     this.activeGroups.clear();
 
     if (!options?.force) {
@@ -65,29 +77,51 @@ export class TaskProcessor {
   }
 
   private schedule<T>(task: Task<T>, options?: EnqueueTaskOptions): Promise<T> {
-    return promiseWithDeadline(
-      (resolve, reject) => {
-        const taskWithContext = () => {
-          return new Promise<void>((resolveTask, failTask) => {
-            const taskPromise = task({
-              ack: resolveTask,
-            });
+    return new Promise<T>((resolve, reject) => {
+      let didQueueTimeout = false;
+      const queueWaitTimer = createQueueWaitTimer(
+        this.options.maxTaskIdleTime,
+        (reason) => {
+          didQueueTimeout = true;
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+          reject(reason);
+        },
+      );
 
-            taskPromise.then(resolve).catch((err) => {
-              // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-              failTask(err);
-              reject(err);
-            });
+      const taskWithContext = () => {
+        return new Promise<void>((resolveTask, failTask) => {
+          if (didQueueTimeout) {
+            resolveTask();
+            return;
+          }
+
+          const taskPromise = task({
+            ack: resolveTask,
           });
-        };
 
-        this.queue.push({ task: taskWithContext, options });
-        if (!this.isProcessing) {
-          this.ensureProcessing();
-        }
-      },
-      { deadline: this.options.maxTaskIdleTime },
-    );
+          taskPromise.then(resolve).catch((err) => {
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            failTask(err);
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            reject(err);
+          });
+        });
+      };
+
+      this.queue.push({
+        task: taskWithContext,
+        options,
+        reject: (reason) => {
+          queueWaitTimer.cancel();
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+          reject(reason);
+        },
+        markStarted: queueWaitTimer.cancel,
+      });
+      if (!this.isProcessing) {
+        this.ensureProcessing();
+      }
+    });
   }
 
   private ensureProcessing(): void {
@@ -130,7 +164,12 @@ export class TaskProcessor {
     }
   }
 
-  private async executeItem({ task, options }: TaskQueueItem): Promise<void> {
+  private async executeItem({
+    task,
+    options,
+    markStarted,
+  }: TaskQueueItem): Promise<void> {
+    markStarted();
     try {
       await task();
     } finally {
@@ -141,6 +180,7 @@ export class TaskProcessor {
         this.activeGroups.delete(options.taskGroupId);
       }
 
+      this.resolveIdleWaiters();
       this.ensureProcessing();
     }
   }
@@ -169,49 +209,35 @@ export class TaskProcessor {
         !item.options?.taskGroupId ||
         !this.activeGroups.has(item.options.taskGroupId),
     ) !== -1;
+
+  private resolveIdleWaiters = (): void => {
+    if (this.activeTasks > 0 || this.queue.length > 0) return;
+
+    const waiters = this.idleWaiters.splice(0);
+    for (const resolve of waiters) {
+      resolve();
+    }
+  };
 }
 
-const DEFAULT_PROMISE_DEADLINE = 2147483647;
+type QueueWaitTimer = { cancel: () => void };
 
-const promiseWithDeadline = <T>(
-  executor: (
-    resolve: (value: T | PromiseLike<T>) => void,
-    reject: (reason?: unknown) => void,
-  ) => void,
-  options: { deadline?: number | undefined },
-) => {
-  return new Promise<T>((resolve, reject) => {
-    let taskStarted = false;
-    let timeoutId: NodeJS.Timeout | null = null;
+const createQueueWaitTimer = (
+  timeoutMs: number | undefined,
+  reject: (reason: unknown) => void,
+): QueueWaitTimer => {
+  if (timeoutMs === undefined) return { cancel: () => {} };
 
-    const deadline = options.deadline ?? DEFAULT_PROMISE_DEADLINE;
+  let timeoutId: NodeJS.Timeout | null = setTimeout(() => {
+    reject(new Error('Task was not started within the maximum waiting time'));
+  }, timeoutMs);
+  timeoutId.unref();
 
-    timeoutId = setTimeout(() => {
-      if (!taskStarted) {
-        reject(
-          new Error('Task was not started within the maximum waiting time'),
-        );
-      }
-    }, deadline);
-    timeoutId.unref();
-
-    executor(
-      (value) => {
-        taskStarted = true;
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-        timeoutId = null;
-        resolve(value);
-      },
-      (reason) => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-        timeoutId = null;
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        reject(reason);
-      },
-    );
-  });
+  return {
+    cancel: () => {
+      if (!timeoutId) return;
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    },
+  };
 };

--- a/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
+++ b/src/packages/dumbo/src/core/taskProcessing/taskProcessor.unit.spec.ts
@@ -441,4 +441,115 @@ describe('TaskProcessor', () => {
       'Group 1 - Task 2',
     ]);
   });
+
+  it('rejects queued tasks on stop without orphaning promises', async () => {
+    const singleTaskProcessor = new TaskProcessor({
+      maxActiveTasks: 1,
+      maxQueueSize: 10,
+    });
+
+    let releaseActiveTask: () => void = () => {};
+    const activeTaskCanFinish = new Promise<void>((resolve) => {
+      releaseActiveTask = resolve;
+    });
+
+    const activeTask = singleTaskProcessor.enqueue(async ({ ack }) => {
+      await activeTaskCanFinish;
+      ack();
+      return 'active';
+    });
+
+    const queuedTask = singleTaskProcessor.enqueue(({ ack }) => {
+      ack();
+      return Promise.resolve('queued');
+    });
+
+    const stopPromise = singleTaskProcessor.stop();
+
+    await assert.rejects(queuedTask, /TaskProcessor has been stopped/);
+
+    releaseActiveTask();
+    await stopPromise;
+    await assert.doesNotReject(activeTask);
+  });
+
+  it('rejects queued tasks immediately on force stop', async () => {
+    const singleTaskProcessor = new TaskProcessor({
+      maxActiveTasks: 1,
+      maxQueueSize: 10,
+    });
+
+    let releaseActiveTask: () => void = () => {};
+    const activeTaskCanFinish = new Promise<void>((resolve) => {
+      releaseActiveTask = resolve;
+    });
+    const activeTask = singleTaskProcessor.enqueue(async ({ ack }) => {
+      await activeTaskCanFinish;
+      ack();
+      return 'active';
+    });
+
+    const queuedTask = singleTaskProcessor.enqueue(({ ack }) => {
+      ack();
+      return Promise.resolve('queued');
+    });
+
+    await singleTaskProcessor.stop({ force: true });
+
+    await assert.rejects(queuedTask, /TaskProcessor has been stopped/);
+    releaseActiveTask();
+    await assert.doesNotReject(activeTask);
+  });
+
+  it('does not reject an active task that runs longer than maxTaskIdleTime', async () => {
+    const singleTaskProcessor = new TaskProcessor({
+      maxActiveTasks: 1,
+      maxQueueSize: 10,
+      maxTaskIdleTime: 10,
+    });
+
+    await assert.doesNotReject(() =>
+      singleTaskProcessor.enqueue(async ({ ack }) => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        ack();
+        return 'active';
+      }),
+    );
+  });
+
+  it('does not run a queued task after maxTaskIdleTime rejects it', async () => {
+    const singleTaskProcessor = new TaskProcessor({
+      maxActiveTasks: 1,
+      maxQueueSize: 10,
+      maxTaskIdleTime: 10,
+    });
+
+    let releaseActiveTask: () => void = () => {};
+    const activeTaskCanFinish = new Promise<void>((resolve) => {
+      releaseActiveTask = resolve;
+    });
+    const activeTask = singleTaskProcessor.enqueue(async ({ ack }) => {
+      await activeTaskCanFinish;
+      ack();
+      return 'active';
+    });
+
+    let queuedTaskRan = false;
+    const queuedTask = singleTaskProcessor.enqueue(({ ack }) => {
+      queuedTaskRan = true;
+      ack();
+      return Promise.resolve('queued');
+    });
+
+    await assert.rejects(
+      queuedTask,
+      /Task was not started within the maximum waiting time/,
+    );
+
+    releaseActiveTask();
+    await activeTask;
+    await singleTaskProcessor.waitForEndOfProcessing();
+
+    assert.strictEqual(queuedTaskRan, false);
+  });
 });

--- a/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
+++ b/src/packages/dumbo/src/storage/postgresql/pg/connections/transaction.ts
@@ -1,5 +1,6 @@
 import {
   databaseTransaction,
+  executeInNestedTransaction,
   sqlExecutor,
   type AnyConnection,
   type DatabaseTransaction,
@@ -86,7 +87,7 @@ export const pgTransaction =
       { allowNestedTransactions, useSavepoints },
     );
 
-    return {
+    const transaction: DatabaseTransaction<ConnectionType> = {
       connection: connection(),
       driverType: PgDriverType,
       begin: tx.begin,
@@ -95,9 +96,13 @@ export const pgTransaction =
       execute: sqlExecutor(pgSQLExecutor({ serializer }), {
         connect: () => getClient,
       }),
+      withTransaction: (handle, options) =>
+        executeInNestedTransaction(transaction, handle, options),
       _transactionOptions: {
         ...(options ?? {}),
         allowNestedTransactions,
       },
     };
+
+    return transaction;
   };

--- a/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/connections/index.ts
@@ -195,7 +195,7 @@ export const sqliteAmbientClientConnection = <
         sqliteTransaction(
           driverType,
           connection,
-          allowNestedTransactions ?? false,
+          { allowNestedTransactions: allowNestedTransactions ?? false },
           serializer,
           defaultTransactionMode,
         )),
@@ -255,7 +255,7 @@ export const sqliteClientConnection = <
       sqliteTransaction(
         options.driverType,
         connection,
-        connectionOptions.transactionOptions?.allowNestedTransactions ?? false,
+        connectionOptions.transactionOptions ?? {},
         serializer,
         connectionOptions.defaultTransactionMode,
       ),
@@ -306,7 +306,7 @@ export const sqlitePoolClientConnection = <
       sqliteTransaction(
         options.driverType,
         connection,
-        connectionOptions.transactionOptions?.allowNestedTransactions ?? false,
+        connectionOptions.transactionOptions ?? {},
         serializer,
         connectionOptions.defaultTransactionMode,
       ),

--- a/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
+++ b/src/packages/dumbo/src/storage/sqlite/core/transactions/index.ts
@@ -4,6 +4,7 @@ import type {
 } from '../../../../core';
 import {
   databaseTransaction,
+  executeInNestedTransaction,
   SQL,
   sqlExecutor,
   type DatabaseTransaction,
@@ -33,7 +34,7 @@ export const sqliteTransaction =
   <ConnectionType extends AnySQLiteConnection = AnySQLiteConnection>(
     driverType: ConnectionType['driverType'],
     connection: () => ConnectionType,
-    allowNestedTransactions: boolean,
+    defaultOptions: boolean | SQLiteTransactionOptions,
     serializer: JSONSerializer,
     defaultTransactionMode?: 'IMMEDIATE' | 'DEFERRED' | 'EXCLUSIVE',
   ) =>
@@ -46,9 +47,18 @@ export const sqliteTransaction =
       ) => Promise<void>;
     } & SQLiteTransactionOptions,
   ): InferTransactionFromConnection<ConnectionType> => {
-    allowNestedTransactions =
-      options?.allowNestedTransactions ?? allowNestedTransactions;
-    const useSavepoints = options?.useSavepoints ?? false;
+    const defaultTransactionOptions =
+      typeof defaultOptions === 'boolean'
+        ? { allowNestedTransactions: defaultOptions }
+        : defaultOptions;
+    const allowNestedTransactions =
+      options?.allowNestedTransactions ??
+      defaultTransactionOptions.allowNestedTransactions ??
+      false;
+    const useSavepoints =
+      options?.useSavepoints ??
+      defaultTransactionOptions.useSavepoints ??
+      false;
 
     const tx = databaseTransaction(
       {
@@ -94,6 +104,12 @@ export const sqliteTransaction =
             SQL`RELEASE transaction${SQL.plain(level.toString())}`,
           );
         },
+        rollbackToSavepoint: async (level) => {
+          const client = (await getClient) as SQLiteClientOrPoolClient;
+          await client.command(
+            SQL`ROLLBACK TO transaction${SQL.plain(level.toString())}`,
+          );
+        },
       },
       { allowNestedTransactions, useSavepoints },
     );
@@ -107,6 +123,8 @@ export const sqliteTransaction =
       execute: sqlExecutor(sqliteSQLExecutor(driverType, serializer), {
         connect: () => getClient,
       }),
+      withTransaction: (handle, options) =>
+        executeInNestedTransaction(transaction, handle, options),
       _transactionOptions: {
         ...options,
         allowNestedTransactions,

--- a/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
+++ b/src/packages/dumbo/src/storage/sqlite/d1/transactions/d1Transaction.ts
@@ -1,5 +1,6 @@
 import type { JSONSerializer } from '../../../../core';
 import {
+  executeInNestedTransaction,
   sqlExecutor,
   transactionNestingCounter,
   type DatabaseTransaction,
@@ -66,7 +67,7 @@ export const d1Transaction =
       return client;
     };
 
-    return {
+    const transaction: D1Transaction = {
       connection: connection(),
       driverType: D1DriverType,
       begin: async function () {
@@ -126,6 +127,10 @@ export const d1Transaction =
           return Promise.resolve(sessionClient);
         },
       }),
+      withTransaction: (handle, options) =>
+        executeInNestedTransaction(transaction, handle, options),
       _transactionOptions: options ?? {},
     };
+
+    return transaction;
   };

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/connections/connection.ts
@@ -53,9 +53,6 @@ export type SQLite3ClientOptions = SQLiteClientOptions &
 
 export type SQLite3Client = SQLiteClientOrPoolClient;
 
-export type SQLite3ConnectionOptions = SQLiteConnectionOptions &
-  ((SQLite3ClientOptions & { client?: never }) | { client: SQLite3Client });
-
 export type SQLite3Connection<
   ClientType extends SQLiteClientOrPoolClient = SQLiteClientOrPoolClient,
 > = Connection<
@@ -64,6 +61,10 @@ export type SQLite3Connection<
   ClientType,
   SQLiteTransaction<SQLite3Connection, SQLiteTransactionOptions>
 >;
+
+export type SQLite3ConnectionOptions =
+  SQLiteConnectionOptions<SQLite3Connection> &
+    ((SQLite3ClientOptions & { client?: never }) | { client: SQLite3Client });
 
 const applyPragma = (
   database: sqlite3.Database,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.int.spec.ts
@@ -296,24 +296,27 @@ describe('SQLite Dual Connection Pool', () => {
     async () => {
       const parallelFileName = 'parallel-init-test.db';
 
-      const readPromises = Array.from({ length: 100 }, async (_, i) => {
-        const pool = sqlite3Pool({
-          fileName: parallelFileName,
+      try {
+        const readPromises = Array.from({ length: 100 }, async (_, i) => {
+          const pool = sqlite3Pool({
+            fileName: parallelFileName,
+          });
+
+          try {
+            return await pool.execute.query(SQL`SELECT ${i} as value`);
+          } catch (error) {
+            return error;
+          } finally {
+            await pool.close();
+          }
         });
 
-        try {
-          return await pool.execute.query(SQL`SELECT ${i} as value`);
-        } catch (error) {
-          return error;
-        } finally {
-          await pool.close();
-          cleanupDb(parallelFileName);
-        }
-      });
+        const results = await Promise.all(readPromises);
 
-      const results = await Promise.all(readPromises);
-
-      assert.equal(results.filter((r) => r instanceof Error).length, 0);
+        assert.equal(results.filter((r) => r instanceof Error).length, 0);
+      } finally {
+        cleanupDb(parallelFileName);
+      }
     },
   );
 
@@ -338,7 +341,7 @@ describe('SQLite Dual Connection Pool', () => {
             SQL`INSERT INTO test (value) VALUES ('outer')`,
           );
 
-          await pool.withTransaction(async (innerTx) => {
+          await outerTx.withTransaction(async (innerTx) => {
             await innerTx.execute.command(
               SQL`INSERT INTO test (value) VALUES ('inner')`,
             );
@@ -375,7 +378,7 @@ describe('SQLite Dual Connection Pool', () => {
               await outerTx.execute.command(
                 SQL`INSERT INTO test (value) VALUES ('outer')`,
               );
-              await pool.withTransaction(async (innerTx) => {
+              await outerTx.withTransaction(async (innerTx) => {
                 await innerTx.execute.command(
                   SQL`INSERT INTO test (value) VALUES ('inner')`,
                 );

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
@@ -8,7 +8,10 @@ import type {
   SQLitePool,
 } from '../../core';
 import { mapSqliteError } from '../../core/errors';
-import { sqlite3SingletonPool } from './singletonPool';
+import {
+  createSQLiteTransactionContext,
+  sqlite3SingletonPool,
+} from './singletonPool';
 
 export type SQLiteDualPoolOptions<
   SQLiteConnectionType extends AnySQLiteConnection,
@@ -36,6 +39,8 @@ export const sqliteDualConnectionPool = <
 ): SQLitePool<SQLiteConnectionType> => {
   const { sqliteConnectionFactory, connectionOptions } = options;
   const readerPoolSize = options.readerPoolSize ?? Math.max(4, cpus().length);
+  const transactionContext =
+    createSQLiteTransactionContext<SQLiteConnectionType>();
 
   let databaseInitPromise: Promise<void> | null = null;
 
@@ -91,6 +96,7 @@ export const sqliteDualConnectionPool = <
   const writerPool = sqlite3SingletonPool<SQLiteConnectionType>({
     driverType: options.driverType,
     getConnection: () => wrappedConnectionFactory(false, connectionOptions),
+    ...(transactionContext ? { transactionContext } : {}),
     ...(options.maxTaskIdleTime !== undefined
       ? { maxTaskIdleTime: options.maxTaskIdleTime }
       : {}),
@@ -102,20 +108,28 @@ export const sqliteDualConnectionPool = <
     maxConnections: readerPoolSize,
   });
 
+  const hasActiveTransaction = () => !!transactionContext?.current();
+
   return {
     driverType: options.driverType,
     connection: (connectionOptions) =>
-      connectionOptions?.readonly
+      connectionOptions?.readonly && !hasActiveTransaction()
         ? readerPool.connection(connectionOptions)
         : writerPool.connection(connectionOptions),
     execute: {
-      query: (...args) => readerPool.execute.query(...args),
-      batchQuery: (...args) => readerPool.execute.batchQuery(...args),
+      query: (...args) =>
+        hasActiveTransaction()
+          ? writerPool.execute.query(...args)
+          : readerPool.execute.query(...args),
+      batchQuery: (...args) =>
+        hasActiveTransaction()
+          ? writerPool.execute.batchQuery(...args)
+          : readerPool.execute.batchQuery(...args),
       command: (...args) => writerPool.execute.command(...args),
       batchCommand: (...args) => writerPool.execute.batchCommand(...args),
     },
     withConnection: (handle, connectionOptions) =>
-      connectionOptions?.readonly
+      connectionOptions?.readonly && !hasActiveTransaction()
         ? readerPool.withConnection(handle, connectionOptions)
         : writerPool.withConnection(handle, connectionOptions),
     transaction: writerPool.transaction,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
@@ -1,13 +1,46 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   createSingletonConnectionPool,
+  type WithDatabaseTransactionFactory,
   type ConnectionPool,
+  type InferTransactionFromConnection,
+  type InferTransactionOptionsFromConnection,
   type PoolCloseOptions,
+  type TransactionResult,
 } from '../../../../core';
-import { TaskProcessor } from '../../../../core/taskProcessing';
+import { guardExclusiveAccess } from '../../../../core/taskProcessing';
 import type { AnySQLiteConnection } from '../../core';
 
 export const DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS = 30_000;
+
+export type SQLiteActiveTransaction<SQLiteConnectionType> = {
+  connection: SQLiteConnectionType;
+};
+
+export type SQLiteTransactionContext<SQLiteConnectionType> = {
+  current: () => SQLiteActiveTransaction<SQLiteConnectionType> | undefined;
+  run: <Result>(
+    active: SQLiteActiveTransaction<SQLiteConnectionType>,
+    handle: () => Promise<Result>,
+  ) => Promise<Result>;
+};
+
+export const createSQLiteTransactionContext = <
+  SQLiteConnectionType extends AnySQLiteConnection,
+>(): SQLiteTransactionContext<SQLiteConnectionType> | undefined => {
+  if (typeof process === 'undefined') return undefined;
+
+  const asyncHooks = process.getBuiltinModule?.('node:async_hooks');
+  if (!asyncHooks) return undefined;
+
+  const context = new asyncHooks.AsyncLocalStorage<
+    SQLiteActiveTransaction<SQLiteConnectionType>
+  >();
+
+  return {
+    current: () => context.getStore(),
+    run: (active, handle) => context.run(active, handle),
+  };
+};
 
 export type SQLite3SingletonPoolOptions<
   SQLiteConnectionType extends AnySQLiteConnection,
@@ -17,21 +50,14 @@ export type SQLite3SingletonPoolOptions<
   closeConnection?: (connection: SQLiteConnectionType) => void | Promise<void>;
   maxQueueSize?: number;
   maxTaskIdleTime?: number;
+  transactionContext?: SQLiteTransactionContext<SQLiteConnectionType>;
 };
 
-// Creates a singleton-connection pool whose callers serialise through a
-// single-slot TaskProcessor. An AsyncLocalStorage flag lets re-entrant calls
-// (made from inside an active task on this pool) bypass the queue instead of
-// deadlocking — that's the path emmett relies on when a workflow handler
-// internally calls back through the same pool (e.g. messageStore.appendToStream).
 export const sqlite3SingletonPool = <
   SQLiteConnectionType extends AnySQLiteConnection,
 >(
   options: SQLite3SingletonPoolOptions<SQLiteConnectionType>,
 ): ConnectionPool<SQLiteConnectionType> => {
-  const maxTaskIdleTime =
-    options.maxTaskIdleTime ?? DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS;
-
   const inner = createSingletonConnectionPool<SQLiteConnectionType>({
     driverType: options.driverType,
     getConnection: options.getConnection,
@@ -39,49 +65,110 @@ export const sqlite3SingletonPool = <
       ? { closeConnection: options.closeConnection }
       : {}),
   });
-
-  const taskProcessor = new TaskProcessor({
-    maxActiveTasks: 1,
+  const writerGuard = guardExclusiveAccess({
     maxQueueSize: options.maxQueueSize ?? 1000,
-    maxTaskIdleTime,
+    maxTaskIdleTime:
+      options.maxTaskIdleTime ?? DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS,
   });
-  const insideWriterTask = new AsyncLocalStorage<true>();
+  const transactionContext =
+    options.transactionContext ?? createSQLiteTransactionContext();
 
-  const enqueue = <Result>(op: () => Promise<Result>): Promise<Result> => {
-    if (insideWriterTask.getStore() === true) {
-      return op();
-    }
-    return taskProcessor.enqueue(({ ack }) =>
-      insideWriterTask.run(true, async () => {
-        try {
-          return await op();
-        } finally {
-          ack();
+  const activeConnection = (): SQLiteConnectionType | undefined =>
+    transactionContext?.current()?.connection;
+
+  const runInTransactionContext = <Result>(
+    connection: SQLiteConnectionType,
+    operation: () => Promise<Result>,
+  ): Promise<Result> =>
+    transactionContext
+      ? transactionContext.run({ connection }, operation)
+      : operation();
+
+  const transactionAwareConnection = (
+    connection: SQLiteConnectionType,
+  ): SQLiteConnectionType =>
+    transactionContext
+      ? {
+          ...connection,
+          withTransaction: (handle, transactionOptions) =>
+            runInTransactionContext(connection, () =>
+              connection.withTransaction(handle, transactionOptions),
+            ),
         }
-      }),
-    );
+      : connection;
+
+  const runConnectionTransaction = <Result>(
+    connection: SQLiteConnectionType,
+    handle: (
+      transaction: InferTransactionFromConnection<SQLiteConnectionType>,
+    ) => Promise<TransactionResult<Result> | Result>,
+    transactionOptions?: InferTransactionOptionsFromConnection<SQLiteConnectionType>,
+  ): Promise<Result> => {
+    const withTransaction =
+      connection.withTransaction as WithDatabaseTransactionFactory<SQLiteConnectionType>['withTransaction'];
+    return withTransaction<Result>(handle, transactionOptions);
   };
+
+  const runOnWriterConnection = <Result>(
+    handle: (connection: SQLiteConnectionType) => Promise<Result>,
+  ): Promise<Result> => {
+    const connection = activeConnection();
+    if (connection) return handle(connection);
+
+    return writerGuard.execute(() => inner.withConnection(handle));
+  };
+
+  const withWriterConnection = <Result>(
+    handle: (connection: SQLiteConnectionType) => Promise<Result>,
+  ): Promise<Result> =>
+    runOnWriterConnection((connection) =>
+      handle(transactionAwareConnection(connection)),
+    );
 
   return {
     driverType: inner.driverType,
     connection: inner.connection.bind(inner),
     transaction: inner.transaction.bind(inner),
     withConnection: (handle, connectionOptions) =>
-      enqueue(() => inner.withConnection(handle, connectionOptions)),
-    withTransaction: (handle, transactionOptions) =>
-      enqueue(() => inner.withTransaction(handle, transactionOptions)),
+      activeConnection() || !connectionOptions?.readonly
+        ? withWriterConnection(handle)
+        : inner.withConnection(handle, connectionOptions),
+    withTransaction: (handle, transactionOptions) => {
+      const connection = activeConnection();
+      if (connection) {
+        return runConnectionTransaction(connection, handle, transactionOptions);
+      }
+
+      return runOnWriterConnection((connection) =>
+        runInTransactionContext(connection, () =>
+          runConnectionTransaction(connection, handle, transactionOptions),
+        ),
+      );
+    },
     execute: {
-      query: (sql, queryOptions) =>
-        enqueue(() => inner.execute.query(sql, queryOptions)),
-      batchQuery: (sqls, queryOptions) =>
-        enqueue(() => inner.execute.batchQuery(sqls, queryOptions)),
+      query: (sql, queryOptions) => {
+        const connection = activeConnection();
+        return connection
+          ? connection.execute.query(sql, queryOptions)
+          : inner.execute.query(sql, queryOptions);
+      },
+      batchQuery: (sqls, queryOptions) => {
+        const connection = activeConnection();
+        return connection
+          ? connection.execute.batchQuery(sqls, queryOptions)
+          : inner.execute.batchQuery(sqls, queryOptions);
+      },
       command: (sql, commandOptions) =>
-        enqueue(() => inner.execute.command(sql, commandOptions)),
+        runOnWriterConnection((connection) =>
+          connection.execute.command(sql, commandOptions),
+        ),
       batchCommand: (sqls, commandOptions) =>
-        enqueue(() => inner.execute.batchCommand(sqls, commandOptions)),
+        runOnWriterConnection((connection) =>
+          connection.execute.batchCommand(sqls, commandOptions),
+        ),
     },
     close: async (closeOptions?: PoolCloseOptions) => {
-      await taskProcessor.stop({
+      await writerGuard.stop({
         ...(closeOptions?.force ? { force: true } : {}),
       });
       await inner.close(closeOptions);

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/transactions/transactions.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/transactions/transactions.int.spec.ts
@@ -88,13 +88,13 @@ describe('SQLite3 Transactions', () => {
           );
 
           await pool.withTransaction(async (outerTx) => {
-            await pool.withTransaction(async (innerTx) => {
+            await outerTx.withTransaction(async (innerTx) => {
               await innerTx.execute.command(
                 SQL`INSERT INTO test_table (id, value) VALUES (1, 'first')`,
               );
             });
 
-            await pool.withTransaction(async (innerTx) => {
+            await outerTx.withTransaction(async (innerTx) => {
               await innerTx.execute.command(
                 SQL`INSERT INTO test_table (id, value) VALUES (2, 'second')`,
               );
@@ -552,7 +552,67 @@ describe('SQLite3 Transactions', () => {
         }
       });
 
-      it(`keeps a plain command outside of an open transaction with ${testName} database`, async () => {
+      it(`does not let concurrent withTransaction callbacks overlap with ${testName} database`, async () => {
+        const pool = sqlite3Pool({
+          fileName,
+          transactionOptions: { allowNestedTransactions: true },
+        });
+
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE transaction_overlap (id INTEGER PRIMARY KEY, value TEXT)`,
+          );
+
+          let releaseFirstTransaction: () => void = () => {};
+          let firstTransactionEntered: () => void = () => {};
+          const firstCanFinish = new Promise<void>((resolve) => {
+            releaseFirstTransaction = resolve;
+          });
+          const firstEntered = new Promise<void>((resolve) => {
+            firstTransactionEntered = resolve;
+          });
+
+          const entered: string[] = [];
+
+          const first = pool.withTransaction(async (tx) => {
+            entered.push('first');
+            firstTransactionEntered();
+            await tx.execute.command(
+              SQL`INSERT INTO transaction_overlap (id, value) VALUES (1, 'first')`,
+            );
+            await firstCanFinish;
+          });
+
+          await firstEntered;
+
+          const second = pool.withTransaction(async (tx) => {
+            entered.push('second');
+            await tx.execute.command(
+              SQL`INSERT INTO transaction_overlap (id, value) VALUES (2, 'second')`,
+            );
+          });
+
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          assert.deepStrictEqual(entered, ['first']);
+
+          releaseFirstTransaction();
+          await Promise.all([first, second]);
+
+          assert.deepStrictEqual(entered, ['first', 'second']);
+
+          const rows = await pool.execute.query<{ id: number }>(
+            SQL`SELECT id FROM transaction_overlap ORDER BY id`,
+          );
+          assert.deepStrictEqual(
+            rows.rows.map((row) => row.id),
+            [1, 2],
+          );
+        } finally {
+          await pool.close();
+        }
+      });
+
+      it(`keeps a root-pool write inside the active transaction callback with ${testName} database`, async () => {
         const pool = sqlite3Pool({
           fileName,
           transactionOptions: { allowNestedTransactions: true },
@@ -563,18 +623,55 @@ describe('SQLite3 Transactions', () => {
             SQL`CREATE TABLE plain_isolation (id INTEGER PRIMARY KEY, value TEXT)`,
           );
 
+          await assert.rejects(
+            () =>
+              pool.withTransaction(async (tx) => {
+                await tx.execute.command(
+                  SQL`INSERT INTO plain_isolation (id, value) VALUES (1, 'tx-row')`,
+                );
+                await Promise.resolve();
+                await pool.execute.command(
+                  SQL`INSERT INTO plain_isolation (id, value) VALUES (2, 'plain-row')`,
+                );
+                throw new Error('tx intentional rollback');
+              }),
+            /tx intentional rollback/,
+          );
+
+          const rows = await pool.execute.query<{
+            id: number;
+            value: string;
+          }>(SQL`SELECT id, value FROM plain_isolation ORDER BY id`);
+
+          assert.deepStrictEqual(rows.rows, []);
+        } finally {
+          await pool.close();
+        }
+      });
+
+      it(`queues a root-pool write started outside the active transaction callback with ${testName} database`, async () => {
+        const pool = sqlite3Pool({
+          fileName,
+          transactionOptions: { allowNestedTransactions: true },
+        });
+
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE parallel_plain_isolation (id INTEGER PRIMARY KEY, value TEXT)`,
+          );
+
           let releaseTx: () => void = () => {};
           let plainMayStart: () => void = () => {};
-          const txMayProceed = new Promise<void>((r) => {
-            releaseTx = r;
+          const txMayProceed = new Promise<void>((resolve) => {
+            releaseTx = resolve;
           });
-          const plainCanStart = new Promise<void>((r) => {
-            plainMayStart = r;
+          const plainCanStart = new Promise<void>((resolve) => {
+            plainMayStart = resolve;
           });
 
           const txPromise = pool.withTransaction(async (tx) => {
             await tx.execute.command(
-              SQL`INSERT INTO plain_isolation (id, value) VALUES (1, 'tx-row')`,
+              SQL`INSERT INTO parallel_plain_isolation (id, value) VALUES (1, 'tx-row')`,
             );
             plainMayStart();
             await txMayProceed;
@@ -583,24 +680,21 @@ describe('SQLite3 Transactions', () => {
 
           await plainCanStart;
 
-          const plainPromise = pool.execute.command(
-            SQL`INSERT INTO plain_isolation (id, value) VALUES (2, 'plain-row')`,
+          const plainWritePromise = pool.execute.command(
+            SQL`INSERT INTO parallel_plain_isolation (id, value) VALUES (2, 'plain-row')`,
           );
 
           releaseTx();
 
           await assert.rejects(txPromise, /tx intentional rollback/);
-          await plainPromise;
+          await plainWritePromise;
 
           const rows = await pool.execute.query<{
             id: number;
             value: string;
-          }>(SQL`SELECT id, value FROM plain_isolation ORDER BY id`);
+          }>(SQL`SELECT id, value FROM parallel_plain_isolation ORDER BY id`);
 
-          assert.deepStrictEqual(
-            rows.rows.map((r) => r.value),
-            ['plain-row'],
-          );
+          assert.deepStrictEqual(rows.rows, [{ id: 2, value: 'plain-row' }]);
         } finally {
           await pool.close();
         }
@@ -653,10 +747,85 @@ describe('SQLite3 Transactions', () => {
         }
       });
 
-      // Reentrancy: a writer-bound call from inside an already-active writer
-      // task (same async stack) must bypass the queue instead of deadlocking.
-      // These tests exercise the patterns emmett relies on (workflow processor
-      // calling messageStore.appendToStream inside its tx handler).
+      it(`treats nested rollback as a no-op without savepoints with ${testName} database`, async () => {
+        const pool = sqlite3Pool({
+          fileName,
+          transactionOptions: { allowNestedTransactions: true },
+        });
+
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE nested_no_savepoints (id INTEGER PRIMARY KEY)`,
+          );
+
+          await pool.withTransaction(async (tx) => {
+            await tx.execute.command(
+              SQL`INSERT INTO nested_no_savepoints (id) VALUES (1)`,
+            );
+            await tx.withTransaction(async (nestedTx) => {
+              await nestedTx.execute.command(
+                SQL`INSERT INTO nested_no_savepoints (id) VALUES (2)`,
+              );
+              return { success: false, result: undefined };
+            });
+            await tx.execute.command(
+              SQL`INSERT INTO nested_no_savepoints (id) VALUES (3)`,
+            );
+          });
+
+          const rows = await pool.execute.query<{ id: number }>(
+            SQL`SELECT id FROM nested_no_savepoints ORDER BY id`,
+          );
+          assert.deepStrictEqual(
+            rows.rows.map((row) => row.id),
+            [1, 2, 3],
+          );
+        } finally {
+          await pool.close();
+        }
+      });
+
+      it(`rolls back only nested work when savepoints are enabled with ${testName} database`, async () => {
+        const pool = sqlite3Pool({
+          fileName,
+          transactionOptions: {
+            allowNestedTransactions: true,
+            useSavepoints: true,
+          },
+        });
+
+        try {
+          await pool.execute.command(
+            SQL`CREATE TABLE nested_savepoints (id INTEGER PRIMARY KEY)`,
+          );
+
+          await pool.withTransaction(async (tx) => {
+            await tx.execute.command(
+              SQL`INSERT INTO nested_savepoints (id) VALUES (1)`,
+            );
+            await tx.withTransaction(async (nestedTx) => {
+              await nestedTx.execute.command(
+                SQL`INSERT INTO nested_savepoints (id) VALUES (2)`,
+              );
+              return { success: false, result: undefined };
+            });
+            await tx.execute.command(
+              SQL`INSERT INTO nested_savepoints (id) VALUES (3)`,
+            );
+          });
+
+          const rows = await pool.execute.query<{ id: number }>(
+            SQL`SELECT id FROM nested_savepoints ORDER BY id`,
+          );
+          assert.deepStrictEqual(
+            rows.rows.map((row) => row.id),
+            [1, 3],
+          );
+        } finally {
+          await pool.close();
+        }
+      });
+
       it(
         `allows pool.withConnection reentry from inside pool.withTransaction with ${testName} database`,
         { timeout: 5000 },
@@ -728,7 +897,7 @@ describe('SQLite3 Transactions', () => {
       );
 
       it(
-        `allows nested pool.withTransaction reentry with ${testName} database`,
+        `allows nested tx.withTransaction with ${testName} database`,
         { timeout: 5000 },
         async () => {
           const pool = sqlite3Pool({
@@ -746,7 +915,7 @@ describe('SQLite3 Transactions', () => {
                 SQL`INSERT INTO reentry_nested_tx (id, value) VALUES (1, 'outer')`,
               );
 
-              await pool.withTransaction(async (innerTx) => {
+              await outerTx.withTransaction(async (innerTx) => {
                 await innerTx.execute.command(
                   SQL`INSERT INTO reentry_nested_tx (id, value) VALUES (2, 'inner')`,
                 );
@@ -763,13 +932,8 @@ describe('SQLite3 Transactions', () => {
         },
       );
 
-      // Mirrors the emmett workflow scenario: outer pool.withConnection holds
-      // the writer, the workflow opens connection.withTransaction on it, then
-      // an inner messageStore.appendToStream re-enters pool.withConnection,
-      // which itself opens connection.withTransaction. That's the exact stack
-      // that deadlocked the LLMAgentWorkflow.
       it(
-        `survives nested pool.withConnection inside connection.withTransaction with ${testName} database`,
+        `allows nested pool.withConnection inside connection.withTransaction with ${testName} database`,
         { timeout: 5000 },
         async () => {
           const pool = sqlite3Pool({


### PR DESCRIPTION
This will avoid weird scenarios when concurrent transactions are opened and could interfere with each other.

Also refactored the connection pool to simplify handling.

Relates to https://github.com/event-driven-io/Pongo/pull/186