### PR TITLE
Fixed sqlite3 connection reentrancy issues for nested connections

### DIFF
--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/dualPool.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../core';
 import { mapSqliteError } from '../../core/errors';
 import {
-  createSQLiteTransactionContext,
+  createSQLiteConnectionContext,
   sqlite3SingletonPool,
 } from './singletonPool';
 
@@ -42,8 +42,8 @@ export const sqliteDualConnectionPool = <
 ): SQLitePool<SQLiteConnectionType> => {
   const { sqliteConnectionFactory, connectionOptions } = options;
   const readerPoolSize = options.readerPoolSize ?? Math.max(4, cpus().length);
-  const transactionContext =
-    createSQLiteTransactionContext<SQLiteConnectionType>();
+  const connectionContext =
+    createSQLiteConnectionContext<SQLiteConnectionType>();
 
   let databaseInitPromise: Promise<void> | null = null;
 
@@ -103,7 +103,7 @@ export const sqliteDualConnectionPool = <
     driverType: options.driverType,
     getConnection: (context) =>
       wrappedConnectionFactory(false, connectionOptions, context),
-    ...(transactionContext ? { transactionContext } : {}),
+    ...(connectionContext ? { connectionContext } : {}),
     ...(options.maxTaskIdleTime !== undefined
       ? { maxTaskIdleTime: options.maxTaskIdleTime }
       : {}),
@@ -116,28 +116,28 @@ export const sqliteDualConnectionPool = <
     maxConnections: readerPoolSize,
   });
 
-  const hasActiveTransaction = () => !!transactionContext?.current();
+  const hasActiveConnection = () => !!connectionContext?.current();
 
   return {
     driverType: options.driverType,
     connection: (connectionOptions) =>
-      connectionOptions?.readonly && !hasActiveTransaction()
+      connectionOptions?.readonly && !hasActiveConnection()
         ? readerPool.connection(connectionOptions)
         : writerPool.connection(connectionOptions),
     execute: {
       query: (...args) =>
-        hasActiveTransaction()
+        hasActiveConnection()
           ? writerPool.execute.query(...args)
           : readerPool.execute.query(...args),
       batchQuery: (...args) =>
-        hasActiveTransaction()
+        hasActiveConnection()
           ? writerPool.execute.batchQuery(...args)
           : readerPool.execute.batchQuery(...args),
       command: (...args) => writerPool.execute.command(...args),
       batchCommand: (...args) => writerPool.execute.batchCommand(...args),
     },
     withConnection: (handle, connectionOptions) =>
-      connectionOptions?.readonly && !hasActiveTransaction()
+      connectionOptions?.readonly && !hasActiveConnection()
         ? readerPool.withConnection(handle, connectionOptions)
         : writerPool.withConnection(handle, connectionOptions),
     transaction: writerPool.transaction,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/poolReentrancy.int.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/poolReentrancy.int.spec.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert';
+import * as fs from 'node:fs';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import { SQL } from '../../../../core';
+import { sqlite3Pool, type Sqlite3Pool } from '../../sqlite3';
+
+const withDeadline = { timeout: 30000 };
+
+const beforeDeadline = async <Result>(
+  work: Promise<Result>,
+  ms = 1000,
+): Promise<Result | 'timed out'> => {
+  let timeoutId: NodeJS.Timeout | undefined;
+
+  try {
+    return await Promise.race([
+      work,
+      new Promise<'timed out'>((resolve) => {
+        timeoutId = setTimeout(() => resolve('timed out'), ms);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+};
+
+describe('SQLite pool reentrancy', () => {
+  const fileName = 'reentrancy-test.db';
+
+  const cleanupDb = (file: string) => {
+    try {
+      fs.unlinkSync(file);
+      fs.unlinkSync(`${file}-shm`);
+      fs.unlinkSync(`${file}-wal`);
+    } catch {
+      // ignore
+    }
+  };
+
+  beforeAll(() => cleanupDb(fileName));
+  afterAll(() => cleanupDb(fileName));
+
+  const poolShapes: [string, () => Sqlite3Pool][] = [
+    ['singleton pool (in-memory)', () => sqlite3Pool({ fileName: ':memory:' })],
+    ['dual pool (file-backed)', () => sqlite3Pool({ fileName })],
+  ];
+
+  for (const [shape, createPool] of poolShapes) {
+    describe(shape, () => {
+      it(
+        'runs a query on a connection acquired inside another connection',
+        withDeadline,
+        async () => {
+          const pool = createPool();
+
+          try {
+            const result = await beforeDeadline(
+              pool.withConnection(() =>
+                pool.withConnection((connection) =>
+                  connection.execute.query(SQL`SELECT 1 AS one`),
+                ),
+              ),
+            );
+
+            assert.notStrictEqual(result, 'timed out');
+          } finally {
+            await pool.close();
+          }
+        },
+      );
+
+      it(
+        'runs a transaction opened inside a connection',
+        withDeadline,
+        async () => {
+          const pool = createPool();
+
+          try {
+            const result = await beforeDeadline(
+              pool.withConnection(() =>
+                pool.withTransaction(() =>
+                  Promise.resolve({ success: true as const, result: 'done' }),
+                ),
+              ),
+            );
+
+            assert.strictEqual(result, 'done');
+          } finally {
+            await pool.close();
+          }
+        },
+      );
+
+      it(
+        'runs a query on a connection acquired inside a transaction',
+        withDeadline,
+        async () => {
+          const pool = createPool();
+
+          try {
+            const result = await beforeDeadline(
+              pool.withTransaction(() =>
+                pool
+                  .withConnection((connection) =>
+                    connection.execute.query(SQL`SELECT 1 AS one`),
+                  )
+                  .then((result) => ({ success: true as const, result })),
+              ),
+            );
+
+            assert.notStrictEqual(result, 'timed out');
+          } finally {
+            await pool.close();
+          }
+        },
+      );
+    });
+  }
+});

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.ts
@@ -14,28 +14,28 @@ import type { AnySQLiteConnection } from '../../core';
 
 export const DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS = 30_000;
 
-export type SQLiteActiveTransaction<SQLiteConnectionType> = {
+export type SQLiteActiveConnection<SQLiteConnectionType> = {
   connection: SQLiteConnectionType;
 };
 
-export type SQLiteTransactionContext<SQLiteConnectionType> = {
-  current: () => SQLiteActiveTransaction<SQLiteConnectionType> | undefined;
+export type SQLiteConnectionContext<SQLiteConnectionType> = {
+  current: () => SQLiteActiveConnection<SQLiteConnectionType> | undefined;
   run: <Result>(
-    active: SQLiteActiveTransaction<SQLiteConnectionType>,
+    active: SQLiteActiveConnection<SQLiteConnectionType>,
     handle: () => Promise<Result>,
   ) => Promise<Result>;
 };
 
-export const createSQLiteTransactionContext = <
+export const createSQLiteConnectionContext = <
   SQLiteConnectionType extends AnySQLiteConnection,
->(): SQLiteTransactionContext<SQLiteConnectionType> | undefined => {
+>(): SQLiteConnectionContext<SQLiteConnectionType> | undefined => {
   if (typeof process === 'undefined') return undefined;
 
   const asyncHooks = process.getBuiltinModule?.('node:async_hooks');
   if (!asyncHooks) return undefined;
 
   const context = new asyncHooks.AsyncLocalStorage<
-    SQLiteActiveTransaction<SQLiteConnectionType>
+    SQLiteActiveConnection<SQLiteConnectionType>
   >();
 
   return {
@@ -54,7 +54,7 @@ export type SQLite3SingletonPoolOptions<
   closeConnection?: (connection: SQLiteConnectionType) => void | Promise<void>;
   maxQueueSize?: number;
   maxTaskIdleTime?: number;
-  transactionContext?: SQLiteTransactionContext<SQLiteConnectionType>;
+  connectionContext?: SQLiteConnectionContext<SQLiteConnectionType>;
 };
 
 export const sqlite3SingletonPool = <
@@ -74,28 +74,28 @@ export const sqlite3SingletonPool = <
     maxTaskIdleTime:
       options.maxTaskIdleTime ?? DEFAULT_SQLITE_MAX_TASK_IDLE_TIME_MS,
   });
-  const transactionContext =
-    options.transactionContext ?? createSQLiteTransactionContext();
+  const connectionContext =
+    options.connectionContext ?? createSQLiteConnectionContext();
 
   const activeConnection = (): SQLiteConnectionType | undefined =>
-    transactionContext?.current()?.connection;
+    connectionContext?.current()?.connection;
 
-  const runInTransactionContext = <Result>(
+  const runInConnectionContext = <Result>(
     connection: SQLiteConnectionType,
     operation: () => Promise<Result>,
   ): Promise<Result> =>
-    transactionContext
-      ? transactionContext.run({ connection }, operation)
+    connectionContext
+      ? connectionContext.run({ connection }, operation)
       : operation();
 
   const transactionAwareConnection = (
     connection: SQLiteConnectionType,
   ): SQLiteConnectionType =>
-    transactionContext
+    connectionContext
       ? {
           ...connection,
           withTransaction: (handle, transactionOptions) =>
-            runInTransactionContext(connection, () =>
+            runInConnectionContext(connection, () =>
               connection.withTransaction(handle, transactionOptions),
             ),
         }
@@ -152,7 +152,9 @@ export const sqlite3SingletonPool = <
   ): Promise<Result> =>
     runOnWriterConnection(
       (connection, context) =>
-        handle(transactionAwareConnection(connection), context),
+        runInConnectionContext(connection, () =>
+          handle(transactionAwareConnection(connection), context),
+        ),
       options,
     );
 
@@ -181,7 +183,7 @@ export const sqlite3SingletonPool = <
 
       return runOnWriterConnection(
         (connection, context) =>
-          runInTransactionContext(connection, () =>
+          runInConnectionContext(connection, () =>
             runConnectionTransaction(
               connection,
               handle,

--- a/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.unit.spec.ts
+++ b/src/packages/dumbo/src/storage/sqlite/sqlite3/pool/singletonPool.unit.spec.ts
@@ -22,8 +22,36 @@ const fakeConnection = (
     },
     open: () => Promise.resolve(undefined),
     transaction: () => undefined,
-    withTransaction: () => Promise.resolve(undefined),
+    withTransaction: async (
+      handle: (transaction: unknown) => Promise<unknown>,
+    ) => {
+      const result = await handle({});
+
+      return result !== null &&
+        typeof result === 'object' &&
+        'success' in result
+        ? (result as unknown as { result: unknown }).result
+        : result;
+    },
   }) as unknown as SQLite3Connection;
+
+const withDeadline = async <Result>(
+  work: Promise<Result>,
+  ms = 500,
+): Promise<Result | 'timed out'> => {
+  let timeoutId: NodeJS.Timeout | undefined;
+
+  try {
+    return await Promise.race([
+      work,
+      new Promise<'timed out'>((resolve) => {
+        timeoutId = setTimeout(() => resolve('timed out'), ms);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+};
 
 describe('sqlite3SingletonPool', () => {
   it('does not start queued writer work when the caller aborts while waiting', async () => {
@@ -62,5 +90,69 @@ describe('sqlite3SingletonPool', () => {
     await pool.close();
 
     assert.strictEqual(commandCallCount, 1);
+  });
+
+  describe('reentrancy', () => {
+    const poolOnFakeConnection = () =>
+      sqlite3SingletonPool({
+        driverType: SQLite3DriverType,
+        getConnection: () =>
+          fakeConnection(() => Promise.resolve(queryResult())),
+      });
+
+    it('lets withConnection nest inside withConnection', async () => {
+      const pool = poolOnFakeConnection();
+
+      try {
+        const result = await withDeadline(
+          pool.withConnection(() =>
+            pool.withConnection(() => Promise.resolve('inner ran')),
+          ),
+        );
+
+        assert.strictEqual(result, 'inner ran');
+      } finally {
+        await pool.close();
+      }
+    });
+
+    it('lets withConnection nest inside withTransaction', async () => {
+      const pool = poolOnFakeConnection();
+
+      try {
+        const result = await withDeadline(
+          pool.withTransaction(() =>
+            pool
+              .withConnection(() => Promise.resolve('inner ran'))
+              .then((value) => ({
+                success: true as const,
+                result: value,
+              })),
+          ),
+        );
+
+        assert.strictEqual(result, 'inner ran');
+      } finally {
+        await pool.close();
+      }
+    });
+
+    it('lets withTransaction nest inside withConnection', async () => {
+      const pool = poolOnFakeConnection();
+
+      try {
+        const result = await withDeadline(
+          pool.withConnection(() =>
+            pool.withTransaction(() =>
+              Promise.resolve({ success: true as const, result: 'inner ran' }),
+            ),
+          ),
+        );
+
+        assert.strictEqual(result, 'inner ran');
+      } finally {
+        await pool.close();
+      }
+    });
   });
 });


### PR DESCRIPTION
It appeared that only using `withConnection` inside the `withTransaction` was fixed previously. This PR addresses that thoroughly.